### PR TITLE
Start debugger with jest.pathToConfig using Debug CodeLens

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -14,6 +14,7 @@ const window = {
 
 const workspace = {
   getConfiguration: jest.fn(),
+  workspaceFolders: jest.fn(),
 }
 
 const OverviewRulerLane = {
@@ -25,6 +26,11 @@ const Range = jest.fn()
 const Diagnostic = jest.fn()
 const DiagnosticSeverity = { Error: 0, Warning: 1, Information: 2, Hint: 3 }
 
+const debug = {
+  onDidTerminateDebugSession: jest.fn(),
+  startDebugging: jest.fn(),
+}
+
 export {
   languages,
   StatusBarAlignment,
@@ -35,4 +41,5 @@ export {
   Range,
   Diagnostic,
   DiagnosticSeverity,
+  debug,
 }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -570,13 +570,18 @@ export class JestExt {
       return
     }
 
+    const args = ['--runInBand', fileName, '--testNamePattern', identifier]
+    if (this.pluginSettings.pathToConfig.length) {
+      args.push('--config', this.pluginSettings.pathToConfig)
+    }
+
     const port = Math.floor(Math.random() * 20000) + 10000
     const configuration = {
       name: 'TestRunner',
       type: 'node',
       request: 'launch',
       program,
-      args: ['--runInBand', fileName, '--testNamePattern', identifier],
+      args,
       runtimeArgs: ['--inspect-brk=' + port],
       port,
       protocol: 'inspector',

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -14,6 +14,7 @@ describe('JestExt', () => {
   let projectWorkspace: ProjectWorkspace
   const channelStub = { appendLine: () => {} } as any
   const mockShowErrorMessage = window.showErrorMessage as jest.Mock<any>
+  const extensionSettings = {} as any
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -27,7 +28,7 @@ describe('JestExt', () => {
       getConfig: callback => callback(),
       jestVersionMajor: 17,
     }))
-    new JestExt(projectWorkspace, channelStub, {})
+    new JestExt(projectWorkspace, channelStub, extensionSettings)
     expect(mockShowErrorMessage.mock.calls).toMatchSnapshot()
   })
 
@@ -36,7 +37,7 @@ describe('JestExt', () => {
       getConfig: callback => callback(),
       jestVersionMajor: 20,
     }))
-    new JestExt(projectWorkspace, channelStub, {})
+    new JestExt(projectWorkspace, channelStub, extensionSettings)
     expect(window.showErrorMessage).not.toBeCalled()
   })
 
@@ -53,7 +54,7 @@ describe('JestExt', () => {
         closeProcess,
       }
       mockRunner.mockImplementation(() => eventEmitter)
-      extension = new JestExt(projectWorkspace, channelStub, {})
+      extension = new JestExt(projectWorkspace, channelStub, extensionSettings)
       extension.startProcess()
     })
 
@@ -158,8 +159,8 @@ describe('JestExt', () => {
       const extensionSettings = {
         pathToConfig: config,
       } as any
-      const sut = new JestExt(projectWorkspace, channelStub, extensionSettings)
 
+      const sut = new JestExt(projectWorkspace, channelStub, extensionSettings)
       // @ts-ignore: Overriding private method
       sut.resolvePathToJestBin = jest.fn().mockReturnValueOnce(true)
       sut.runTest(fileName, testNamePattern)


### PR DESCRIPTION
This fixes #191.

I've added a test to confirm the config is added, and it looks good in the terminal that starts **but I haven't managed to get the debugger to hit a breakpoint**. The debug console just spits out this on my Linux box -- will test from Windows and update / create an issue soon:

```
Error processing "setBreakpoints": TypeError: Cannot read property 'mappedPath' of undefined
    at EagerSourceMapTransformer.setBreakpoints (/usr/share/code/resources/app/extensions/ms-vscode.node-debug2/node_modules/vscode-chrome-debug-core/out/src/transformers/baseSourceMapTransformer.js:63:23)
    at validateBreakpointsPath.then (/usr/share/code/resources/app/extensions/ms-vscode.node-debug2/node_modules/vscode-chrome-debug-core/out/src/chrome/chromeDebugAdapter.js:827:40)
    at <anonymous>
Error processing "setBreakpoints": TypeError: Cannot read property 'mappedPath' of undefined
    at EagerSourceMapTransformer.setBreakpoints (/usr/share/code/resources/app/extensions/ms-vscode.node-debug2/node_modules/vscode-chrome-debug-core/out/src/transformers/baseSourceMapTransformer.js:63:23)
    at validateBreakpointsPath.then (/usr/share/code/resources/app/extensions/ms-vscode.node-debug2/node_modules/vscode-chrome-debug-core/out/src/chrome/chromeDebugAdapter.js:827:40)
    at <anonymous>
Error processing "setBreakpoints": TypeError: Cannot read property 'mappedPath' of undefined
    at EagerSourceMapTransformer.setBreakpoints (/usr/share/code/resources/app/extensions/ms-vscode.node-debug2/node_modules/vscode-chrome-debug-core/out/src/transformers/baseSourceMapTransformer.js:63:23)
    at validateBreakpointsPath.then (/usr/share/code/resources/app/extensions/ms-vscode.node-debug2/node_modules/vscode-chrome-debug-core/out/src/chrome/chromeDebugAdapter.js:827:40)
    at <anonymous>
```