### PR TITLE
Hide Debug CodeLens for skipped tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Master
 
-*
+* Hide Debug CodeLens for skipped tests - seanpoulter
 
 ### 2.5.5
 

--- a/src/DebugCodeLens/DebugCodeLensProvider.ts
+++ b/src/DebugCodeLens/DebugCodeLensProvider.ts
@@ -40,7 +40,7 @@ export class DebugCodeLensProvider implements vscode.CodeLensProvider {
     const testResults = this.testResultProvider.getResults(filePath)
     const fileName = basename(document.fileName)
     for (const test of testResults) {
-      if (test.status === TestReconciliationState.KnownSuccess) {
+      if (test.status === TestReconciliationState.KnownSuccess || test.status === TestReconciliationState.KnownSkip) {
         continue
       }
 

--- a/tests/DebugCodeLens/DebugCodeLensProvider.test.ts
+++ b/tests/DebugCodeLens/DebugCodeLensProvider.test.ts
@@ -153,11 +153,19 @@ describe('DebugCodeLensProvider', () => {
       expect(testResultProvider.getResults).toBeCalledWith(document.fileName)
     })
 
-    it('should not show DebugCodeLenses for successful test results', () => {
+    function expectNoDebugCodeLensesForTestStatus(status: TestReconciliationState) {
       const sut = new DebugCodeLensProvider(testResultProvider, true)
-      getResults.mockReturnValueOnce([{ status: TestReconciliationState.KnownSuccess }])
+      getResults.mockReturnValueOnce([{ status }])
 
       expect(sut.provideCodeLenses(document, token)).toEqual([])
+    }
+
+    it('should not show DebugCodeLenses for successful test results', () => {
+      expectNoDebugCodeLensesForTestStatus(TestReconciliationState.KnownSuccess)
+    })
+
+    it('should not show DebugCodeLenses for skipped test results', () => {
+      expectNoDebugCodeLensesForTestStatus(TestReconciliationState.KnownSkip)
     })
 
     it('should create the CodeLens at the start of the `test`/`it` block', () => {


### PR DESCRIPTION
This closes #197.