### PR TITLE
 Mute output from `console.warn` during tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Master
 
-*
+* Mute output from `console.warn` during tests - seanpoulter
 
 ### 2.5.5
 

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -65,6 +65,7 @@ describe('JestExt', () => {
       extension.startProcess()
       expect(closeProcess).toHaveBeenCalledTimes(1)
     })
+
     it('should closeProcess when starting again', () => {
       expect(closeProcess).toHaveBeenCalledTimes(0)
       extension.startProcess()
@@ -75,6 +76,7 @@ describe('JestExt', () => {
       const filtered = eventEmitter.on.mock.calls.filter(args => args[0] === 'debuggerProcessExit')
       return filtered[filtered.length - 1][1]
     }
+
     describe('when jest process exit', () => {
       function getJestWatchMode(index: number): boolean {
         return eventEmitter.start.mock.calls[index][0]
@@ -84,6 +86,7 @@ describe('JestExt', () => {
         handler = getExitHandler()
         jest.clearAllMocks()
       })
+
       it('if non-watch mode, exit should reset process and trigger the watch mode', () => {
         eventEmitter.watchMode = false
         handler()
@@ -93,6 +96,7 @@ describe('JestExt', () => {
         expect(eventEmitter.start).toHaveBeenCalledTimes(1)
         expect(getJestWatchMode(0)).toEqual(true)
       })
+
       it('in watch mode, exit should re-start the watch mode', () => {
         eventEmitter.watchMode = true
         handler()
@@ -100,6 +104,7 @@ describe('JestExt', () => {
         expect(eventEmitter.start).toHaveBeenCalledTimes(1)
         expect(getJestWatchMode(0)).toEqual(true)
       })
+
       it('should not restart jest if closeProcess() is invoked by exit handler', () => {
         expect(eventEmitter.start).toHaveBeenCalledTimes(0)
         ;[true, false].forEach(watchMode => {
@@ -112,6 +117,7 @@ describe('JestExt', () => {
         })
       })
     })
+
     describe('safeguard restart', () => {
       function testMaxRestart(maxCount: number) {
         for (let i = 1; i <= maxCount * 2; i++) {
@@ -123,20 +129,28 @@ describe('JestExt', () => {
         }
       }
       let handler: () => void
+      const consoleWarn = console.warn
+
       beforeEach(() => {
         handler = getExitHandler()
         jest.clearAllMocks()
+        console.warn = consoleWarn
       })
+
       it('should not restart jest if closeProcess() is invoked by user', () => {
         extension.stopProcess()
         expect(eventEmitter.closeProcess).toHaveBeenCalledTimes(1)
         handler()
         expect(eventEmitter.start).toHaveBeenCalledTimes(0)
       })
+
       it('will not restart if exceed maxRestart (4)', () => {
+        console.warn = jest.fn()
         testMaxRestart(4)
       })
+
       it('will reset maxRestart if startProcess() is called again', () => {
+        console.warn = jest.fn()
         testMaxRestart(4)
 
         extension.startProcess()

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -23,10 +23,11 @@ describe('test diagnostics', () => {
       expect(mockDiagnostics.clear).toBeCalled()
     })
   })
-  describe('updateDiagnostics', () => {
-    // const MockReconciler = (TestReconciler as any) as jest.Mock<any>
 
+  describe('updateDiagnostics', () => {
+    const consoleWarn = console.warn
     let lineNumber = 17
+
     function createAssertion(title: string, status: TestReconcilationState): TestAssertionStatus {
       return {
         title,
@@ -56,6 +57,7 @@ describe('test diagnostics', () => {
 
     beforeEach(() => {
       jest.resetAllMocks()
+      console.warn = consoleWarn
     })
 
     it('can handle when all tests passed', () => {
@@ -132,6 +134,7 @@ describe('test diagnostics', () => {
       // verify: removed passed tests
       expect(mockDiagnostics.delete).toHaveBeenCalledTimes(notFailedTestSuiteCount)
     })
+
     it('knows how many failed suite from diagnostics', () => {
       const mockDiagnostics = new MockDiagnosticCollection()
       const invokeCount = 7
@@ -143,10 +146,13 @@ describe('test diagnostics', () => {
 
       expect(failedSuiteCount(mockDiagnostics)).toEqual(invokeCount)
     })
+
     it('should not produce negative diagnostic range', () => {
       const mockDiagnostics = new MockDiagnosticCollection()
       const assertion = createAssertion('a', 'KnownFail')
       const invalidLine = [0, -1, undefined, null, NaN]
+      console.warn = jest.fn()
+
       invalidLine.forEach(line => {
         jest.clearAllMocks()
         assertion.line = line


### PR DESCRIPTION
This closes #202.