### PR TITLE
Fix dot decoration display on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Master
 
+* Fix dot decoration display on Windows - seanpoulter
+
 ### 2.5.6
 
 * Improve the dot decoration placement as we edit - seanpoulter


### PR DESCRIPTION
On Windows systems the dot decorations would appear unknown. This occurred when the test result lookup failed. The document file path from VS Code would always have a lowercase drive letter which did not match the results from Jest.

This fixes the issue raised by @jonathandelgado in #116. Sorry for the regression adding the test result provider. I really hope that fixes it for good.