### PR TITLE
Fix dot decoration display on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 ## Master
 
-### 2.5.7
+*
+
+### 2.5.7-8
 
 * Fix dot decoration display on Windows - seanpoulter
 

--- a/typings/jest-editor-support.d.ts
+++ b/typings/jest-editor-support.d.ts
@@ -4,5 +4,11 @@ declare module 'jest-editor-support' {
     coverageMap: any
   }
 
-  type FormattedTestResults = {}
+  type FormattedTestResults = {
+    testResults: TestResult[]
+  }
+
+  type TestResult = {
+    name: string
+  }
 }


### PR DESCRIPTION
The test result lookup failed on Windows **again** after #204. This change moves the adapter into `updateResults`. The source of the problem is the difference between:
* the TextDocument URI always having a lowercase drive letter
* the Jest test results having a drive letter that is system dependent
I incorrectly assumed Jest was sending us uppercase drive letters for #204, sorry. :hankey: :disappointed:

Confirmed this looks OK from my Linux and Windows boxes.

This closes #206.