### PR TITLE
Hide the notes and work in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-// Please add your own contribution below inside the Master section
-// Bug-fixes within the same version aren't needed
+<!--
+
+Please add your own contribution below inside the Master section
+Bug-fixes within the same version aren't needed
 
 ## Master
 
 *
+
+-->
 
 ### 2.5.7-8
 


### PR DESCRIPTION
When looking at the extension Changelog in VS Code the notes and Master are visible but not relevant. I'm feeling like this is #trivial and shouldn't go in the changelog.

![image](https://user-images.githubusercontent.com/2585460/34413772-76df0026-ebb3-11e7-980c-da13445720e0.png)
