### PR TITLE
Keep coverage overlay when no new tests found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug-fixes within the same version aren't needed
 * Adds ability to open snapshot file directly from test - bookman25
 * start automatically if jest.config.js or jest.json is in workspace - uucue2
 * use pathToJest setting to properly locate jest's package.json and read the version - uucue2
+* Keep coverage overlay after "No tests found related to files changed since the last commit" - seanpoulter
 
 -->
 

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
 import * as fs from 'fs'
-import { Runner, Settings, ProjectWorkspace, JestTotalResults } from 'jest-editor-support'
+import { Runner, Settings, ProjectWorkspace, JestTotalResults, JestTotalResultsMeta } from 'jest-editor-support'
 import { matcher } from 'micromatch'
 
 import * as decorations from './decorations'
@@ -92,8 +92,8 @@ export class JestExt {
         this.closeJest()
         this.startWatchMode()
       })
-      .on('executableJSON', (data: JestTotalResults) => {
-        this.updateWithData(data)
+      .on('executableJSON', (data: JestTotalResults, meta: JestTotalResultsMeta) => {
+        this.updateWithData(data, meta)
       })
       .on('executableOutput', (output: string) => {
         if (!this.shouldIgnoreOutput(output)) {
@@ -359,8 +359,10 @@ export class JestExt {
     status.running(details)
   }
 
-  private updateWithData(data: JestTotalResults) {
-    this.coverage.mapCoverage(data.coverageMap)
+  private updateWithData(data: JestTotalResults, meta: JestTotalResultsMeta) {
+    if (!meta || !meta.noTestsFound) {
+      this.coverage.mapCoverage(data.coverageMap)
+    }
 
     const statusList = this.testResultProvider.updateTestResults(data)
     updateDiagnostics(statusList, this.failDiagnostics)

--- a/typings/jest-editor-support.d.ts
+++ b/typings/jest-editor-support.d.ts
@@ -26,4 +26,8 @@ declare module 'jest-editor-support' {
     constructor(parser?: any, customMatchers?: Array<string>)
     getMetadata(filepath: string): Array<SnapshotMetadata>
   }
+
+  interface JestTotalResultsMeta {
+    noTestsFound: boolean
+  }
 }


### PR DESCRIPTION
When Jest is run for only changed files the tests results that follow the "No tests found related to files changed since the last commit" message are empty. This causes the coverage overlay to be cleared.

This commit skips the coverage overlay update when the test results
follow:
* the "No tests found..." message
* the "No tests found..." then "Watch Usage..." messages

#### Wait ... :hand: 
This commit shouldn't be merged until:
- [x] facebook/jest#5208 is merged
- [ ] changes are deployed in `jest-editor-support`
- [ ] `package.json` is bumped
- [ ] manually tested (again)
- [ ] resolve merge conflicts
  