### PR TITLE
Migrate from orta/ to jest-community/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vscode-jest [![Build Status](https://travis-ci.org/orta/vscode-jest.svg?branch=master)](https://travis-ci.org/orta/vscode-jest)
+# vscode-jest [![Build Status](https://travis-ci.org/jest-community/vscode-jest.svg?branch=master)](https://travis-ci.org/jest-community/vscode-jest)
 
 ## The Aim
 
@@ -7,7 +7,7 @@ A comprehensive experience when using [Facebook's Jest](https://github.com/faceb
 * Useful IDE based Feedback
 * Session based test watching
 
-<img src="https://github.com/orta/vscode-jest/raw/master/images/vscode-jest.gif" alt="Screenshot of the tool" width="100%">
+<img src="https://github.com/jest-community/vscode-jest/raw/master/images/vscode-jest.gif" alt="Screenshot of the tool" width="100%">
 
 ## Features
 
@@ -61,7 +61,7 @@ These are the things that will trigger the extension loading. If one of these ap
 The extension is in two parts, one is _this_ repo. It contains all the VS Code specific work.
 
 ```js
-git clone https://github.com/orta/vscode-jest
+git clone https://github.com/jest-community/vscode-jest
 cd vscode-jest
 yarn install
 code .

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/orta/vscode-jest"
+    "url": "https://github.com/jest-community/vscode-jest"
   },
   "galleryBanner": {
     "theme": "light",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,7 +18,7 @@ export function pathToJest(pluginSettings: IPluginSettings) {
     return platform() === 'win32' ? 'npm.cmd test --' : 'npm test --'
   }
 
-  // For windows support, see https://github.com/orta/vscode-jest/issues/10
+  // For windows support, see https://github.com/jest-community/vscode-jest/issues/10
   if (!path.includes('.cmd') && platform() === 'win32') {
     return path + '.cmd'
   }


### PR DESCRIPTION
Uh oh! The repo moved and we don't know the build status anymore! :truck:

![image](https://user-images.githubusercontent.com/2585460/34658399-ca25888a-f3fc-11e7-85f1-a58334039154.png)

Excluded from the changelog, it's #trivial.