### PR TITLE
hierarchical module resolution when looking for jest/package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug-fixes within the same version aren't needed
 
 * Adds ability to open snapshot file directly from test - bookman25
 * start automatically if jest.config.js or jest.json is in workspace - uucue2
+* search for jest/package.json in node_modules or ../node_modules or ../../node_modules etc.
 
 -->
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -59,6 +59,7 @@ export function pathToJestPackageJSON(pluginSettings: IPluginSettings): string |
   let updir = ''
 
   const paths = [defaultPath, craPath]
+  let max_levels = 20
   do {
     for (const i in paths) {
       const absolutePath = join(pluginSettings.rootPath, updir, paths[i])
@@ -67,7 +68,8 @@ export function pathToJestPackageJSON(pluginSettings: IPluginSettings): string |
       }
     }
     updir += '../'
-  } while (join(pluginSettings.rootPath, updir) !== join(pluginSettings.rootPath, updir, '../'))
+    max_levels--
+  } while (max_levels > 0 && join(pluginSettings.rootPath, updir) !== join(pluginSettings.rootPath, updir, '../'))
 
   return null
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -67,7 +67,7 @@ export function pathToJestPackageJSON(pluginSettings: IPluginSettings): string |
       }
     }
     updir += '../'
-  } while (join(pluginSettings.rootPath, updir) != join(pluginSettings.rootPath, updir, '../'))
+  } while (join(pluginSettings.rootPath, updir) !== join(pluginSettings.rootPath, updir, '../'))
 
   return null
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -56,13 +56,18 @@ export function pathToConfig(pluginSettings: IPluginSettings) {
 export function pathToJestPackageJSON(pluginSettings: IPluginSettings): string | null {
   const defaultPath = normalize('node_modules/jest/package.json')
   const craPath = normalize('node_modules/react-scripts/node_modules/jest/package.json')
+  let updir = ''
 
   const paths = [defaultPath, craPath]
-  for (const i in paths) {
-    const absolutePath = join(pluginSettings.rootPath, paths[i])
-    if (existsSync(absolutePath)) {
-      return absolutePath
+  do {
+    for (const i in paths) {
+      const absolutePath = join(pluginSettings.rootPath, updir, paths[i])
+      if (existsSync(absolutePath)) {
+        return absolutePath
+      }
     }
-  }
+    updir += '../'
+  } while (join(pluginSettings.rootPath, updir) != join(pluginSettings.rootPath, updir, '../'))
+
   return null
 }


### PR DESCRIPTION
Add support for setups in which jest is installed in an ancestor directory.

(As per [node](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders) docs, the jest module can be located in a `node_modules` directory anywhere upwards in the directory hierarchy).

Note that this also relates to #218 (as inability to resolve jest version might be due to such a hierarchical setup).
