### PR TITLE
add jest-cli to pathToJestPackgeJSON #trivial

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -64,8 +64,9 @@ export function pathToJestPackageJSON(pluginSettings: IPluginSettings): string |
   }
 
   const defaultPath = normalize(join(pathToNodeModules, 'jest/package.json'))
+  const cliPath = normalize(join(pathToNodeModules, 'jest-cli/package.json'))
   const craPath = normalize(join(pathToNodeModules, 'react-scripts/node_modules/jest/package.json'))
-  const paths = [defaultPath, craPath]
+  const paths = [defaultPath, cliPath, craPath]
 
   for (const i in paths) {
     if (existsSync(paths[i])) {

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -57,6 +57,17 @@ describe('ModuleHelpers', () => {
           expect(pathToJestPackageJSON(workspace)).toBe(expected)
         })
 
+        it('should return package.json when Jest-cli is installed as a dependency', () => {
+          const expected = path.join('..', '..', 'node_modules', 'jest-cli', 'package.json')
+          existsMock.mockImplementation(path => path === expected)
+
+          const workspace: any = {
+            rootPath: path.join('..', '..'),
+            pathToJest: defaultPathToJest,
+          }
+          expect(pathToJestPackageJSON(workspace)).toBe(expected)
+        })
+
         it('should return package.json when React Scripts are installed as a dependency', () => {
           const expected = path.join(
             '..',


### PR DESCRIPTION
VSC was giving an error when a user had "jest-cli" installed instead of simple "jest" package. This adds support for that circumstance. 