### PR TITLE
Update settings at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Update settings at runtime - gcangussu
+
 ### 2.6.1
 
 * Strips testNames so they can be used as regex - BLamy

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -239,6 +239,8 @@ export class JestExt {
   }
 
   public triggerUpdateSettings(updatedSettings: IPluginSettings) {
+    this.pluginSettings = updatedSettings
+    this.coverageOverlay.enabled = updatedSettings.showCoverageOnLoad
     this.debugCodeLensProvider.enabled = updatedSettings.enableCodeLens
   }
 

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -13,7 +13,7 @@ import {
   TestResult,
   resultsWithLowerCaseWindowsDriveLetters,
 } from './TestResults'
-import { pathToJestPackageJSON } from './helpers'
+import { pathToJestPackageJSON, pathToJest, pathToConfig } from './helpers'
 import { readFileSync } from 'fs'
 import { CoverageMapProvider } from './Coverage'
 import { updateDiagnostics, resetDiagnostics, failedSuiteCount } from './diagnostics'
@@ -240,6 +240,13 @@ export class JestExt {
 
   public triggerUpdateSettings(updatedSettings: IPluginSettings) {
     this.pluginSettings = updatedSettings
+
+    this.workspace.rootPath = updatedSettings.rootPath
+    this.workspace.pathToJest = pathToJest(updatedSettings)
+    this.workspace.pathToConfig = pathToConfig(updatedSettings)
+
+    this.jestSettings = new Settings(this.workspace)
+
     this.coverageOverlay.enabled = updatedSettings.showCoverageOnLoad
     this.debugCodeLensProvider.enabled = updatedSettings.enableCodeLens
   }


### PR DESCRIPTION
Changing settings will not require vscode to be restarted. Fixed #262 