### PR TITLE
Improved detection logic for projects created by `create-react-app`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Improved detection logic for projects created by `create-react-app`
 * Added `JestProcess` and `JestProcessManager` abstractions to simplify Jest process management - marcinczenko
 
 ### 2.6.1

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'fs'
 import { normalize, join } from 'path'
 
 import { IPluginSettings } from './IPluginSettings'
-import { isArray } from 'util'
+import { isArray, isObject } from 'util'
 
 /**
  *  Handles getting the jest runner, handling the OS and project specific work too
@@ -31,7 +31,7 @@ function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
   try {
     const packagePath = join(rootPath, 'package.json')
     const packageJSON = JSON.parse(readFileSync(packagePath, 'utf8'))
-    if (!packageJSON || !packageJSON.dependencies || !isArray(packageJSON.dependencies)) {
+    if (!packageJSON || !packageJSON.dependencies || !isObject(packageJSON.dependencies)) {
       return false
     }
     const dependencies = packageJSON.dependencies as { [id: string]: string }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,7 +26,9 @@ export function pathToJest(pluginSettings: IPluginSettings) {
 }
 
 function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
+  // Known `create-react-app` `scripts-version`s:
   const packageNames = ['react-scripts', 'react-native-scripts', 'react-scripts-ts']
+  // If possible, try to parse `package.json` and look for known packages
   try {
     const packagePath = join(rootPath, 'package.json')
     const packageJSON = JSON.parse(readFileSync(packagePath, 'utf8'))
@@ -36,6 +38,8 @@ function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
     const dependencies = packageJSON.dependencies as { [id: string]: string }
     return packageNames.some(pkg => !!dependencies[pkg])
   } catch {}
+  // In case parsing `package.json` failed or was unconclusive,
+  // check for the presence of binaries from known packages
   return packageNames.some(pkg => hasNodeExecutable(rootPath, pkg))
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,5 @@
 import { platform } from 'os'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { normalize, join } from 'path'
 
 import { IPluginSettings } from './IPluginSettings'
@@ -26,11 +26,19 @@ export function pathToJest(pluginSettings: IPluginSettings) {
 }
 
 function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
+  try {
+    const packagePath = join(rootPath, 'package.json')
+    const packageJSON = JSON.parse(readFileSync(packagePath, 'utf8'))
+    if (!packageJSON || !packageJSON.dependencies) {
+      return false
+    }
+    const dependencies = packageJSON.dependencies as { [id: string]: string }
+    return !!(dependencies['react-scripts'] || dependencies['react-native-scripts'] || dependencies['react-scripts-ts'])
+  } catch {}
   return (
     hasExecutable(rootPath, 'node_modules/.bin/react-scripts') ||
-    hasExecutable(rootPath, 'node_modules/react-scripts/node_modules/.bin/jest') ||
-    hasExecutable(rootPath, 'node_modules/react-native-scripts') ||
-    hasExecutable(rootPath, 'node_modules/react-scripts-ts')
+    hasExecutable(rootPath, 'node_modules/.bin/react-native-scripts') ||
+    hasExecutable(rootPath, 'node_modules/.bin/react-scripts-ts')
   )
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,7 +3,6 @@ import { existsSync, readFileSync } from 'fs'
 import { normalize, join } from 'path'
 
 import { IPluginSettings } from './IPluginSettings'
-import { isArray, isObject } from 'util'
 
 /**
  *  Handles getting the jest runner, handling the OS and project specific work too
@@ -31,7 +30,7 @@ function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
   try {
     const packagePath = join(rootPath, 'package.json')
     const packageJSON = JSON.parse(readFileSync(packagePath, 'utf8'))
-    if (!packageJSON || !packageJSON.dependencies || !isObject(packageJSON.dependencies)) {
+    if (!packageJSON || !packageJSON.dependencies) {
       return false
     }
     const dependencies = packageJSON.dependencies as { [id: string]: string }


### PR DESCRIPTION
The old logic for detecting `react-scripts` or similar had a flaw (#244): When testing for the presence of for example `react-scripts-ts`, on Windows it checked the existence of a folder named `node_modules/react-scripts-ts.cmd`. Furthermore that approach is not compatible with Yarn workspaces, which usually places the folder in a parent directory.

Instead it is better to check for the existence of the binary within `node_modules/.bin`. Another, in my opinion more stable, approach would be to parse `package.json` and check its dependencies.