### PR TITLE
Improve debugging of tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+### 2.6.3
+
+* Even better detection logic for projects created by `create-react-app` - stephtr
+
 ### 2.6.2
 
 * Adding `.cmd` in `pathToJest` on Windows isn't necessary anymore - stephtr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
-* Enable debugging of tasks in (some) more complex scenarios (like when using `create-react-app`) - stephtr
+* Enable debugging of tests in (some) more complex scenarios (like when using `create-react-app`) - stephtr
 
 ### 2.6.4
 
-* Fixes debugging of tasks on Windows (bug introduced in 2.6.2) - stephtr
+* Fixes debugging of tests on Windows (bug introduced in 2.6.2) - stephtr
 
 ### 2.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Enable debugging of tasks in (some) more complex scenarios (like when using `create-react-app`) - stephtr
+
 ### 2.6.4
 
 * Fixes debugging of tasks on Windows (bug introduced in 2.6.2) - stephtr

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.18.0"

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -445,7 +445,7 @@ export class JestExt {
   /**
    * Primitive way to resolve path to jest.js
    */
-  private resolvePathToJestBin() {
+  private resolveTestProgram(): { program: string; args: string[]; isCreateReactApp: boolean } {
     // Let's start with the given command
     let jest = this.workspace.pathToJest
     let basename = path.basename(jest)
@@ -569,7 +569,7 @@ export class JestExt {
   public runTest = (fileName: string, identifier: string) => {
     const restart = this.jestProcessManager.numberOfProcesses > 0
     this.jestProcessManager.stopAll()
-    const launcher = this.resolvePathToJestBin()
+    const launcher = this.resolveTestProgram()
     if (!launcher) {
       console.log("Could not find Jest's CLI path")
       return

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -586,6 +586,7 @@ export class JestExt {
 
     const port = Math.floor(Math.random() * 20000) + 10000
     let runtimeArgs = ['--inspect-brk=' + port]
+    const env: any = {}
 
     if (launcher.isCreateReactApp) {
       // If the project has been created by create-react-app,
@@ -598,6 +599,9 @@ export class JestExt {
       // arguments for generating the new node process.
       args = runtimeArgs.concat(args)
       runtimeArgs = []
+      // `react-scripts` automatically appends the `--watch` flag
+      // if CI isn't set.
+      env.CI = 'VSCode-test-debugger'
     }
 
     const configuration = {
@@ -612,7 +616,7 @@ export class JestExt {
       console: 'integratedTerminal',
       smartStep: true,
       sourceMaps: true,
-      env: { CI: 'VSCode-test-debugger' },
+      env,
     }
 
     const handle = vscode.debug.onDidTerminateDebugSession(_ => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -21,9 +21,14 @@ export function pathToJest(pluginSettings: IPluginSettings) {
   return path
 }
 
+const knownCreateReactAppBinaries = ['react-scripts', 'react-native-scripts', 'react-scripts-ts', 'react-app-rewired']
+
+export function testCommandIsCreateReactApp(command: string): boolean {
+  return knownCreateReactAppBinaries.some(binary => command.indexOf(binary + ' ') === 0)
+}
+
 function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
   // Known binary names of `react-scripts` forks:
-  const packageBinaryNames = ['react-scripts', 'react-native-scripts', 'react-scripts-ts', 'react-app-rewired']
   // If possible, try to parse `package.json` and look for known binary beeing called in `scripts.test`
   try {
     const packagePath = join(rootPath, 'package.json')
@@ -31,12 +36,11 @@ function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
     if (!packageJSON || !packageJSON.scripts || !packageJSON.scripts.test) {
       return false
     }
-    const testCommand = packageJSON.scripts.test as string
-    return packageBinaryNames.some(binary => testCommand.indexOf(binary + ' test ') === 0)
+    return testCommandIsCreateReactApp(packageJSON.scripts.test)
   } catch {}
   // In case parsing `package.json` failed or was unconclusive,
   // fallback to checking for the presence of the binaries in `./node_modules/.bin`
-  return packageBinaryNames.some(binary => hasNodeExecutable(rootPath, binary))
+  return knownCreateReactAppBinaries.some(binary => hasNodeExecutable(rootPath, binary))
 }
 
 function hasNodeExecutable(rootPath: string, executable: string): boolean {

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -145,7 +145,7 @@ describe('JestExt', () => {
 
       const sut = new JestExt(projectWorkspace, channelStub, extensionSettings)
       // @ts-ignore: Overriding private method
-      sut.resolvePathToJestBin = jest.fn().mockReturnValueOnce({
+      sut.resolveTestProgram = jest.fn().mockReturnValueOnce({
         program: 'jest',
         args: [],
         isCreateReactApp: false,

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -145,7 +145,11 @@ describe('JestExt', () => {
 
       const sut = new JestExt(projectWorkspace, channelStub, extensionSettings)
       // @ts-ignore: Overriding private method
-      sut.resolvePathToJestBin = jest.fn().mockReturnValueOnce(true)
+      sut.resolvePathToJestBin = jest.fn().mockReturnValueOnce({
+        program: 'jest',
+        args: [],
+        isCreateReactApp: false,
+      })
       sut.runTest(fileName, testNamePattern)
 
       expect(debug.startDebugging).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Closed in favor of #287 
---
Previously debugging of tests was only possible when `pathToJest` referenced to the jest binary.
This PR should enable support for other JS files or `npm test --`, including projects which have been generated using `create-react-app`. (fixes #239 and in most cases #193)

Since this change misses quite for sure some corner cases, I would be happy for some pairs of eyes looking over it or trying it out, even though this change shouldn't degrade support.111