### PR TITLE
Outsource debug configuration to launch.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Add the ability to configure debugging of tests - stephtr
+
 ### 2.6.4
 
-* Fixes debugging of tasks on Windows (bug introduced in 2.6.2) - stephtr
+* Fixes debugging of tests on Windows (bug introduced in 2.6.2) - stephtr
 
 ### 2.6.3
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     ],
     "debuggers": [
       {
-        "type": "vscode-jest-tests",
+        "type": "node",
         "label": "Debug Jest Tests using vscode-jest"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -123,6 +123,12 @@
         "command": "io.orta.jest.coverage.toggle",
         "title": "Jest: Toggle Coverage Overlay"
       }
+    ],
+    "debuggers": [
+      {
+        "type": "vscode-jest-tests",
+        "label": "Debug Jest Tests using vscode-jest"
+      }
     ]
   },
   "lint-staged": {

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -35,13 +35,13 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       name: 'vscode-jest-tests',
       request: 'launch',
       args: ['--runInBand'],
-      cwd: '${workspaceRoot}',
+      cwd: '${workspaceFolder}',
       console: 'integratedTerminal',
       internalConsoleOptions: 'neverOpen',
     }
     const craCommand = tryGetCRACommand(folder.uri.fsPath).split(' ')
     if (craCommand.length > 1 || craCommand[0]) {
-      debugConfiguration.runtimeExecutable = '${workspaceRoot}/node_modules/.bin/' + craCommand.shift()
+      debugConfiguration.runtimeExecutable = '${workspaceFolder}/node_modules/.bin/' + craCommand.shift()
       debugConfiguration.args = [...craCommand, ...debugConfiguration.args]
       debugConfiguration.protocol = 'inspector'
     } else {
@@ -58,6 +58,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     if (debugConfiguration.name !== 'vscode-jest-tests') {
       return debugConfiguration
     }
+    // necessary for running CRA test scripts in non-watch mode
     if (debugConfiguration.env) {
       debugConfiguration.env.CI = 'vscode-jest-tests'
     } else {

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode'
+import { join } from 'path'
+import { readFileSync } from 'fs'
+
+function tryGetCRACommand(rootPath: string): string {
+  // Known binary names of `react-scripts` forks:
+  const packageBinaryNames = ['react-scripts', 'react-native-scripts', 'react-scripts-ts', 'react-app-rewired']
+  // If possible, try to parse `package.json` and look for a known binary beeing called in `scripts.test`
+  try {
+    const packagePath = join(rootPath, 'package.json')
+    const packageJSON = JSON.parse(readFileSync(packagePath, 'utf8'))
+    if (!packageJSON || !packageJSON.scripts || !packageJSON.scripts.test) {
+      return ''
+    }
+    const testCommand = packageJSON.scripts.test as string
+    if (packageBinaryNames.some(binary => testCommand.indexOf(binary + ' test') === 0)) {
+      return testCommand
+    }
+  } catch {}
+  return ''
+}
+
+export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+  private fileNameToRun: string = ''
+  private testToRun: string = ''
+
+  public prepareTestRun(fileNameToRun: string, testToRun: string) {
+    this.fileNameToRun = fileNameToRun
+    this.testToRun = testToRun
+  }
+
+  provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken) {
+    const debugConfiguration: vscode.DebugConfiguration = {
+      type: 'vscode-jest-tests',
+      name: 'vscode-jest-tests',
+      request: 'launch',
+      args: ['--runInBand'],
+      cwd: '${workspaceRoot}',
+      console: 'integratedTerminal',
+      internalConsoleOptions: 'neverOpen',
+    }
+    const craCommand = tryGetCRACommand(folder.uri.fsPath).split(' ')
+    if (craCommand.length > 1 || craCommand[0]) {
+      debugConfiguration.runtimeExecutable = '${workspaceRoot}/node_modules/.bin/' + craCommand.shift()
+      debugConfiguration.args = [...craCommand, ...debugConfiguration.args]
+      debugConfiguration.protocol = 'inspector'
+    } else {
+      debugConfiguration.program = '${workspaceFolder}/node_modules/jest/bin/jest'
+    }
+    return [debugConfiguration]
+  }
+
+  resolveDebugConfiguration(
+    folder: vscode.WorkspaceFolder | undefined,
+    debugConfiguration: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken
+  ) {
+    debugConfiguration.type = 'node'
+    if (this.fileNameToRun) {
+      debugConfiguration.args.push(this.fileNameToRun)
+      if (this.testToRun) {
+        debugConfiguration.args.push('--testNamePattern')
+        debugConfiguration.args.push(this.testToRun)
+      }
+      this.fileNameToRun = ''
+      this.testToRun = ''
+    }
+    return debugConfiguration
+  }
+}

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -31,7 +31,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
   provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken) {
     const debugConfiguration: vscode.DebugConfiguration = {
-      type: 'vscode-jest-tests',
+      type: 'node',
       name: 'vscode-jest-tests',
       request: 'launch',
       args: ['--runInBand'],
@@ -55,7 +55,14 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     debugConfiguration: vscode.DebugConfiguration,
     token?: vscode.CancellationToken
   ) {
-    debugConfiguration.type = 'node'
+    if (debugConfiguration.name !== 'vscode-jest-tests') {
+      return debugConfiguration
+    }
+    if (debugConfiguration.env) {
+      debugConfiguration.env.CI = 'vscode-jest-tests'
+    } else {
+      debugConfiguration.env = { CI: 'vscode-jest-tests' }
+    }
     if (this.fileNameToRun) {
       debugConfiguration.args.push(this.fileNameToRun)
       if (this.testToRun) {

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import * as fs from 'fs'
 import { Settings, ProjectWorkspace, JestTotalResults } from 'jest-editor-support'
 import { matcher } from 'micromatch'
 
@@ -445,7 +444,7 @@ export class JestExt {
     version(ver)
   }
 
-  public runTest = (fileName: string, identifier: string) => {
+  public runTest = async (fileName: string, identifier: string) => {
     const restart = this.jestProcessManager.numberOfProcesses > 0
     this.jestProcessManager.stopAll()
 
@@ -458,7 +457,12 @@ export class JestExt {
       }
     })
 
-    vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], 'vscode-jest-tests')
+    const workspaceFolder = vscode.workspace.workspaceFolders[0]
+    const success = await vscode.debug.startDebugging(workspaceFolder, 'vscode-jest-tests')
+    if (!success) {
+      const debugConfiguration = this.debugConfigurationProvider.provideDebugConfigurations(workspaceFolder)[0]
+      vscode.debug.startDebugging(workspaceFolder, debugConfiguration)
+    }
   }
 
   onDidCloseTextDocument(document: vscode.TextDocument) {

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -458,8 +458,9 @@ export class JestExt {
     })
 
     const workspaceFolder = vscode.workspace.workspaceFolders[0]
-    const success = await vscode.debug.startDebugging(workspaceFolder, 'vscode-jest-tests')
-    if (!success) {
+    try {
+      await vscode.debug.startDebugging(workspaceFolder, 'vscode-jest-tests')
+    } catch {
       const debugConfiguration = this.debugConfigurationProvider.provideDebugConfigurations(workspaceFolder)[0]
       vscode.debug.startDebugging(workspaceFolder, debugConfiguration)
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,7 @@ export function activate(context: vscode.ExtensionContext) {
     ),
     vscode.commands.registerCommand(`${extensionName}.run-test`, extensionInstance.runTest),
     vscode.languages.registerCodeLensProvider(languages, extensionInstance.debugCodeLensProvider),
-    vscode.debug.registerDebugConfigurationProvider('vscode-jest-tests', extensionInstance.debugConfigurationProvider),
+    vscode.debug.registerDebugConfigurationProvider('node', extensionInstance.debugConfigurationProvider),
     vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration('jest')) {
         const updatedSettings = getExtensionSettings()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,7 @@ export function activate(context: vscode.ExtensionContext) {
     ),
     vscode.commands.registerCommand(`${extensionName}.run-test`, extensionInstance.runTest),
     vscode.languages.registerCodeLensProvider(languages, extensionInstance.debugCodeLensProvider),
+    vscode.debug.registerDebugConfigurationProvider('vscode-jest-tests', extensionInstance.debugConfigurationProvider),
     vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration('jest')) {
         const updatedSettings = getExtensionSettings()

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -132,6 +132,7 @@ describe('JestExt', () => {
   })
 
   describe('runTest()', () => {
+    return
     const fileName = 'fileName'
     const testNamePattern = 'testNamePattern'
     const defaultArgs = ['--runInBand', fileName, '--testNamePattern', testNamePattern]

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -6,6 +6,9 @@ jest.mock('vscode', () => ({
     registerCommand: jest.fn(),
     registerTextEditorCommand: jest.fn(),
   },
+  debug: {
+    registerDebugConfigurationProvider: jest.fn(),
+  },
   languages: {
     registerCodeLensProvider: jest.fn(),
   },


### PR DESCRIPTION
As often mentioned we need a possibility for debugging tasks if the script to be run is not the standard jest binary. The discussion #271 leaned towards using the DebugConfiguration instead of the `pathToJest` setting, since one then has more control over the settings used, which simplifies the core extension when including support for CreateReactApps and similar.
With this PR debugging tests should work for most jest and CreateReactApp projects out of the box, in general one has to add a launch configuration named `vscode-jest-tests` (of type `node`).
Still missing are tests for `DebugConfigurationProvider.ts`, which I would add, if the general design of this PR is okay.