### PR TITLE
Configure when the debug CodeLens is displayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-out
-node_modules
 _jest-editor/
+.vscode/symbols.json
+coverage/
 integrations/create-react-example/node_modules
-/coverage/
-/.vscode/symbols.json
+node_modules/
+out/
+
+**/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
-* [your thing] - [you]
+* Adds a setting to control when the debug CodeLens appears - seanpoulter
 
 -->
-
-## Master
 
 ### 2.7.2
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,14 @@
           "type": "boolean",
           "default": true
         },
+        "jest.debugCodeLens.showWhenTestStateIn": {
+          "description": "Show the debug CodeLens when the it/test block state is in this collection",
+          "type": "array",
+          "items": {
+            "enum": ["fail", "pass", "skip", "unknown"]
+          },
+          "default": ["fail", "unknown"]
+        },
         "jest.enableSnapshotPreviews": {
           "description": "Whether snapshot previews should show",
           "type": "boolean",

--- a/src/DebugCodeLens/TestState.ts
+++ b/src/DebugCodeLens/TestState.ts
@@ -1,0 +1,6 @@
+export enum TestState {
+  Fail = 'fail',
+  Pass = 'pass',
+  Skip = 'skip',
+  Unknown = 'unknown',
+}

--- a/src/DebugCodeLens/TestState.ts
+++ b/src/DebugCodeLens/TestState.ts
@@ -1,6 +1,15 @@
+import { TestReconciliationState } from '../TestResults'
+
 export enum TestState {
   Fail = 'fail',
   Pass = 'pass',
   Skip = 'skip',
   Unknown = 'unknown',
+}
+
+export const TestStateByTestReconciliationState = {
+  [TestReconciliationState.KnownFail]: TestState.Fail,
+  [TestReconciliationState.KnownSkip]: TestState.Skip,
+  [TestReconciliationState.KnownSuccess]: TestState.Pass,
+  [TestReconciliationState.Unknown]: TestState.Unknown,
 }

--- a/src/DebugCodeLens/index.ts
+++ b/src/DebugCodeLens/index.ts
@@ -1,1 +1,2 @@
 export { DebugCodeLensProvider } from './DebugCodeLensProvider'
+export { TestState } from './TestState'

--- a/src/IPluginSettings.ts
+++ b/src/IPluginSettings.ts
@@ -1,13 +1,18 @@
+import { TestState } from './DebugCodeLens'
+
 export interface IPluginSettings {
   autoEnable?: boolean
-  enableCodeLens?: boolean
+  debugCodeLens: {
+    enabled: boolean
+    showWhenTestStateIn: TestState[]
+  }
   enableInlineErrorMessages?: boolean
   enableSnapshotPreviews?: boolean
   enableSnapshotUpdateMessages?: boolean
-  pathToJest?: string
   pathToConfig?: string
+  pathToJest?: string
+  restartJestOnSnapshotUpdate?: boolean
   rootPath?: string
   runAllTestsFirst?: boolean
   showCoverageOnLoad: boolean
-  restartJestOnSnapshotUpdate?: boolean
 }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -69,7 +69,10 @@ export class JestExt {
     this.coverageOverlay = new CoverageOverlay(this.coverageMapProvider, pluginSettings.showCoverageOnLoad)
 
     this.testResultProvider = new TestResultProvider()
-    this.debugCodeLensProvider = new DebugCodeLensProvider(this.testResultProvider, pluginSettings.enableCodeLens)
+    this.debugCodeLensProvider = new DebugCodeLensProvider(
+      this.testResultProvider,
+      pluginSettings.debugCodeLens.enabled ? pluginSettings.debugCodeLens.showWhenTestStateIn : []
+    )
     this.debugConfigurationProvider = new DebugConfigurationProvider()
 
     this.jestProcessManager = new JestProcessManager({
@@ -244,7 +247,10 @@ export class JestExt {
     this.jestSettings = new Settings(this.workspace)
 
     this.coverageOverlay.enabled = updatedSettings.showCoverageOnLoad
-    this.debugCodeLensProvider.enabled = updatedSettings.enableCodeLens
+
+    this.debugCodeLensProvider.showWhenTestStateIn = updatedSettings.debugCodeLens.enabled
+      ? updatedSettings.debugCodeLens.showWhenTestStateIn
+      : []
 
     this.stopProcess()
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { IPluginSettings } from './IPluginSettings'
 import { registerStatusBar } from './statusBar'
 import { registerSnapshotCodeLens, registerSnapshotPreview } from './SnapshotCodeLens'
 import { registerCoverageCodeLens } from './Coverage'
+import { TestState } from './DebugCodeLens'
 
 let extensionInstance: JestExt
 
@@ -80,7 +81,10 @@ export function getExtensionSettings(): IPluginSettings {
   const config = vscode.workspace.getConfiguration('jest')
   return {
     autoEnable: config.get<boolean>('autoEnable'),
-    enableCodeLens: config.get<boolean>('enableCodeLens'),
+    debugCodeLens: {
+      enabled: config.get<boolean>('enableCodeLens'),
+      showWhenTestStateIn: config.get<TestState[]>('debugCodeLens.showWhenTestStateIn'),
+    },
     enableInlineErrorMessages: config.get<boolean>('enableInlineErrorMessages'),
     enableSnapshotPreviews: config.get<boolean>('enableSnapshotPreviews'),
     enableSnapshotUpdateMessages: config.get<boolean>('enableSnapshotUpdateMessages'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,19 +76,19 @@ export function deactivate() {
   extensionInstance.deactivate()
 }
 
-function getExtensionSettings(): IPluginSettings {
+export function getExtensionSettings(): IPluginSettings {
   const config = vscode.workspace.getConfiguration('jest')
   return {
     autoEnable: config.get<boolean>('autoEnable'),
-    pathToConfig: config.get<string>('pathToConfig'),
-    pathToJest: config.get<string>('pathToJest'),
     enableCodeLens: config.get<boolean>('enableCodeLens'),
     enableInlineErrorMessages: config.get<boolean>('enableInlineErrorMessages'),
     enableSnapshotPreviews: config.get<boolean>('enableSnapshotPreviews'),
     enableSnapshotUpdateMessages: config.get<boolean>('enableSnapshotUpdateMessages'),
+    pathToConfig: config.get<string>('pathToConfig'),
+    pathToJest: config.get<string>('pathToJest'),
+    restartJestOnSnapshotUpdate: config.get<boolean>('restartJestOnSnapshotUpdate'),
     rootPath: path.join(vscode.workspace.rootPath, config.get<string>('rootPath')),
     runAllTestsFirst: config.get<boolean>('runAllTestsFirst'),
     showCoverageOnLoad: config.get<boolean>('showCoverageOnLoad'),
-    restartJestOnSnapshotUpdate: config.get<boolean>('restartJestOnSnapshotUpdate'),
   }
 }

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -17,7 +17,7 @@ describe('JestExt', () => {
   let projectWorkspace: ProjectWorkspace
   const channelStub = { appendLine: () => {} } as any
   const mockShowErrorMessage = window.showErrorMessage as jest.Mock<any>
-  const extensionSettings = {} as any
+  const extensionSettings = { debugCodeLens: {} } as any
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -103,7 +103,10 @@ describe('JestExt', () => {
 
   describe('generateInlineErrorDecorator()', () => {
     it('should add the decoration type to the cache', () => {
-      const settings: any = { enableInlineErrorMessages: true }
+      const settings: any = {
+        debugCodeLens: {},
+        enableInlineErrorMessages: true,
+      }
       const sut = new JestExt(projectWorkspace, channelStub, settings)
       const editor: any = {
         document: { fileName: 'file.js' },

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -21,8 +21,21 @@ jest.mock('vscode', () => ({
     onDidChangeActiveTextEditor: jest.fn().mockReturnValue('onDidChangeActiveTextEditor'),
   },
   workspace: {
-    getConfiguration: jest.fn().mockReturnValue({
-      get: jest.fn().mockImplementation(key => key),
+    /** Mock getConfiguration by reading default values from package.json */
+    getConfiguration: jest.fn().mockImplementation(section => {
+      const data = readFileSync('./package.json')
+      const config = JSON.parse(data.toString()).contributes.configuration.properties
+
+      const defaults = {}
+      for (const key of Object.keys(config)) {
+        if (section.length === 0 || key.startsWith(`${section}.`)) {
+          defaults[key] = config[key].default
+        }
+      }
+
+      return {
+        get: jest.fn().mockImplementation(key => defaults[`${section}.${key}`]),
+      }
     }),
     onDidChangeConfiguration: jest.fn(),
     onDidCloseTextDocument: jest.fn(),
@@ -50,8 +63,9 @@ jest.mock('../src/SnapshotCodeLens', () => ({
   registerSnapshotPreview: jest.fn(() => []),
 }))
 
-import { activate } from '../src/extension'
+import { activate, getExtensionSettings } from '../src/extension'
 import * as vscode from 'vscode'
+import { readFileSync } from 'fs'
 
 describe('Extension', () => {
   describe('activate()', () => {
@@ -103,6 +117,26 @@ describe('Extension', () => {
       const registeredAsNode = register.mock.calls.some(parameters => parameters[0] === 'node')
       const registeredAsJestTest = register.mock.calls.some(parameters => parameters[0] === 'vscode-jest-tests')
       expect(registeredAsNode && registeredAsJestTest).toBeTruthy()
+    })
+  })
+
+  describe('getExtensionSettings()', () => {
+    it('should return the extension configuration', async () => {
+      vscode.workspace.rootPath = '<rootDir>'
+
+      expect(getExtensionSettings()).toEqual({
+        autoEnable: true,
+        enableCodeLens: true,
+        enableInlineErrorMessages: true,
+        enableSnapshotPreviews: true,
+        enableSnapshotUpdateMessages: true,
+        pathToConfig: '',
+        pathToJest: 'node_modules/.bin/jest',
+        restartJestOnSnapshotUpdate: false,
+        rootPath: '<rootDir>',
+        runAllTestsFirst: true,
+        showCoverageOnLoad: false,
+      })
     })
   })
 })

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -66,6 +66,7 @@ jest.mock('../src/SnapshotCodeLens', () => ({
 import { activate, getExtensionSettings } from '../src/extension'
 import * as vscode from 'vscode'
 import { readFileSync } from 'fs'
+import { TestState } from '../src/DebugCodeLens'
 
 describe('Extension', () => {
   describe('activate()', () => {
@@ -126,7 +127,10 @@ describe('Extension', () => {
 
       expect(getExtensionSettings()).toEqual({
         autoEnable: true,
-        enableCodeLens: true,
+        debugCodeLens: {
+          enabled: true,
+          showWhenTestStateIn: [TestState.Fail, TestState.Unknown],
+        },
         enableInlineErrorMessages: true,
         enableSnapshotPreviews: true,
         enableSnapshotUpdateMessages: true,

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -135,7 +135,7 @@ describe('Extension', () => {
         enableSnapshotPreviews: true,
         enableSnapshotUpdateMessages: true,
         pathToConfig: '',
-        pathToJest: 'node_modules/.bin/jest',
+        pathToJest: null,
         restartJestOnSnapshotUpdate: false,
         rootPath: '<rootDir>',
         runAllTestsFirst: true,


### PR DESCRIPTION
This PR adds a new setting to control when the debug CodeLens appears above a test. Set `"jest.debugCodeLens.showWhenTestStateIn"` to any of combination of `"fail"`, `"pass"`, `"skip"`, `"unknown"` to your liking. It defaults to the current behaviour.

Can you think of a better name for the setting?

This will close #240.
