### PR TITLE
Start Jest with the --no-color CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Prevent ANSI escape codes from appearing in test messages - seanpoulter
 * Your message here - name
 
 -->

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -18,8 +18,11 @@ export class JestProcess {
     this.stopRequested = false
     let exited = false
 
-    const useShell = platform() === 'win32'
-    this.runner = new Runner(this.projectWorkspace, { shell: useShell })
+    const options = {
+      noColor: true,
+      shell: platform() === 'win32',
+    }
+    this.runner = new Runner(this.projectWorkspace, options)
 
     this.restoreJestEvents()
 


### PR DESCRIPTION
This PR will prevent the ANSI escape codes from appearing in the test messages. This is dependent on  a change to `jest-editor-support` that adds the `--no-color` option (facebook/jest#5909).