### PR TITLE
Highlight the full line of the jest error, not just the first 6 characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Highlight the full line of the jest error, not just the first 6 characters - ThomasRooney
+
 ### 2.7.0
 
 * Add the ability to configure debugging of tests - stephtr, connectdotz

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -36,8 +36,9 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
         let endColumn = Number.MAX_SAFE_INTEGER
         const associatedTextEditor = vscode.window.visibleTextEditors.find(e => e.document.uri.fsPath === uri.fsPath)
         if (associatedTextEditor) {
-          startColumn = associatedTextEditor.document.lineAt(line).firstNonWhitespaceCharacterIndex
-          endColumn = associatedTextEditor.document.lineAt(line).text.length
+          const textLine = associatedTextEditor.document.lineAt(line)
+          startColumn = textLine.firstNonWhitespaceCharacterIndex
+          endColumn = textLine.text.length
         }
         const diag = new vscode.Diagnostic(
           new vscode.Range(line, startColumn, line, endColumn),

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -32,9 +32,15 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
             `received invalid line number '${assertion.line}' for '${uri.toString()}'. (most likely due to unexpected test results... you can help fix the root cause by logging an issue with a sample project to reproduce this warning)`
           )
         }
-        const start = 0
+        let startColumn = 0
+        let endColumn = Number.MAX_SAFE_INTEGER
+        const associatedTextEditor = vscode.window.visibleTextEditors.find(e => e.document.uri.fsPath === uri.fsPath)
+        if (associatedTextEditor) {
+          startColumn = associatedTextEditor.document.lineAt(line).firstNonWhitespaceCharacterIndex
+          endColumn = associatedTextEditor.document.lineAt(line).text.length
+        }
         const diag = new vscode.Diagnostic(
-          new vscode.Range(line, start, line, start + 6),
+          new vscode.Range(line, startColumn, line, endColumn),
           assertion.terseMessage || assertion.shortMessage || assertion.message,
           vscode.DiagnosticSeverity.Error
         )

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,5 +1,4 @@
 jest.unmock('../src/diagnostics')
-
 import { updateDiagnostics, resetDiagnostics, failedSuiteCount } from '../src/diagnostics'
 import * as vscode from 'vscode'
 import { TestFileAssertionStatus, TestReconcilationState, TestAssertionStatus } from 'jest-editor-support'
@@ -14,6 +13,8 @@ class MockDiagnosticCollection implements vscode.DiagnosticCollection {
   has = jest.fn()
   dispose = jest.fn()
 }
+
+vscode.window.visibleTextEditors = []
 
 describe('test diagnostics', () => {
   describe('resetDiagnostics', () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -165,5 +165,26 @@ describe('test diagnostics', () => {
         validateRange(rangeCalls[0], 0, 0)
       })
     })
+
+    it('should highlight the full line', () => {
+      const mockDiagnostics = new MockDiagnosticCollection()
+      const assertion = createAssertion('a', 'KnownFail')
+      const tests = [createTestResult('f', [assertion])]
+      vscode.Uri.file = jest.fn(() => ({ fsPath: 'f' }))
+      vscode.window.visibleTextEditors = [
+        {
+          document: {
+            lineAt: jest.fn(() => ({
+              firstNonWhitespaceCharacterIndex: 2,
+              text: '  text',
+            })),
+            uri: { fsPath: 'f' },
+          },
+        },
+      ] as any[]
+      updateDiagnostics(tests, mockDiagnostics)
+      expect(vscode.window.visibleTextEditors[0].document.lineAt).toHaveBeenCalled()
+      expect(vscode.Range).toHaveBeenCalledWith(assertion.line - 1, 2, assertion.line - 1, 6)
+    })
   })
 })


### PR DESCRIPTION
It bothered me that just the first 6 characters of each line were highlighted for the erronous jest diagnostic statement.

This makes it highlight the full line instead.

If the editor is open, it highlights from the trimmed firstNonWhitespaceCharacter, otherwise it's highlighting the full line. This means the columns highlighted swap slightly when the file is opened. I couldn't see a way around this but for either parsing the error message structure from jest, or loading the file into memory; neither nice options. 

Old:

![old-vscode-error](https://user-images.githubusercontent.com/2904857/39950603-3171577e-557a-11e8-9f90-36c7f3e41481.png)

New:

![new-vscode-error](https://user-images.githubusercontent.com/2904857/39950602-3151fc94-557a-11e8-9495-d711885763e6.png)


