### PR TITLE
Fix decorators on windows by adjusting implicit jest path based on OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Fixes decorators [test highlight dots] working on Windows when jest path implicit - ThomasRooney
+
 ### 2.7.0
 
 * Add the ability to configure debugging of tests - stephtr, connectdotz

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
           "description":
             "The path to the Jest binary, or an npm command to run tests prefixed with `--` e.g. `npm test --`",
           "type": "string",
-          "default": "node_modules/.bin/jest"
+          "default": null
         },
         "jest.pathToConfig": {
           "description": "The path to your Jest configuration file",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -61,15 +61,24 @@ function hasNodeExecutable(rootPath: string, executable: string): boolean {
  * @returns {string}
  */
 export function pathToJest(pluginSettings: IPluginSettings) {
-  const path = normalize(pluginSettings.pathToJest)
-
-  const defaultPath = normalize('node_modules/.bin/jest')
-  if (path === defaultPath && isBootstrappedWithCRA(pluginSettings.rootPath)) {
-    // If it's the default, run the script instead
-    return 'npm test --'
+  if (pluginSettings.pathToJest) {
+    if (isBootstrappedWithCRA(pluginSettings.rootPath)) {
+      return 'npm test --'
+    }
+    return normalize(pluginSettings.pathToJest)
   }
 
-  return path
+  const platform = process.platform
+  if (platform === 'win32' && existsSync(join(pluginSettings.rootPath, 'node_modules', '.bin', 'jest.cmd'))) {
+    return normalize(join(pluginSettings.rootPath, 'node_modules', '.bin', 'jest.cmd'))
+  } else if (
+    (platform === 'linux' || platform === 'darwin') &&
+    existsSync(join(pluginSettings.rootPath, 'node_modules', '.bin', 'jest'))
+  ) {
+    return normalize(join(pluginSettings.rootPath, 'node_modules', '.bin', 'jest'))
+  }
+
+  return 'jest'
 }
 
 /**


### PR DESCRIPTION
The green/red dots are currently broken on windows if jest path isn't configured.

The jest path selected is always a shell `jest` (linux/mac) script, rather than a feature based on current operating system, and potentially running the `jest.cmd` file. As such it crashes when attempting to run in windows `ENOENT`, because windows cannot evaluate shell scripts. 

This fixes that.

 * Removed double default configuration in package.json and in pathToJest helper
 * Check for OS platform before deciding on which script to run
 * Assumes global jest if jest not in node_modules. 

Not tested on Mac/Linux. Please confirm this doesn't regress there if you decide to merge.

This closes quite a few bugs that are correlated because the `jest --getConfig` command wasn't working on windows. FYI for a current workaround, just define jest path explicitly.

Closes #274 #320 #306 #289