### PR TITLE
Fix tests with same name corrupting the decorator dots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Fix decorators showing corrupt values when two tests of the same name in one file (e.g. in different describe blocks) exist - ThomasRooney
 * Highlight the full line of the jest error, not just the first 6 characters - ThomasRooney
 * Fixes decorators [test highlight dots] working on Windows when jest path implicit - ThomasRooney
 

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -42,8 +42,10 @@ export class TestResultProvider {
     for (const test of itBlocks) {
       const assertion =
         results.filter(result => result.line >= test.start.line && result.line <= test.end.line)[0] ||
-        results.filter(result => result.title === test.name && result.status !== 'KnownFail')[0] ||
-        {}
+        results.filter(
+          result => result.title === test.name && result.status !== TestReconciliationState.KnownFail
+        )[0] ||
+        ({} as any)
 
       // Note the shift from one-based to zero-based line number and columns
       result.push({

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -42,7 +42,8 @@ export class TestResultProvider {
     for (const test of itBlocks) {
       const assertion =
         results.filter(result => result.line >= test.start.line && result.line <= test.end.line)[0] ||
-        results.filter(result => result.title === test.name && result.status !== 'KnownFail')[0]
+        results.filter(result => result.title === test.name && result.status !== 'KnownFail')[0] ||
+        {}
 
       // Note the shift from one-based to zero-based line number and columns
       result.push({

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -38,15 +38,11 @@ export class TestResultProvider {
     const { itBlocks } = parseTest(filePath)
     const results = this.reconciler.assertionsForTestFile(filePath) || []
 
-    const resultsByTestName = {}
-    for (const result of results) {
-      const testName = result.title
-      resultsByTestName[testName] = result
-    }
-
     const result: TestResult[] = []
     for (const test of itBlocks) {
-      const assertion = resultsByTestName[test.name] || {}
+      const assertion =
+        results.filter(result => result.line >= test.start.line && result.line <= test.end.line)[0] ||
+        results.filter(result => result.title === test.name && result.status !== 'KnownFail')[0]
 
       // Note the shift from one-based to zero-based line number and columns
       result.push({

--- a/tests/TestResults/TestResultProvider.test.ts
+++ b/tests/TestResults/TestResultProvider.test.ts
@@ -116,6 +116,37 @@ describe('TestResultProvider', () => {
       expect(actual[0].terseMessage).toBeUndefined()
       expect(actual[0].lineNumberOfError).toBeUndefined()
     })
+    it('should handle duplicate test names', () => {
+      const sut = new TestResultProvider()
+      ;(parseTest as jest.Mock<{}>).mockReturnValueOnce({
+        itBlocks: [
+          testBlock,
+          {
+            name: testBlock.name,
+            start: {
+              line: 5,
+              column: 3,
+            },
+            end: {
+              line: 7,
+              column: 5,
+            },
+          },
+        ],
+      })
+      assertionsForTestFile.mockReturnValueOnce([
+        assertion,
+        {
+          title: testBlock.name,
+          status: TestReconciliationState.KnownSuccess,
+        },
+      ])
+      const actual = sut.getResults(filePath)
+
+      expect(actual).toHaveLength(2)
+      expect(actual[0].status).toBe(TestReconciliationState.KnownFail)
+      expect(actual[1].status).toBe(TestReconciliationState.KnownSuccess)
+    })
   })
 
   describe('getSortedResults()', () => {


### PR DESCRIPTION
Two tests with the same name (e.g. in different describe blocks) currently get the decorator of the last test result.

This is bad behaviour, as its common practice when testing an API under different conditions, to have the scenario be in the `describe` block and the API method under test in the `test` block. I.e. its a valid scenario to have multiple `test` blocks with the same key.

This adjusts that behaviour, by using the line numbers of the test under KnownFail scenarios to assign the decorators correctly, or otherwise just using the first Success or Unknown case (as they have the same parsed test result anyway -- line numbers being only available in KnownFail scenario). 