### PR TITLE
Support commands without active text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Bug-fixes within the same version aren't needed
 ## Master
 
 * Adds a setting to control when the debug CodeLens appears - seanpoulter
+* Support the "Jest: Start/Stop" and "Show output" commands without an active
+  text editor - seanpoulter
 
 -->
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,12 +35,12 @@ export function activate(context: vscode.ExtensionContext) {
   ]
   context.subscriptions.push(
     registerStatusBar(channel),
-    vscode.commands.registerTextEditorCommand(`${extensionName}.start`, () => {
+    vscode.commands.registerCommand(`${extensionName}.start`, () => {
       vscode.window.showInformationMessage('Started Jest, press escape to hide this message.')
       extensionInstance.startProcess()
     }),
-    vscode.commands.registerTextEditorCommand(`${extensionName}.stop`, () => extensionInstance.stopProcess()),
-    vscode.commands.registerTextEditorCommand(`${extensionName}.show-channel`, () => {
+    vscode.commands.registerCommand(`${extensionName}.stop`, () => extensionInstance.stopProcess()),
+    vscode.commands.registerCommand(`${extensionName}.show-channel`, () => {
       channel.show()
     }),
     ...registerSnapshotCodeLens(pluginSettings.enableSnapshotPreviews),

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -4,7 +4,6 @@ jest.mock('vscode', () => ({
   CodeLens: class {},
   commands: {
     registerCommand: jest.fn(),
-    registerTextEditorCommand: jest.fn(),
   },
   debug: {
     registerDebugConfigurationProvider: jest.fn(),


### PR DESCRIPTION
This issue will close #318. 

Changes proposed in this PR:
* It was reported that the **Jest: Start runner** command would not work when there wasn't an active text editor open. Changing the call from `registerTextEditorCommand` to `registerCommand` fixes this.
  
  The change has been tested locally and works OK.
  There are no changes to the tests. 😓 
