### PR TITLE
When --watch is not supported, restart with --watchAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Bug-fixes within the same version aren't needed
 * Adds a setting to control when the debug CodeLens appears - seanpoulter
 * Support the "Jest: Start/Stop" and "Show output" commands without an active
   text editor - seanpoulter
+* Restart Jest with --watchAll when --watch is not supported without git/hg
+  - seanpoulter
 
 -->
 

--- a/src/Jest/index.ts
+++ b/src/Jest/index.ts
@@ -1,0 +1,8 @@
+export enum WatchMode {
+  None = 'none',
+  Watch = 'watch',
+  WatchAll = 'watchAll',
+}
+
+export const isWatchNotSupported = (str = '') =>
+  new RegExp('^s*--watch is not supported without git/hg, please use --watchAlls*', 'im').test(str)

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -22,6 +22,7 @@ import { DecorationOptions } from './types'
 import { hasDocument, isOpenInMultipleEditors } from './editor'
 import { CoverageOverlay } from './Coverage/CoverageOverlay'
 import { JestProcess, JestProcessManager } from './JestProcessManagement'
+import { isWatchNotSupported, WatchMode } from './Jest'
 
 export class JestExt {
   private workspace: ProjectWorkspace
@@ -103,6 +104,10 @@ export class JestExt {
       return
     }
 
+    if (isWatchNotSupported(message)) {
+      this.jestProcess.watchMode = WatchMode.WatchAll
+    }
+
     // The "tests are done" message comes through stdErr
     // We want to use this as a marker that the console should
     // be cleared, as the next input will be from a new test run.
@@ -152,7 +157,7 @@ export class JestExt {
     }
 
     this.jestProcess = this.jestProcessManager.startJestProcess({
-      watch: true,
+      watchMode: WatchMode.Watch,
       keepAlive: true,
       exitCallback: (jestProcess, jestProcessInWatchMode) => {
         if (jestProcessInWatchMode) {

--- a/tests/Jest/index.test.ts
+++ b/tests/Jest/index.test.ts
@@ -1,0 +1,13 @@
+jest.unmock('../../src/Jest')
+import { isWatchNotSupported } from '../../src/Jest'
+
+describe('isWatchNotSupported', () => {
+  it('returns true when matching the expected message', () => {
+    const str = '\n--watch is not supported without git/hg, please use --watchAll \n'
+    expect(isWatchNotSupported(str)).toBe(true)
+  })
+
+  it('returns false otherwise', () => {
+    expect(isWatchNotSupported()).toBe(false)
+  })
+})

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -3,6 +3,7 @@ jest.unmock('../../src/JestProcessManagement/JestProcess')
 import { Runner, ProjectWorkspace } from 'jest-editor-support'
 import { JestProcess } from '../../src/JestProcessManagement/JestProcess'
 import { EventEmitter } from 'events'
+import { WatchMode } from '../../src/Jest'
 
 describe('JestProcess', () => {
   let projectWorkspaceMock
@@ -39,20 +40,15 @@ describe('JestProcess', () => {
       expect(jestProcess.stopRequested).toBeFalsy()
     })
 
-    it('accepts watchMode boolean argument', () => {
-      jestProcess = new JestProcess({
-        projectWorkspace: projectWorkspaceMock,
-        watchMode: true,
-      })
-      expect(jestProcess).not.toBe(null)
-    })
-
     it('records watchMode in the watchMode property', () => {
+      const expected = WatchMode.Watch
+
       jestProcess = new JestProcess({
         projectWorkspace: projectWorkspaceMock,
-        watchMode: true,
+        watchMode: expected,
       })
-      expect(jestProcess.watchMode).toBe(true)
+
+      expect(jestProcess.watchMode).toBe(expected)
     })
 
     it('creates an instance of jest-editor-support runner', () => {
@@ -69,34 +65,28 @@ describe('JestProcess', () => {
       expect(runnerMock.mock.calls[0][0]).toBe(projectWorkspaceMock)
     })
 
-    it('starts the jest-editor-support runner', () => {
+    it('starts the jest-editor-support Runner without watch mode by default', () => {
       jestProcess = new JestProcess({
         projectWorkspace: projectWorkspaceMock,
       })
       expect(runnerMockImplementation.start).toHaveBeenCalledTimes(1)
+      expect(runnerMockImplementation.start.mock.calls[0]).toEqual([false, false])
     })
 
-    it('passes the watchMode argument == false to the start command when it is not provided', () => {
+    it('starts the jest-editor-support Runner in --watch mode', () => {
       jestProcess = new JestProcess({
         projectWorkspace: projectWorkspaceMock,
+        watchMode: WatchMode.Watch,
       })
-      expect(runnerMockImplementation.start.mock.calls[0][0]).toBe(false)
+      expect(runnerMockImplementation.start.mock.calls[0]).toEqual([true, false])
     })
 
-    it('passes the watchMode argument == false to the start command when it is false', () => {
+    it('starts the jest-editor-support Runner in --watchAll mode', () => {
       jestProcess = new JestProcess({
         projectWorkspace: projectWorkspaceMock,
-        watchMode: false,
+        watchMode: WatchMode.WatchAll,
       })
-      expect(runnerMockImplementation.start.mock.calls[0][0]).toBe(false)
-    })
-
-    it('passes the watchMode argument == true to the start command when it is true', () => {
-      jestProcess = new JestProcess({
-        projectWorkspace: projectWorkspaceMock,
-        watchMode: true,
-      })
-      expect(runnerMockImplementation.start.mock.calls[0][0]).toBe(true)
+      expect(runnerMockImplementation.start.mock.calls[0]).toEqual([true, true])
     })
   })
 
@@ -241,7 +231,7 @@ describe('JestProcess', () => {
       expect(jestProcess.keepAlive).toBeFalsy()
     })
 
-    it('creates new instance of jest-editor-support runner', () => {
+    it('creates new instance of jest-editor-support Runner', () => {
       jestProcess = new JestProcess({
         projectWorkspace: projectWorkspaceMock,
         keepAlive: true,
@@ -297,26 +287,16 @@ describe('JestProcess', () => {
       expect(runnerMockImplementation.start).toHaveBeenCalledTimes(2)
     })
 
-    it('passes the watchMode argument to the new runner instance when it is false', () => {
-      jestProcess = new JestProcess({
-        projectWorkspace: projectWorkspaceMock,
-        watchMode: false,
-        keepAlive: true,
-      })
-      jestProcess.onExit(onExit)
-      eventEmitter.emit('debuggerProcessExit')
-      expect(runnerMockImplementation.start.mock.calls[1][0]).toBe(false)
-    })
-
     it('passes the watchMode argument to the new runner instance when it is true', () => {
       jestProcess = new JestProcess({
         projectWorkspace: projectWorkspaceMock,
-        watchMode: true,
+        watchMode: WatchMode.WatchAll,
         keepAlive: true,
       })
       jestProcess.onExit(onExit)
       eventEmitter.emit('debuggerProcessExit')
-      expect(runnerMockImplementation.start.mock.calls[1][0]).toBe(true)
+
+      expect(runnerMockImplementation.start.mock.calls[1]).toEqual([true, true])
     })
 
     it('removes all event listeners from the previous instance of the runner', () => {


### PR DESCRIPTION
The change introduced in #325 incorrectly configured the Runner to start with `--watchAll` enabled. I'll take some of that blame for the unclear API. To use `--watchAll` you need to set `true, true` which isn't clear. 😞 

Changes proposed in this PR:
* Change the watch mode flag from a Boolean to an enumeration: none, watch, watchAll
* Properly start the Runner with `--watch` and `--watchAll`
* Detect the error message when `--watch` is not supported and restart with `--watchAll`

Changes not proposed in this PR:
* No setting to "always use --watchAll" since we can detect when `--watch` fails
* Moving the error message detection into `jest-editor-support`. I know **cpojer** wants to add integration tests to make sure we catch if the text changes.

Testing:
* Manually tested using a workspace without a git or hg repo:
  
  **index.test.js**:
  ```js
  describe('Test suite', () => {
    it('Test', () => {
      expect(1).toBe(2);
    })
  })
  ```
* Tests have been updated with a few redundant test cases removed

This will resolve #327.