### PR TITLE
Highlight error of failed test when assertion was made outside of test

### DIFF
--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -45,6 +45,7 @@ export class TestResultProvider {
         results.filter(
           result => result.title === test.name && result.status !== TestReconciliationState.KnownFail
         )[0] ||
+        results.filter(result => result.title === test.name)[0] ||
         ({} as any)
 
       // Note the shift from one-based to zero-based line number and columns
@@ -62,7 +63,7 @@ export class TestResultProvider {
         status: assertion.status || TestReconciliationState.Unknown,
         shortMessage: assertion.shortMessage,
         terseMessage: assertion.terseMessage,
-        lineNumberOfError: assertion.line ? assertion.line - 1 : undefined,
+        lineNumberOfError: assertion.line ? assertion.line - 1 : test.end.line - 1,
       })
     }
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -7,6 +7,7 @@ import { existsSync } from 'fs'
 // import { DiagnosticCollection, Uri, Diagnostic, Range, DiagnosticSeverity } from 'vscode'
 import { TestFileAssertionStatus } from 'jest-editor-support'
 import { TestReconciliationState } from './TestResults'
+import { parseTest } from './TestParser'
 
 export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagnostics: vscode.DiagnosticCollection) {
   function addTestFileError(result: TestFileAssertionStatus, uri: vscode.Uri) {
@@ -23,10 +24,15 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
     diagnostics.set(
       uri,
       asserts.map(assertion => {
-        let line: number
-        if (assertion.line >= 0) {
-          line = Math.max(assertion.line - 1, 0)
+        let line: number = -1
+        if (assertion.line > 0) {
+          line = assertion.line - 1
         } else {
+          const { itBlocks } = parseTest(result.file)
+          const test = itBlocks.filter(t => t.name === assertion.title)[0]
+          if (test) line = test.end.line - 1
+        }
+        if (line < 0) {
           line = 0
           console.warn(
             `received invalid line number '${assertion.line}' for '${uri.toString()}'. (most likely due to unexpected test results... you can help fix the root cause by logging an issue with a sample project to reproduce this warning)`


### PR DESCRIPTION
Currently the failed assertions that are raised outside of test (eg. rxjs-marbles testing) are not visible. The failure is shown on the first line of the file.
![before](https://user-images.githubusercontent.com/1668205/40366079-88ee3314-5dd6-11e8-9ebd-f85f45040bbb.png)
This commit changes this to get the assertion location from the location of the test.
![after](https://user-images.githubusercontent.com/1668205/40366120-a8748eea-5dd6-11e8-8ffa-5d8f68d41681.png)
