### PR TITLE
Fix when "update snapshots" message is displayed #trivial

### DIFF
--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -124,7 +124,7 @@ export class JestExt {
     }
     // thanks Qix, http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
     const noANSI = message.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
-    if (noANSI.includes('snapshot test failed')) {
+    if (/(snapshot failed)|(snapshot test failed)/i.test(noANSI)) {
       this.detectedSnapshotErrors()
     }
 


### PR DESCRIPTION
The existing check was not working in jest@23.4.1