### PR TITLE
Fix mapping from Native Windows to WSL Paths

### DIFF
--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -1,6 +1,7 @@
 import { platform } from 'os'
-import { Runner, ProjectWorkspace } from 'jest-editor-support'
+import { Runner, ProjectWorkspace, Options } from 'jest-editor-support'
 import { WatchMode } from '../Jest'
+import { createProcessInWSL } from './WslProcess'
 
 export class JestProcess {
   static readonly keepAliveLimit = 5
@@ -18,9 +19,13 @@ export class JestProcess {
     this.stopRequested = false
     let exited = false
 
-    const options = {
+    const options: Options = {
       noColor: true,
       shell: platform() === 'win32',
+    }
+    // If Windows Subsystem for Linux is used, spawn in wsl
+    if (this.projectWorkspace.pathToJest && this.projectWorkspace.pathToJest.startsWith('wsl')) {
+      options.createProcess = createProcessInWSL
     }
     this.runner = new Runner(this.projectWorkspace, options)
 

--- a/src/JestProcessManagement/WslProcess.ts
+++ b/src/JestProcessManagement/WslProcess.ts
@@ -1,0 +1,70 @@
+'use strict'
+import * as child_process from 'child_process'
+
+import { ProjectWorkspace, Options } from '../../node_modules/jest-editor-support'
+
+/**
+ * Spawns and returns a Jest process with specific args
+ *
+ * @param {string[]} args
+ * @returns {ChildProcess}
+ */
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+import { win32, posix } from 'path'
+
+export const createProcessInWSL = (workspace: ProjectWorkspace, args, options: Options = { shell: true }) => {
+  // A command could look like `npm run test`, which we cannot use as a command
+  // as they can only be the first command, so take out the command, and add
+  // any other bits into the args
+  const runtimeExecutable = workspace.pathToJest
+  const parameters = runtimeExecutable.split(' ')
+  const command = parameters[0]
+  const initialArgs = parameters.slice(1)
+  let runtimeArgs = [].concat(initialArgs, args)
+
+  // If a path to configuration file was defined, push it to runtimeArgs
+  if (workspace.pathToConfig) {
+    runtimeArgs.push('--config')
+    runtimeArgs.push(workspace.pathToConfig)
+  }
+
+  runtimeArgs = runtimeArgs.map(windowsPathToWSL)
+
+  // To use our own commands in create-react, we need to tell the command that
+  // we're in a CI environment, or it will always append --watch
+  const env = process.env
+  env['CI'] = 'true'
+
+  const spawnOptions = {
+    cwd: workspace.rootPath,
+    env: env,
+    shell: options.shell,
+  }
+
+  if (workspace.debug) {
+    console.log(`spawning process with command=${command}, args=${runtimeArgs.toString()}`)
+  }
+
+  return child_process.spawn(command, runtimeArgs, spawnOptions)
+}
+
+function windowsPathToWSL(maybePath: string): string {
+  const isPath = win32.parse(maybePath).dir
+  if (!isPath) {
+    return maybePath
+  }
+  const windowsPath = maybePath[0].toLocaleLowerCase() + maybePath.substr(1)
+  const path = windowsPath
+    .split(win32.sep)
+    .join(posix.sep)
+    .replace(/^(\w):/, '/mnt/$1')
+
+  return path
+}

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -60,7 +60,7 @@ export function coverageMapWithLowerCaseWindowsDriveLetters(data: JestTotalResul
 }
 
 function fileCoverageWithLowerCaseWindowsDriveLetter(fileCoverage: FileCoverage) {
-  const newFilePath = withLowerCaseWindowsDriveLetter(fileCoverage.path)
+  const newFilePath = withNormalizedWindowsPath(fileCoverage.path)
   if (newFilePath) {
     return {
       ...fileCoverage,
@@ -82,7 +82,7 @@ export function testResultsWithLowerCaseWindowsDriveLetters(
 }
 
 function testResultWithLowerCaseWindowsDriveLetter(testResult: JestFileResults): JestFileResults {
-  const newFilePath = withLowerCaseWindowsDriveLetter(testResult.name)
+  const newFilePath = withNormalizedWindowsPath(testResult.name)
   if (newFilePath) {
     return {
       ...testResult,
@@ -93,9 +93,24 @@ function testResultWithLowerCaseWindowsDriveLetter(testResult: JestFileResults):
   return testResult
 }
 
-export function withLowerCaseWindowsDriveLetter(filePath: string): string | undefined {
+export function withNormalizedWindowsPath(filePath: string, platform = process.platform): string | undefined {
+  if (platform === 'win32') {
+    filePath = convertWSLPathToWindows(filePath)
+  }
+
   const match = filePath.match(/^([A-Z]:\\)(.*)$/)
   if (match) {
     return `${match[1].toLowerCase()}${match[2]}`
   }
+  return filePath
+}
+
+function convertWSLPathToWindows(filePath: string) {
+  const isLinuxPath = filePath.match(/^\/mnt\/(\w)\/(.*)$/)
+  if (isLinuxPath) {
+    const normalizedPath = isLinuxPath[2].split(path.posix.sep).join(path.win32.sep)
+    const driveLetter = `${isLinuxPath[1]}:\\`
+    filePath = `${driveLetter}${normalizedPath}`
+  }
+  return filePath
 }

--- a/tests/JestProcessManagement/WslProcess.test.ts
+++ b/tests/JestProcessManagement/WslProcess.test.ts
@@ -1,0 +1,39 @@
+jest.mock('child_process')
+jest.unmock('../../src/JestProcessManagement/WslProcess')
+jest.unmock('jest-editor-support')
+
+import * as child_process from 'child_process'
+import { ProjectWorkspace } from 'jest-editor-support'
+import { createProcessInWSL } from '../../src/JestProcessManagement/WslProcess'
+
+describe('WslProcess', () => {
+  beforeEach(() => jest.resetAllMocks())
+
+  it('should convert windows path to the wsl root', () => {
+    const expectedArguments = ['test', '--config', '/mnt/c/config/json']
+    const projectWorkspaceMock = new ProjectWorkspace('C:\\Temp', 'wsl test', 'C:\\config\\json', null)
+
+    createProcessInWSL(projectWorkspaceMock, [], {
+      shell: true,
+    })
+
+    const spawnMock = child_process.spawn as jest.Mock
+    const spawnArguments: string[] = spawnMock.mock.calls[0][1]
+
+    expect(spawnArguments).toEqual(expectedArguments)
+  })
+
+  it('should convert also wrongly build windows paths to the wsl root', () => {
+    const expectedArguments = ['test', '--config', '/mnt/c/myPath/some_unix_path']
+    const projectWorkspaceMock = new ProjectWorkspace('C:\\Temp', 'wsl test', 'C:\\myPath/some_unix_path', null)
+
+    createProcessInWSL(projectWorkspaceMock, [], {
+      shell: true,
+    })
+
+    const spawnMock = child_process.spawn as jest.Mock
+    const spawnArguments: string[] = spawnMock.mock.calls[0][1]
+
+    expect(spawnArguments).toEqual(expectedArguments)
+  })
+})


### PR DESCRIPTION
This is a naive fix that allows jest runs in WSL (Windows Subsystem for Linux)
to be executed and also fixes mapping wsl paths to the windows paths (which
are required by the vscode instance that is not running in WSL). Parts
of this fix should be moved to jest-editor-support.

The idea was to touch as little logic as possible and only introduce wsl specific logic in the spawning of the process and the parsing of resultpaths.

- JestProcess (I have no clue why the diff says everything has changed): The 
```
    // If Windows Subsystem for Linux is used, spawn in wsl
    if (this.projectWorkspace.pathToJest && this.projectWorkspace.pathToJest.startsWith('wsl')) {
      options.createProcess = createProcessInWSL
    }
```
snippet is a really dirty workaround which I would try to circumvent by updating the jest-editor-support in the aftermath. Having a useWSL Flag would really make sense in the ProjectWorkspace, even if that means it becomes an even bigger data structure

- WslProcess would also end up in jest-editor-support, or the process implementation there. 

- TestResult has been updated to rewrite the WSL (/mnt/c) paths to Windows paths (C:\)