### PR TITLE
Make debug button respect custom jest config location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Bug-fixes within the same version aren't needed
 -->
 
 ## Master
-* Fixes 'Debug' button ignoring configuration option 'pathToJest'.
+* Fixes 'Debug' button ignoring configuration option 'pathToConfig'.
 
 ### 2.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Bug-fixes within the same version aren't needed
 
 -->
 
+## Master
+* Fixes 'Debug' button ignoring configuration option 'pathToJest'.
+
 ### 2.9.0
 
 * Adds a setting to control when the debug CodeLens appears - seanpoulter

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -1,17 +1,20 @@
 import * as vscode from 'vscode'
+import { ProjectWorkspace } from 'jest-editor-support'
 import { getTestCommand, isCreateReactAppTestCommand } from './helpers'
 
 export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
   private fileNameToRun: string = ''
   private testToRun: string = ''
+  private workspace: ProjectWorkspace
 
   /**
    * Prepares injecting the name of the test, which has to be debugged, into the `DebugConfiguration`,
    * This function has to be called before `vscode.debug.startDebugging`.
    */
-  public prepareTestRun(fileNameToRun: string, testToRun: string) {
+  public prepareTestRun(fileNameToRun: string, testToRun: string, workspace: ProjectWorkspace) {
     this.fileNameToRun = fileNameToRun
     this.testToRun = testToRun
+    this.workspace = workspace
   }
 
   resolveDebugConfiguration(
@@ -71,6 +74,9 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       debugConfiguration.protocol = 'inspector'
     } else {
       // Plain jest setup
+      if (this.workspace.pathToConfig) {
+        debugConfiguration.args = [...debugConfiguration.args, '--config', this.workspace.pathToConfig]
+      }
       debugConfiguration.program = '${workspaceFolder}/node_modules/jest/bin/jest'
     }
 

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -5,7 +5,7 @@ import { getTestCommand, isCreateReactAppTestCommand } from './helpers'
 export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
   private fileNameToRun: string = ''
   private testToRun: string = ''
-  private workspace: ProjectWorkspace
+  private workspace: ProjectWorkspace = {} as ProjectWorkspace
 
   /**
    * Prepares injecting the name of the test, which has to be debugged, into the `DebugConfiguration`,

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -402,7 +402,7 @@ export class JestExt {
     const restart = this.jestProcessManager.numberOfProcesses > 0
     this.jestProcessManager.stopAll()
 
-    this.debugConfigurationProvider.prepareTestRun(fileName, identifier)
+    this.debugConfigurationProvider.prepareTestRun(fileName, identifier, this.workspace)
 
     const handle = vscode.debug.onDidTerminateDebugSession(_ => {
       handle.dispose()

--- a/tests/DebugConfigurationProvider.test.ts
+++ b/tests/DebugConfigurationProvider.test.ts
@@ -2,6 +2,7 @@ jest.unmock('../src/DebugConfigurationProvider')
 
 import { DebugConfigurationProvider } from '../src/DebugConfigurationProvider'
 import { getTestCommand, isCreateReactAppTestCommand } from '../src/helpers'
+import { ProjectWorkspace } from 'jest-editor-support'
 
 describe('DebugConfigurationProvider', () => {
   it('should by default return a DebugConfiguration for Jest', () => {
@@ -33,7 +34,23 @@ describe('DebugConfigurationProvider', () => {
     expect(config.args).toContain('--env=jsdom')
     expect(config.args).toContain('--runInBand')
   })
+  it('should utilise workspace jestConfig', () => {
+    const folder = { uri: { fspath: 'folderName' } }
+    const fileName = 'fileName'
+    const testNamePattern = 'testNamePattern'
+    const workspace = {
+      pathToConfig: './jest-config.js',
+    }
+    const expected = ['--runInBand', '--config', workspace.pathToConfig]
 
+    const sut = new DebugConfigurationProvider()
+    sut.prepareTestRun(fileName, testNamePattern, workspace as any)
+
+    const configuration = sut.provideDebugConfigurations(folder as any)
+
+    expect(configuration).toBeDefined()
+    expect(configuration[0].args).toEqual(expected)
+  })
   it('should append the specified tests', () => {
     const fileName = 'fileName'
     const testNamePattern = 'testNamePattern'
@@ -41,7 +58,7 @@ describe('DebugConfigurationProvider', () => {
     let configuration: any = { name: 'vscode-jest-tests' }
 
     const sut = new DebugConfigurationProvider()
-    sut.prepareTestRun(fileName, testNamePattern)
+    sut.prepareTestRun(fileName, testNamePattern, {} as ProjectWorkspace)
 
     configuration = sut.resolveDebugConfiguration(undefined, configuration)
 

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -146,7 +146,7 @@ describe('JestExt', () => {
       expect(configuration).toBeDefined()
       expect(configuration.type).toBe('dummyconfig')
 
-      expect(sut.debugConfigurationProvider.prepareTestRun).toBeCalledWith(fileName, testNamePattern)
+      expect(sut.debugConfigurationProvider.prepareTestRun).toBeCalledWith(fileName, testNamePattern, projectWorkspace)
     })
   })
 


### PR DESCRIPTION
Fixes 'Debug' button ignoring configuration option 'pathToJest'.

Can be replicated by breaking a test on core jest repo and clicking 'Debug' option -- it is shown that the jest config defined in .vscode/settings.json is ignored.