### PR TITLE
Fix #331: Support useWsl parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug-fixes within the same version aren't needed
 
 * Your message here - name
 
+* Support running jest in WSL (Windows Subsystem for Linux) - mojadev
 -->
 
 ### 2.9.1
@@ -158,7 +159,7 @@ Bug-fixes within the same version aren't needed
 * Use "jest-test-typescript-parser" for our TypeScript parser - orta
 * Bumps min VS code release - orta
 
-Note: This release consolidates a lot of code with the Jest project, and so if you have a custom `testRegex` and use 
+Note: This release consolidates a lot of code with the Jest project, and so if you have a custom `testRegex` and use
       Jest below v20, chances are the decorators will not show. Everything else should be 👍 - orta
 
 ### 2.0.4
@@ -182,9 +183,9 @@ Note: This release consolidates a lot of code with the Jest project, and so if y
 
 * Move all of the Jest specific code into a new repo: [jest-editor-support](https://github.com/facebook/jest/tree/master/packages/jest-editor-support) where
   we can share the code with a nuclide implementation. This brings some changes to the development process (see the README) but should only affect users
-  if we've missed something in moving over. 
+  if we've missed something in moving over.
 
-  - orta / bookman25 / cpojer 
+  - orta / bookman25 / cpojer
 
 * Significant improvements to JavaScript parsers - bookman25
 * Introduction of TypeScript support - bookman25
@@ -208,14 +209,14 @@ Note: This release consolidates a lot of code with the Jest project, and so if y
 
 ### 1.6.1
 
-* More windows improvements - KalleOtt 
+* More windows improvements - KalleOtt
 
 ### 1.6.0
 
-* Separation of VS Code specific code from the extension by creating a lib directory, 
+* Separation of VS Code specific code from the extension by creating a lib directory,
   in preparation for moving to the Jest repo - https://github.com/facebook/jest/issues/2183 - orta
 * Minor improvements for create-react users - orta
-* Support for running Jest even in repos where Jest is not a direct dependency via the command `Start Jest Runner` - you will definitely need to set the per-project `.vscode/settings.json` to whatever would normally trigger a jest run - orta 
+* Support for running Jest even in repos where Jest is not a direct dependency via the command `Start Jest Runner` - you will definitely need to set the per-project `.vscode/settings.json` to whatever would normally trigger a jest run - orta
 
 ### 1.5.1
 
@@ -224,7 +225,7 @@ Note: This release consolidates a lot of code with the Jest project, and so if y
 
 ### 1.5.0
 
-* Adds support for running the tests inside `create react` apps - orta 
+* Adds support for running the tests inside `create react` apps - orta
 
 ### 1.4.0
 
@@ -240,7 +241,7 @@ Note: This release consolidates a lot of code with the Jest project, and so if y
 
 ### 1.2.0
 
-* Adds syntax highlights for the JSX in `.js.snap` files - orta 
+* Adds syntax highlights for the JSX in `.js.snap` files - orta
 
 ### 1.1.0
 
@@ -250,7 +251,7 @@ Note: This release consolidates a lot of code with the Jest project, and so if y
 * You can define your own path to the Jest test runner - orta
 * Not a feature, but the code has been thoroughly commented - orta
 * Improvements to parsing passing test files - orta
-* Only run JS parser on files that match the Jest tesRegex - orta 
+* Only run JS parser on files that match the Jest tesRegex - orta
 
 ### 1.0.3
 
@@ -267,7 +268,7 @@ Note: This release consolidates a lot of code with the Jest project, and so if y
 * Starts Jest automatically when you're in a project with Jest installed.
 * Show individual fail / passes inline.
 * Show fails inside the problem inspector.
-* Highlights the errors next to the `expect` functions 
+* Highlights the errors next to the `expect` functions
 
 - orta
 
@@ -286,6 +287,6 @@ Note: This release consolidates a lot of code with the Jest project, and so if y
 * Adds statusbar support - orta
 * Adds fails to the problems section - orta
 
-### 0.0.3 
+### 0.0.3
 
 * Parses current file for it/test blocks - orta

--- a/README.md
+++ b/README.md
@@ -140,19 +140,26 @@ These are the [activation events](https://code.visualstudio.com/docs/extensionAP
 These are the things that will trigger the extension loading. If one of these applies, and you're not seeing the "Jest" in the bottom bar, reference the self-diagnosis below
 
 ### non-standard environments
-vscode-jest supports common jest configuration, such as when jest is in `root/node_modules/.bin/jest`, or for react-native `root/node_modules/react-native-scripts`. 
+vscode-jest supports common jest configuration, such as when jest is in `root/node_modules/.bin/jest`, or for react-native `root/node_modules/react-native-scripts`.
 
 However, if your repo doesn't fall into these patterns or you want to pass extra parameters, you can easily use the `jest.pathToJest` or `jest.pathToConfig` settings to instruct the plugin on how to start jest. You can even use the scripts from package.json, such as `npm run test --` or `yarn test`. Feel free to experiment and search the issues for many examples.
 
+When running in Windows Subsystem for Linux, make sure to set the jest.ueWsl flag either to true or the run command of your WSL environment (e.g. ubuntu run), for example:
+
+```
+  "jest.pathToJest": "npm run test -- --coverage",
+  "jest.useWsl": "ubuntu run",
+```
+
 ### plugin not running as expect? try self-diagnosis
 If your can execute jest tests on command line but vscode-jest was not running as expected, here is what you can do to find out what it is actually doing:
-1. click on `Jest:stopped` on status bar to show Jest Output window: 
+1. click on `Jest:stopped` on status bar to show Jest Output window:
    <img src="https://github.com/jest-community/vscode-jest/raw/master/images/output-channel.png" alt="Screenshot of the tool" width="100%">
-1. turn on the debug mode: set `"jest.debugMode": true` in `.vscode/settings.json` 
+1. turn on the debug mode: set `"jest.debugMode": true` in `.vscode/settings.json`
 1. restart vscode-jest or reload the window (via `Reload Window` command)
 1. open the developer tool (via `Help > Toggle Developer Tools` menu), you should see more information including how we extract jest config and spawn jest processes.
 
-Hopefully most issues would be pretty obvious after seeing these extra output, and you can probably fix most yourself by customizing the `jest.pathToJest` and other settings. 
+Hopefully most issues would be pretty obvious after seeing these extra output, and you can probably fix most yourself by customizing the `jest.pathToJest` and other settings.
 
 ## Want to Contribute?
 

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "elegant-spinner": "^1.0.1",
     "istanbul-lib-coverage": "^1.1.1",
     "istanbul-lib-source-maps": "^1.1.0",
-    "jest-editor-support": "23.3.0",
+    "jest-editor-support": "mojadev/jest-editor-support#WSL_Support",
     "jest-snapshot": "^23.0.1",
     "jest-test-typescript-parser": "^23.3.0",
     "micromatch": "^2.3.11"

--- a/package.json
+++ b/package.json
@@ -122,6 +122,12 @@
           "description": "Enable debug mode to diagnose plugin issues. (see developer console)",
           "type": "boolean",
           "default": false
+        },
+        "jest.useWsl": {
+          "description":
+            "Execute jest in a wsl environment (use true for 'wsl' or enter the wsl command you want to use).",
+          "type": ["boolean", "string"],
+          "default": false
         }
       }
     },

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -17,6 +17,7 @@ export interface IPluginSettings {
   showCoverageOnLoad: boolean
   coverageFormatter: string
   debugMode?: boolean
+  useWsl?: boolean | string
 }
 
 export function isDefaultPathToJest(str) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,8 @@ export function activate(context: vscode.ExtensionContext) {
     configPath,
     currentJestVersion,
     null,
-    debugMode
+    debugMode,
+    pluginSettings.useWsl
   )
 
   // Create our own console
@@ -104,5 +105,6 @@ export function getExtensionSettings(): IPluginSettings {
     showCoverageOnLoad: config.get<boolean>('showCoverageOnLoad'),
     coverageFormatter: config.get<string>('coverageFormatter'),
     debugMode: config.get<boolean>('debugMode'),
+    useWsl: config.get<boolean>('useWsl'),
   }
 }

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -141,6 +141,7 @@ describe('Extension', () => {
         runAllTestsFirst: true,
         showCoverageOnLoad: false,
         debugMode: false,
+        useWsl: false,
       })
     })
   })


### PR DESCRIPTION
As discussed, now a version without any mapping in vscode-jest itself. This relies on the changes in the jest-editor-support package, so expect the CI to fail 😃 