### PR TITLE
Restart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bug-fixes within the same version aren't needed
 * Your message here - name
 
 -->
+## Master
+
+* Adds "Jest: Restart Runner" command - vdh
 
 ### 2.10.0
 

--- a/package.json
+++ b/package.json
@@ -164,6 +164,10 @@
         "title": "Jest: Stop Runner"
       },
       {
+        "command": "io.orta.jest.restart",
+        "title": "Jest: Restart Runner"
+      },
+      {
         "command": "io.orta.jest.show-channel",
         "title": "Jest: Show Test Output Channel"
       },

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -215,7 +215,7 @@ export class JestExt {
   }
 
   public restartProcess() {
-    this.stopProcess().then(() => {
+    return this.stopProcess().then(() => {
       this.startProcess()
     })
   }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -417,7 +417,7 @@ export class JestExt {
 
   public runTest = async (workspaceFolder: vscode.WorkspaceFolder, fileName: string, identifier: string) => {
     const restart = this.jestProcessManager.numberOfProcesses > 0
-    this.jestProcessManager.stopAll()
+    await this.jestProcessManager.stopAll()
 
     this.debugConfigurationProvider.prepareTestRun(fileName, identifier)
 

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -213,6 +213,14 @@ export class JestExt {
     this.status.stopped()
   }
 
+  public restartProcess() {
+    this.stopProcess()
+
+    setTimeout(() => {
+      this.startProcess()
+    }, 500)
+  }
+
   private detectedSnapshotErrors() {
     if (!this.pluginSettings.enableSnapshotUpdateMessages) {
       return
@@ -267,11 +275,7 @@ export class JestExt {
 
     this.coverageOverlay.enabled = updatedSettings.showCoverageOnLoad
 
-    this.stopProcess()
-
-    setTimeout(() => {
-      this.startProcess()
-    }, 500)
+    this.restartProcess()
   }
 
   updateDecorators(testResults: SortedTestResults, editor: vscode.TextEditor) {

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -209,16 +209,15 @@ export class JestExt {
 
   public stopProcess() {
     this.channel.appendLine('Closing Jest')
-    this.jestProcessManager.stopAll()
-    this.status.stopped()
+    return this.jestProcessManager.stopAll().then(() => {
+      this.status.stopped()
+    })
   }
 
   public restartProcess() {
-    this.stopProcess()
-
-    setTimeout(() => {
+    this.stopProcess().then(() => {
       this.startProcess()
-    }, 500)
+    })
   }
 
   private detectedSnapshotErrors() {

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -417,7 +417,7 @@ export class JestExt {
 
   public runTest = async (workspaceFolder: vscode.WorkspaceFolder, fileName: string, identifier: string) => {
     const restart = this.jestProcessManager.numberOfProcesses > 0
-    await this.jestProcessManager.stopAll()
+    this.jestProcessManager.stopAll()
 
     this.debugConfigurationProvider.prepareTestRun(fileName, identifier)
 

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -72,13 +72,13 @@ export class JestProcess {
     this.onExitCallback = callback
   }
 
-  public onJestEditorSupportEvent(event, callback) {
+  public onJestEditorSupportEvent(event: string, callback: (...args: any) => void) {
     this.jestSupportEvents.set(event, callback)
     this.runner.on(event, callback)
     return this
   }
 
-  public stop() {
+  public stop(): Promise<undefined> {
     this.stopRequested = true
     this.keepAliveCounter = 1
     this.jestSupportEvents.clear()
@@ -88,7 +88,7 @@ export class JestProcess {
     })
   }
 
-  public runJestWithUpdateForSnapshots(callback) {
+  public runJestWithUpdateForSnapshots(callback: Function) {
     this.runner.runJestWithUpdateForSnapshots(callback)
   }
 }

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -4,6 +4,7 @@ import { WatchMode } from '../Jest'
 
 export class JestProcess {
   static readonly keepAliveLimit = 5
+  static readonly stopHangTimeout = 500
   private runner: Runner
   private projectWorkspace: ProjectWorkspace
   private onExitCallback: Function
@@ -79,12 +80,14 @@ export class JestProcess {
   }
 
   public stop(): Promise<void> {
-    this.stopRequested = true
-    this.keepAliveCounter = 1
-    this.jestSupportEvents.clear()
     return new Promise(resolve => {
+      this.stopRequested = true
+      this.keepAliveCounter = 1
       this.resolve = resolve
+      this.jestSupportEvents.clear()
       this.runner.closeProcess()
+
+      setTimeout(resolve, JestProcess.stopHangTimeout)
     })
   }
 

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -72,13 +72,13 @@ export class JestProcess {
     this.onExitCallback = callback
   }
 
-  public onJestEditorSupportEvent(event: string, callback: (...args: any) => void) {
+  public onJestEditorSupportEvent(event: string, callback: (...args: any[]) => void) {
     this.jestSupportEvents.set(event, callback)
     this.runner.on(event, callback)
     return this
   }
 
-  public stop(): Promise<undefined> {
+  public stop(): Promise<void> {
     this.stopRequested = true
     this.keepAliveCounter = 1
     this.jestSupportEvents.clear()
@@ -88,7 +88,7 @@ export class JestProcess {
     })
   }
 
-  public runJestWithUpdateForSnapshots(callback: Function) {
+  public runJestWithUpdateForSnapshots(callback: () => void) {
     this.runner.runJestWithUpdateForSnapshots(callback)
   }
 }

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -82,9 +82,9 @@ export class JestProcess {
     this.stopRequested = true
     this.keepAliveCounter = 1
     this.jestSupportEvents.clear()
-    this.runner.closeProcess()
     return new Promise(resolve => {
       this.resolve = resolve
+      this.runner.closeProcess()
     })
   }
 

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -39,6 +39,7 @@ export class JestProcess {
           this.onExitCallback(this)
           if (this.stopRequested) {
             this.resolve()
+            this.resolve = null
           }
         }
       }
@@ -87,7 +88,13 @@ export class JestProcess {
       this.jestSupportEvents.clear()
       this.runner.closeProcess()
 
-      setTimeout(resolve, JestProcess.stopHangTimeout)
+      // As a safety fallback to prevent the stop from hanging, resolve after a timeout
+      // TODO: If `closeProcess` can be guarenteed to always resolve, remove this
+      setTimeout(() => {
+        if (this.resolve === resolve) {
+          resolve()
+        }
+      }, JestProcess.stopHangTimeout)
     })
   }
 

--- a/src/JestProcessManagement/JestProcessManager.ts
+++ b/src/JestProcessManagement/JestProcessManager.ts
@@ -18,14 +18,22 @@ export class JestProcessManager {
     this.runAllTestsFirstInWatchMode = runAllTestsFirstInWatchMode
   }
 
-  private removeJestProcessReference(jestProcess) {
+  private removeJestProcessReference(jestProcess: JestProcess) {
     const index = this.jestProcesses.indexOf(jestProcess)
     if (index !== -1) {
       this.jestProcesses.splice(index, 1)
     }
   }
 
-  private runJest({ watchMode, keepAlive, exitCallback }) {
+  private runJest({
+    watchMode,
+    keepAlive,
+    exitCallback,
+  }: {
+    watchMode: WatchMode
+    keepAlive: boolean
+    exitCallback: Function
+  }) {
     const jestProcess = new JestProcess({
       projectWorkspace: this.projectWorkspace,
       watchMode,
@@ -38,7 +46,15 @@ export class JestProcessManager {
     return jestProcess
   }
 
-  private run({ watchMode, keepAlive, exitCallback }) {
+  private run({
+    watchMode,
+    keepAlive,
+    exitCallback,
+  }: {
+    watchMode: WatchMode
+    keepAlive: boolean
+    exitCallback: Function
+  }) {
     return this.runJest({
       watchMode,
       keepAlive,
@@ -51,7 +67,7 @@ export class JestProcessManager {
     })
   }
 
-  private runAllTestsFirst(onExit) {
+  private runAllTestsFirst(onExit: Function) {
     return this.runJest({
       watchMode: WatchMode.None,
       keepAlive: false,
@@ -95,7 +111,7 @@ export class JestProcessManager {
     return Promise.all(processesToRemove.map(jestProcess => jestProcess.stop()))
   }
 
-  public stopJestProcess(jestProcess) {
+  public stopJestProcess(jestProcess: JestProcess) {
     this.removeJestProcessReference(jestProcess)
     return jestProcess.stop()
   }

--- a/src/JestProcessManagement/JestProcessManager.ts
+++ b/src/JestProcessManagement/JestProcessManager.ts
@@ -92,9 +92,7 @@ export class JestProcessManager {
   public stopAll() {
     const processesToRemove = [...this.jestProcesses]
     this.jestProcesses = []
-    processesToRemove.forEach(jestProcess => {
-      jestProcess.stop()
-    })
+    return Promise.all(processesToRemove.map(jestProcess => jestProcess.stop()))
   }
 
   public stopJestProcess(jestProcess) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
       extension.startProcess()
     }),
     extensionManager.registerCommand(`${extensionName}.stop`, extension => extension.stopProcess()),
+    extensionManager.registerCommand(`${extensionName}.restart`, extension => extension.restartProcess()),
     // dublicate of "show-output" maybe remove?
     extensionManager.registerCommand(`${extensionName}.show-channel`, extension => extension.channel.show()),
     extensionManager.registerCommand(`${extensionName}.coverage.toggle`, extension =>

--- a/tests/JestProcessManagement/JestProcessManager.test.ts
+++ b/tests/JestProcessManagement/JestProcessManager.test.ts
@@ -255,11 +255,14 @@ describe('JestProcessManager', () => {
       jestProcessManager.startJestProcess()
       jestProcessManager.startJestProcess()
 
-      jestProcessManager.stopAll()
+      const stopAll = jestProcessManager.stopAll()
 
-      expect(jestProcessMock.mock.instances.length).toBe(2)
-      expect(mockImplementation.stop).toHaveBeenCalledTimes(2)
-      expect(jestProcessManager.numberOfProcesses).toBe(0)
+      expect(stopAll).toBeInstanceOf(Promise)
+      return stopAll.then(() => {
+        expect(jestProcessMock.mock.instances.length).toBe(2)
+        expect(mockImplementation.stop).toHaveBeenCalledTimes(2)
+        expect(jestProcessManager.numberOfProcesses).toBe(0)
+      })
     })
 
     it('does not stop any jest process if none is running', () => {
@@ -270,11 +273,14 @@ describe('JestProcessManager', () => {
 
       jestProcessMock.mockImplementation(() => mockImplementation)
 
-      jestProcessManager.stopAll()
+      const stopAll = jestProcessManager.stopAll()
 
-      expect(jestProcessMock.mock.instances.length).toBe(0)
-      expect(mockImplementation.stop).not.toHaveBeenCalled()
-      expect(jestProcessManager.numberOfProcesses).toBe(0)
+      expect(stopAll).toBeInstanceOf(Promise)
+      return stopAll.then(() => {
+        expect(jestProcessMock.mock.instances.length).toBe(0)
+        expect(mockImplementation.stop).not.toHaveBeenCalled()
+        expect(jestProcessManager.numberOfProcesses).toBe(0)
+      })
     })
   })
 

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -150,7 +150,9 @@ describe('Extension', () => {
 
       expect(callArg).toBeDefined()
       callArg[1](jestInstance)
+      expect(jestInstance.restartProcess).toHaveBeenCalled()
       expect(jestInstance.startProcess).toHaveBeenCalled()
+      expect(jestInstance.stopProcess).toHaveBeenCalled()
     })
 
     it('should register a command to toggle the coverage overlay visibility', () => {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -48,6 +48,7 @@ const jestInstance = {
   runTest: jest.fn(),
   startProcess: jest.fn(),
   stopProcess: jest.fn(),
+  restartProcess: jest.fn(),
 }
 
 const extensionManager = {
@@ -139,6 +140,17 @@ describe('Extension', () => {
       expect(callArg).toBeDefined()
       callArg[1](jestInstance)
       expect(jestInstance.stopProcess).toHaveBeenCalled()
+    })
+
+    it('should register a command to restart extension', () => {
+      activate(context)
+      const callArg = context.subscriptions.push.mock.calls[0].find(args => {
+        return args[0] === `${extensionName}.restart`
+      })
+
+      expect(callArg).toBeDefined()
+      callArg[1](jestInstance)
+      expect(jestInstance.startProcess).toHaveBeenCalled()
     })
 
     it('should register a command to toggle the coverage overlay visibility', () => {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -120,61 +120,69 @@ describe('Extension', () => {
       expect(context.subscriptions.push.mock.calls[0]).toContain('onDidChangeWorkspaceFolders')
     })
 
-    it('should register a command to start extension', () => {
-      activate(context)
-      const callArg = context.subscriptions.push.mock.calls[0].find(args => {
-        return args[0] === `${extensionName}.start`
+    describe('should register a command', () => {
+      beforeEach(() => {
+        jestInstance.toggleCoverageOverlay.mockReset()
+        jestInstance.runTest.mockReset()
+        jestInstance.startProcess.mockReset()
+        jestInstance.stopProcess.mockReset()
+        jestInstance.restartProcess.mockReset()
       })
 
-      expect(callArg).toBeDefined()
-      callArg[1](jestInstance)
-      expect(jestInstance.startProcess).toHaveBeenCalled()
-    })
+      it('to start extension', () => {
+        activate(context)
+        const callArg = context.subscriptions.push.mock.calls[0].find(args => {
+          return args[0] === `${extensionName}.start`
+        })
 
-    it('should register a command to stop extension', () => {
-      activate(context)
-      const callArg = context.subscriptions.push.mock.calls[0].find(args => {
-        return args[0] === `${extensionName}.stop`
+        expect(callArg).toBeDefined()
+        callArg[1](jestInstance)
+        expect(jestInstance.startProcess).toHaveBeenCalled()
       })
 
-      expect(callArg).toBeDefined()
-      callArg[1](jestInstance)
-      expect(jestInstance.stopProcess).toHaveBeenCalled()
-    })
+      it('to stop extension', () => {
+        activate(context)
+        const callArg = context.subscriptions.push.mock.calls[0].find(args => {
+          return args[0] === `${extensionName}.stop`
+        })
 
-    it('should register a command to restart extension', () => {
-      activate(context)
-      const callArg = context.subscriptions.push.mock.calls[0].find(args => {
-        return args[0] === `${extensionName}.restart`
+        expect(callArg).toBeDefined()
+        callArg[1](jestInstance)
+        expect(jestInstance.stopProcess).toHaveBeenCalled()
       })
 
-      expect(callArg).toBeDefined()
-      callArg[1](jestInstance)
-      expect(jestInstance.restartProcess).toHaveBeenCalled()
-      expect(jestInstance.startProcess).toHaveBeenCalled()
-      expect(jestInstance.stopProcess).toHaveBeenCalled()
-    })
+      it('to restart extension', () => {
+        activate(context)
+        const callArg = context.subscriptions.push.mock.calls[0].find(args => {
+          return args[0] === `${extensionName}.restart`
+        })
 
-    it('should register a command to toggle the coverage overlay visibility', () => {
-      activate(context)
-      const callArg = context.subscriptions.push.mock.calls[0].find(args => {
-        return args[0] === `${extensionName}.coverage.toggle`
+        expect(callArg).toBeDefined()
+        callArg[1](jestInstance)
+        expect(jestInstance.restartProcess).toHaveBeenCalled()
       })
 
-      expect(callArg).toBeDefined()
-      callArg[1](jestInstance)
-      expect(jestInstance.toggleCoverageOverlay).toHaveBeenCalled()
-    })
+      it('to toggle the coverage overlay visibility', () => {
+        activate(context)
+        const callArg = context.subscriptions.push.mock.calls[0].find(args => {
+          return args[0] === `${extensionName}.coverage.toggle`
+        })
 
-    it('should register a command to run specific test', () => {
-      activate(context)
-      const callArg = context.subscriptions.push.mock.calls[0].find(args => {
-        return args[0] === `${extensionName}.run-test`
+        expect(callArg).toBeDefined()
+        callArg[1](jestInstance)
+        expect(jestInstance.toggleCoverageOverlay).toHaveBeenCalled()
       })
 
-      expect(callArg).toBeDefined()
-      callArg[1]({ uri: '' })
-      expect(jestInstance.runTest).toHaveBeenCalled()
+      it('to run specific test', () => {
+        activate(context)
+        const callArg = context.subscriptions.push.mock.calls[0].find(args => {
+          return args[0] === `${extensionName}.run-test`
+        })
+
+        expect(callArg).toBeDefined()
+        callArg[1]({ uri: '' })
+        expect(jestInstance.runTest).toHaveBeenCalled()
+      })
     })
 
     it('should register a DebugConfigurationProvider', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,6 @@
     "curly": true,
     "eofline": true,
     "no-duplicate-variable": true,
-    "no-unused-expression": true,
     "no-var-keyword": true,
     "prefer-const": true,
     "triple-equals": true,


### PR DESCRIPTION
- Added a "Jest: Restart Runner" / `restartProcess` command that calls `stopProcess` then `startProcess`
- Updated `stopAll` in the process manager to return a promise (via `Promise.all`), similar to `stopJestProcess`
- Updated `stopProcess` to return the promise from `stopAll`
- To keep things DRY, replaced some restart logic at the end of `triggerUpdateSettings` with a call to `restartProcess`, and used the promise from `stopProcess` instead of the 500ms timeout

Fixes #59