### PR TITLE
Fix #403: replaced deprecated vscode.previewHtml command with webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
-* Your message here - name
+* replaced deprecated vscode.previewHtml command with webview - qalex
 
 -->
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "2.9.1",
   "publisher": "Orta",
   "engines": {
-    "vscode": "^1.18.0"
+    "vscode": "^1.23.0"
   },
   "author": {
     "name": "Orta Therox, ConnectDotz & Sean Poulter",

--- a/src/SnapshotCodeLens/SnapshotPreviewProvider.ts
+++ b/src/SnapshotCodeLens/SnapshotPreviewProvider.ts
@@ -6,33 +6,11 @@ import { extensionName } from '../appGlobals'
 export const previewCommand = `${extensionName}.snapshot.preview`
 
 export function registerSnapshotPreview() {
-  const previewUri = vscode.Uri.parse(`${extensionName}.snapshot.preview://snapshot-preview`)
-  const provider = new SnapshotPreviewProvider()
-  return [
-    vscode.commands.registerCommand(previewCommand, (snapshot: SnapshotMetadata) => {
-      vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.Two, snapshot.name)
-      provider.update(previewUri, snapshot.content)
-    }),
-    vscode.workspace.registerTextDocumentContentProvider(`${extensionName}.snapshot.preview`, provider),
-  ]
-}
+  let panel: vscode.WebviewPanel = null
 
-class SnapshotPreviewProvider implements vscode.TextDocumentContentProvider {
-  private _onDidChange = new vscode.EventEmitter<vscode.Uri>()
-  private snapshot: string
-
-  get onDidChange() {
-    return this._onDidChange.event
-  }
-
-  public update(uri: vscode.Uri, snapshot: string) {
-    this.snapshot = snapshot
-    this._onDidChange.fire(uri)
-  }
-
-  public provideTextDocumentContent() {
-    if (this.snapshot) {
-      const escaped = this.snapshot
+  const escaped = (snapshot: string) => {
+    if (snapshot) {
+      const escaped = snapshot
         .replace(/&/g, '&amp;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;')
@@ -41,4 +19,21 @@ class SnapshotPreviewProvider implements vscode.TextDocumentContentProvider {
       return `<pre>${escaped}</pre>`
     }
   }
+
+  return [
+    vscode.commands.registerCommand(previewCommand, (snapshot: SnapshotMetadata) => {
+      if (panel) {
+        panel.reveal()
+      } else {
+        panel = vscode.window.createWebviewPanel('view_snapshot', snapshot.name, vscode.ViewColumn.Two, {})
+
+        panel.onDidDispose(() => {
+          panel = null
+        })
+      }
+
+      panel.webview.html = escaped(snapshot.content)
+      panel.title = snapshot.name
+    }),
+  ]
 }


### PR DESCRIPTION
This is to fix 'view snapshot' feature.
Background: 'vscode.previewHtml' command has been deprecated for some time and in VS Code 1.33 it was removed (details: https://github.com/Microsoft/vscode/issues/62630), so 'view snapshot' feature stopped working. This is my humble attempt to provide a fix for that by replacing 'vscode.previewHtml' with webview as recommended in the mentioned Microsoft issue.