### PR TITLE
Detect pluarlized message 'snapshots failed'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* Fix regex to detect the pluralized message 'snapshots failed' and show the 'Would you like to update your Snapshots' dialog.
+
 -->
 
 ### 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
-* Fix regex to detect the pluralized message 'snapshots failed' and show the 'Would you like to update your Snapshots' dialog.
+* Fix regex to detect the pluralized message 'snapshots failed' and show the 'Would you like to update your Snapshots' dialog - shruda
 
 -->
 

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -405,7 +405,7 @@ export class JestExt {
     }
     // thanks Qix, http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
     const noANSI = message.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
-    if (/(snapshot failed)|(snapshot test failed)/i.test(noANSI)) {
+    if (/(snapshots? failed)|(snapshot test failed)/i.test(noANSI)) {
       this.detectedSnapshotErrors()
     }
 

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -642,8 +642,9 @@ describe('JestExt', () => {
       const spy = jest.spyOn(sut as any, 'detectedSnapshotErrors')
       ;(sut as any).handleStdErr(new Error('Snapshot test failed'))
       ;(sut as any).handleStdErr(new Error('Snapshot failed'))
+      ;(sut as any).handleStdErr(new Error('Snapshots failed'))
       ;(sut as any).handleStdErr(new Error('Failed for some other reason'))
-      expect(spy).toHaveBeenCalledTimes(2)
+      expect(spy).toHaveBeenCalledTimes(3)
     })
   })
 


### PR DESCRIPTION
Fixes #474 by adding 's?' to detect pluralized message 'snapshots failed'.

