### PR TITLE
Fix Jest config file for 'Debug Tests' task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "Debug Tests",
       "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
       "cwd": "${workspaceRoot}",
-      "args": ["--i", "--config", "jest.json"]
+      "args": ["--i", "--config", "jest.config.js"]
     },
     {
       "name": "Launch Extension (development)",


### PR DESCRIPTION
The Jest configuration file was renamed from `jest.json` to `jest.config.js` with #447 but this reference was forgotten.