### PR TITLE
Fix watch task to run a shell command instead

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,8 +3,8 @@
   "tasks": [
     {
       "label": "watch",
-      "type": "npm",
-      "script": "watch",
+      "type": "shell",
+      "command": "yarn run watch",
       "isBackground": true,
       "problemMatcher": [
         {


### PR DESCRIPTION
I believe the old implementation (`"type": "npm"`) requires [this extension](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script) to be installed otherwise the "Launch Extension (development)" configuration won't work.

This PR removes that dependency by running the `yarn run watch` command as a shell process instead. I used `yarn` because this project includes a `yarn.lock`.