### PR TITLE
Remove ANSI color characters from diagnostic messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug-fixes within the same version aren't needed
 
 * Add 'hair space' (U+200A) after decoration text - [@rfgamaral](https://github.com/rfgamaral)
 * Fix decoration color for 'unknown' tests - [@rfgamaral](https://github.com/rfgamaral)
+* Fix remove ANSI characters from test messages - [@jmarceli](https://github.com/jmarceli)
 
 -->
 

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -11,7 +11,7 @@ import {
   resultsWithLowerCaseWindowsDriveLetters,
   SortedTestResults,
 } from './TestResults'
-import { pathToJest, pathToConfig } from './helpers'
+import { pathToJest, pathToConfig, cleanAnsi } from './helpers'
 import { CoverageMapProvider } from './Coverage'
 import { updateDiagnostics, updateCurrentDiagnostics, resetDiagnostics, failedSuiteCount } from './diagnostics'
 import { DebugCodeLensProvider } from './DebugCodeLens'
@@ -22,6 +22,7 @@ import { CoverageOverlay } from './Coverage/CoverageOverlay'
 import { JestProcess, JestProcessManager } from './JestProcessManagement'
 import { isWatchNotSupported, WatchMode } from './Jest'
 import * as messaging from './messaging'
+import { resultsWithoutAnsiCharacters } from './TestResults/TestResult'
 
 interface InstanceSettings {
   multirootEnv: boolean
@@ -403,8 +404,8 @@ export class JestExt {
       this.parsingTestFile = false
       this.channel.clear()
     }
-    // thanks Qix, http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
-    const noANSI = message.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+
+    const noANSI = cleanAnsi(message)
     if (/(snapshots? failed)|(snapshot test failed)/i.test(noANSI)) {
       this.detectedSnapshotErrors()
     }
@@ -459,7 +460,8 @@ export class JestExt {
   }
 
   private updateWithData(data: JestTotalResults) {
-    const normalizedData = resultsWithLowerCaseWindowsDriveLetters(data)
+    const noAnsiData = resultsWithoutAnsiCharacters(data)
+    const normalizedData = resultsWithLowerCaseWindowsDriveLetters(noAnsiData)
     this.coverageMapProvider.update(normalizedData.coverageMap)
 
     const statusList = this.testResultProvider.updateTestResults(normalizedData)

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -22,7 +22,7 @@ import { CoverageOverlay } from './Coverage/CoverageOverlay'
 import { JestProcess, JestProcessManager } from './JestProcessManagement'
 import { isWatchNotSupported, WatchMode } from './Jest'
 import * as messaging from './messaging'
-import { resultsWithoutAnsiCharacters } from './TestResults/TestResult'
+import { resultsWithoutAnsiEscapeSequence } from './TestResults/TestResult'
 
 interface InstanceSettings {
   multirootEnv: boolean
@@ -460,7 +460,7 @@ export class JestExt {
   }
 
   private updateWithData(data: JestTotalResults) {
-    const noAnsiData = resultsWithoutAnsiCharacters(data)
+    const noAnsiData = resultsWithoutAnsiEscapeSequence(data)
     const normalizedData = resultsWithLowerCaseWindowsDriveLetters(noAnsiData)
     this.coverageMapProvider.update(normalizedData.coverageMap)
 

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -2,6 +2,7 @@ import { TestReconciliationState } from './TestReconciliationState'
 import { JestFileResults, JestTotalResults } from 'jest-editor-support'
 import { FileCoverage } from 'istanbul-lib-coverage'
 import * as path from 'path'
+import { cleanAnsi } from '../helpers'
 
 interface Position {
   /** Zero-based column number */
@@ -41,6 +42,27 @@ export function resultsWithLowerCaseWindowsDriveLetters(data: JestTotalResults) 
   }
 
   return data
+}
+
+/**
+ * Removes ANSI characters from test results in order to get clean messages
+ */
+export function resultsWithoutAnsiCharacters(data: JestTotalResults) {
+  if (!data || !data.testResults) {
+    return data
+  }
+
+  return {
+    ...data,
+    testResults: data.testResults.map(result => ({
+      ...result,
+      message: cleanAnsi(result.message),
+      assertionResults: result.assertionResults.map(assertion => ({
+        ...assertion,
+        failureMessages: assertion.failureMessages.map(message => cleanAnsi(message)),
+      })),
+    })),
+  }
 }
 
 export function coverageMapWithLowerCaseWindowsDriveLetters(data: JestTotalResults) {

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -45,9 +45,9 @@ export function resultsWithLowerCaseWindowsDriveLetters(data: JestTotalResults) 
 }
 
 /**
- * Removes ANSI characters from test results in order to get clean messages
+ * Removes ANSI escape sequence characters from test results in order to get clean messages
  */
-export function resultsWithoutAnsiCharacters(data: JestTotalResults) {
+export function resultsWithoutAnsiEscapeSequence(data: JestTotalResults) {
   if (!data || !data.testResults) {
     return data
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -128,3 +128,10 @@ function removeSurroundingQuotes(str) {
 export function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 }
+
+/**
+ * ANSI colors/characters cleaning based on http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
+ */
+export function cleanAnsi(str: string): string {
+  return str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+}

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -1,5 +1,8 @@
 jest.unmock('events')
 jest.unmock('../src/JestExt')
+jest.mock('../src/helpers', () => ({
+  cleanAnsi: (str: string) => str,
+}))
 
 jest.mock('../src/DebugCodeLens', () => ({
   DebugCodeLensProvider: class MockCodeLensProvider {},

--- a/tests/TestResults/TestResult.test.ts
+++ b/tests/TestResults/TestResult.test.ts
@@ -64,6 +64,11 @@ describe('TestResult', () => {
   })
 
   describe('resultsWithoutAnsiCharacters', () => {
+    it('should not break when there is no data or testResults', () => {
+      expect(resultsWithoutAnsiCharacters(undefined)).toEqual(undefined)
+      const noTestResults: any = {}
+      expect(resultsWithoutAnsiCharacters(noTestResults)).toEqual({})
+    })
     it('should remove ANSI characters from the test results when provided', () => {
       const data: any = {
         testResults: [

--- a/tests/TestResults/TestResult.test.ts
+++ b/tests/TestResults/TestResult.test.ts
@@ -6,7 +6,7 @@ import {
   resultsWithLowerCaseWindowsDriveLetters,
   coverageMapWithLowerCaseWindowsDriveLetters,
   testResultsWithLowerCaseWindowsDriveLetters,
-  resultsWithoutAnsiCharacters,
+  resultsWithoutAnsiEscapeSequence,
   withLowerCaseWindowsDriveLetter,
 } from '../../src/TestResults/TestResult'
 import * as path from 'path'
@@ -63,11 +63,11 @@ describe('TestResult', () => {
     })
   })
 
-  describe('resultsWithoutAnsiCharacters', () => {
+  describe('resultsWithoutAnsiEscapeSequence', () => {
     it('should not break when there is no data or testResults', () => {
-      expect(resultsWithoutAnsiCharacters(undefined)).toEqual(undefined)
+      expect(resultsWithoutAnsiEscapeSequence(undefined)).toEqual(undefined)
       const noTestResults: any = {}
-      expect(resultsWithoutAnsiCharacters(noTestResults)).toEqual({})
+      expect(resultsWithoutAnsiEscapeSequence(noTestResults)).toEqual({})
     })
     it('should remove ANSI characters from the test results when provided', () => {
       const data: any = {
@@ -85,7 +85,7 @@ describe('TestResult', () => {
           },
         ],
       }
-      expect(resultsWithoutAnsiCharacters(data).testResults).toEqual([
+      expect(resultsWithoutAnsiEscapeSequence(data).testResults).toEqual([
         {
           message: '<body> <div> <div class="root" > Learn React </div> </div></body>',
           assertionResults: [

--- a/tests/TestResults/TestResult.test.ts
+++ b/tests/TestResults/TestResult.test.ts
@@ -1,10 +1,12 @@
 jest.unmock('../../src/TestResults/TestResult')
+jest.unmock('../../src/helpers')
 jest.mock('path', () => ({ sep: require.requireActual('path').sep }))
 
 import {
   resultsWithLowerCaseWindowsDriveLetters,
   coverageMapWithLowerCaseWindowsDriveLetters,
   testResultsWithLowerCaseWindowsDriveLetters,
+  resultsWithoutAnsiCharacters,
   withLowerCaseWindowsDriveLetter,
 } from '../../src/TestResults/TestResult'
 import * as path from 'path'
@@ -58,6 +60,34 @@ describe('TestResult', () => {
           coverageMap: expected,
         })
       })
+    })
+  })
+
+  describe('resultsWithoutAnsiCharacters', () => {
+    it('should remove ANSI characters from the test results when provided', () => {
+      const data: any = {
+        testResults: [
+          {
+            message:
+              '\u001b[36m<body>\u001b[39m \u001b[36m<div>\u001b[39m \u001b[36m<div\u001b[39m \u001b[33mclass\u001b[39m=\u001b[32m"root"\u001b[39m \u001b[36m>\u001b[39m \u001b[0mLearn React\u001b[0m \u001b[36m</div>\u001b[39m \u001b[36m</div>\u001b[39m\u001b[36m</body>\u001b[39m',
+            assertionResults: [
+              {
+                failureMessages: [
+                  '\u001b[36m<body>\u001b[39m \u001b[36m<div>\u001b[39m \u001b[36m<div\u001b[39m \u001b[33mclass\u001b[39m=\u001b[32m"root"\u001b[39m \u001b[36m>\u001b[39m \u001b[0mLearn React\u001b[0m \u001b[36m</div>\u001b[39m \u001b[36m</div>\u001b[39m\u001b[36m</body>\u001b[39m',
+                ],
+              },
+            ],
+          },
+        ],
+      }
+      expect(resultsWithoutAnsiCharacters(data).testResults).toEqual([
+        {
+          message: '<body> <div> <div class="root" > Learn React </div> </div></body>',
+          assertionResults: [
+            { failureMessages: ['<body> <div> <div class="root" > Learn React </div> </div></body>'] },
+          ],
+        },
+      ])
     })
   })
 

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -18,7 +18,7 @@ jest.mock('path', () => ({
   normalize: mockNormalize,
 }))
 
-import { isCreateReactAppTestCommand, pathToJest, pathToJestPackageJSON } from '../src/helpers'
+import { isCreateReactAppTestCommand, pathToJest, pathToJestPackageJSON, cleanAnsi } from '../src/helpers'
 import * as path from 'path'
 
 describe('ModuleHelpers', () => {
@@ -190,6 +190,15 @@ describe('ModuleHelpers', () => {
       mockExistsSync.mockImplementation(_ => false)
 
       expect(pathToJest(defaultSettings)).toBe(expected)
+    })
+  })
+
+  describe('cleanAnsi', () => {
+    it('removes ANSI characters from string', () => {
+      const ansiString =
+        '\u001b[36m<body>\u001b[39m \u001b[36m<div>\u001b[39m \u001b[36m<div\u001b[39m \u001b[33mclass\u001b[39m=\u001b[32m"root"\u001b[39m \u001b[36m>\u001b[39m \u001b[0mLearn React\u001b[0m \u001b[36m</div>\u001b[39m \u001b[36m</div>\u001b[39m\u001b[36m</body>\u001b[39m'
+
+      expect(cleanAnsi(ansiString)).toBe('<body> <div> <div class="root" > Learn React </div> </div></body>')
     })
   })
 })


### PR DESCRIPTION
This MR should solve https://github.com/jest-community/vscode-jest/issues/493 as well as https://github.com/jest-community/vscode-jest/issues/279.

Before this MR output looks like this:
<img width="687" alt="vscode-jest-ansi-colors" src="https://user-images.githubusercontent.com/4281333/65392688-b3dd9200-dd77-11e9-9d95-131ef7260937.png">

and after:
<img width="692" alt="vscode-jest-no-ansi" src="https://user-images.githubusercontent.com/4281333/65392691-be982700-dd77-11e9-98aa-a3177499247c.png">
