### PR TITLE
Replacing status bar spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Bug-fixes within the same version aren't needed
 
 -->
 
+## Master
+
+* replacing the status bar spinner to VS Code spinner
+
 ### 3.0.1
 
 * use webpack for compilation, resulting in a much smaller extension size - stephtr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
-* replacing the status bar spinner with VS Code spinner - rhalaly
+* replacing the status bar spinner with the VS Code spinner - rhalaly
 
 ### 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
-* replacing the status bar spinner to VS Code spinner - rhalaly
+* replacing the status bar spinner with VS Code spinner - rhalaly
 
 ### 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
-* replacing the status bar spinner to VS Code spinner
+* replacing the status bar spinner to VS Code spinner - rhalaly
 
 ### 3.0.1
 

--- a/package.json
+++ b/package.json
@@ -249,7 +249,6 @@
     "@types/node": "^8.0.31",
     "coveralls": "^3.0.0",
     "danger": "^2",
-    "elegant-spinner": "^1.0.1",
     "glob": "^7.1.1",
     "husky": "^0.14.3",
     "istanbul-lib-coverage": "^1.1.1",

--- a/tests/StatusBar.test.ts
+++ b/tests/StatusBar.test.ts
@@ -158,11 +158,6 @@ describe('StatusBar', () => {
 
       expect(renderSpy).toHaveBeenCalledTimes(2)
 
-      renderSpy.mockClear()
-
-      jest.advanceTimersByTime(150)
-
-      expect(renderSpy).toHaveBeenCalledTimes(2)
       const calls: any[][] = renderSpy.mock.calls
       expect(calls.every(c => c[0].status === 'running')).toBe(true)
       expect(calls.some(c => c[1].type === StatusType.active)).toBe(true)
@@ -175,8 +170,6 @@ describe('StatusBar', () => {
       statusBar.bind('testSource1').running()
       expect(active.show).toBeCalledTimes(1)
       expect(summary.show).toBeCalledTimes(0)
-      expect(setInterval).toBeCalledTimes(1)
-      expect(clearInterval).toBeCalledTimes(0)
 
       jest.clearAllMocks()
       jest.clearAllTimers()
@@ -185,11 +178,7 @@ describe('StatusBar', () => {
       expect(active.show).toBeCalledTimes(0)
       expect(summary.show).toBeCalledTimes(1)
 
-      // from summary status only
-      expect(setInterval).toBeCalledTimes(1)
-
       expect(active.hide).toBeCalledTimes(1)
-      expect(clearInterval).toBeCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
Replacing the status bar spinner with the [VS Code spinner](https://code.visualstudio.com/api/references/icons-in-labels#animation) `$(sync~spin)`.

This change will make the status bar to be less "jumpy" since the old slashes spinner frames have no equal width.

Fixes #505 