### PR TITLE
Use short message and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug-fixes within the same version aren't needed
 * Improve global and local detection for Jest executable on `win32` platform - [@rfgamaral](https://github.com/rfgamaral)
 * Set `"extensionKind": "workspace"` in `package.json` to support remote developement - [@rfgamaral](https://github.com/rfgamaral)
 * Fix remove ANSI characters from test messages - [@jmarceli](https://github.com/jmarceli)
+* Use short message instead of terse message in test diagnostic tooltip and tab - [@jmarceli](https://github.com/jmarceli)
 
 -->
 

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -375,7 +375,6 @@ export class JestExt {
     const errorMessage = test.terseMessage || test.shortMessage
     const decorator = {
       range: new vscode.Range(test.lineNumberOfError, 0, test.lineNumberOfError, 0),
-      hoverMessage: errorMessage,
     }
 
     // We have to make a new style for each unique message, this is

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -51,7 +51,7 @@ export function updateCurrentDiagnostics(
     testResult.map(r => {
       const line = r.lineNumberOfError || r.end.line
       const textLine = editor.document.lineAt(line)
-      return createDiagnosticWithRange(r.terseMessage || r.shortMessage, textLine.range)
+      return createDiagnosticWithRange(r.shortMessage, textLine.range)
     })
   )
 }
@@ -73,11 +73,7 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
     diagnostics.set(
       uri,
       asserts.map(assertion =>
-        createDiagnostic(
-          uri,
-          assertion.terseMessage || assertion.shortMessage || assertion.message,
-          assertion.line > 0 ? assertion.line - 1 : 0
-        )
+        createDiagnostic(uri, assertion.shortMessage || assertion.message, assertion.line > 0 ? assertion.line - 1 : 0)
       )
     )
   }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -9,20 +9,12 @@ import { TestFileAssertionStatus } from 'jest-editor-support'
 import { TestReconciliationState, TestResult } from './TestResults'
 
 function createDiagnostic(
-  uri: vscode.Uri,
   message: string,
   lineNumber: number,
   startCol = 0,
   endCol = Number.MAX_SAFE_INTEGER
 ): vscode.Diagnostic {
-  let line = lineNumber
-  if (line < 0) {
-    line = 0
-    // tslint:disable-next-line no-console
-    console.warn(
-      `received invalid line number '${line}' for '${uri.toString()}'. (most likely due to unexpected test results... you can help fix the root cause by logging an issue with a sample project to reproduce this warning)`
-    )
-  }
+  const line = lineNumber > 0 ? lineNumber - 1 : 0
   return createDiagnosticWithRange(message, new vscode.Range(line, startCol, line, endCol))
 }
 
@@ -64,7 +56,7 @@ export function updateCurrentDiagnostics(
 
 export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagnostics: vscode.DiagnosticCollection) {
   function addTestFileError(result: TestFileAssertionStatus, uri: vscode.Uri) {
-    const diag = createDiagnostic(uri, result.message || 'test file error', 0, 0, 0)
+    const diag = createDiagnostic(result.message || 'test file error', 0, 0, 0)
     diagnostics.set(uri, [diag])
   }
 
@@ -72,9 +64,7 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
     const asserts = result.assertions.filter(a => a.status === TestReconciliationState.KnownFail)
     diagnostics.set(
       uri,
-      asserts.map(assertion =>
-        createDiagnostic(uri, assertion.shortMessage || assertion.message, assertion.line > 0 ? assertion.line - 1 : 0)
-      )
+      asserts.map(assertion => createDiagnostic(assertion.shortMessage || assertion.message, assertion.line))
     )
   }
 

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -70,6 +70,39 @@ describe('test diagnostics', () => {
       expect(mockDiagnostics.set).not.toBeCalled()
     })
 
+    it('uses shortMessage format to display error details', () => {
+      const mockDiagnostics = new MockDiagnosticCollection()
+
+      const testResult = createTestResult('mocked-test-file.js', [
+        {
+          title: 'should be valid',
+          status: 'KnownFail',
+          message: `expect(received).toBe(expected) // Object.is equality
+
+        Expected: 2
+        Received: 1
+
+        at Object.toBe (src/pages/Home.test.tsx:6:13)`,
+          shortMessage: `expect(received).toBe(expected) // Object.is equality
+
+        Expected: 2
+        Received: 1`,
+          terseMessage: `Expected: 2, Received: 1`,
+          line: 123,
+        },
+      ])
+      updateDiagnostics([testResult], mockDiagnostics)
+      expect(vscode.Diagnostic).toHaveBeenCalledTimes(1)
+      expect(vscode.Diagnostic).toHaveBeenCalledWith(
+        expect.anything(),
+        `expect(received).toBe(expected) // Object.is equality
+
+        Expected: 2
+        Received: 1`,
+        expect.anything()
+      )
+    })
+
     it('can update diagnostics from mixed test results', () => {
       const allTests = [
         createTestResult('f1', [createAssertion('a1', 'KnownFail'), createAssertion('a2', 'KnownFail')]),

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -70,6 +70,22 @@ describe('test diagnostics', () => {
       expect(mockDiagnostics.set).not.toBeCalled()
     })
 
+    it('ensures non-negative line number in diagnostic message', () => {
+      const mockDiagnostics = new MockDiagnosticCollection()
+
+      console.warn = jest.fn()
+      const testResult = createTestResult('mocked-test-file.js', [
+        {
+          title: 'should be valid',
+          status: 'KnownFail',
+          message: 'failing reason',
+          line: -100,
+        },
+      ])
+      updateDiagnostics([testResult], mockDiagnostics)
+      expect(vscode.Range).toHaveBeenCalledWith(0, 0, 0, Number.MAX_SAFE_INTEGER)
+    })
+
     it('uses shortMessage format to display error details', () => {
       const mockDiagnostics = new MockDiagnosticCollection()
 


### PR DESCRIPTION
This PR replaces a terse message with a short one according to the https://github.com/jest-community/jest-editor-support/pull/18 discussion. It should improve `vscode-jest` plugin user experience as a terse message is often much less readable than short.
Simple example:

Terse:
<img width="626" alt="terse-message" src="https://user-images.githubusercontent.com/4281333/66703216-83529d80-ed10-11e9-8e7b-2404d77b3305.png">

Short:
<img width="628" alt="short-message" src="https://user-images.githubusercontent.com/4281333/66703218-85b4f780-ed10-11e9-9342-48b4db33c633.png">

What is more, for specialized testing frameworks like [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro) terse messages may be totally useless.

I hope that this PR will improve problems like this one https://github.com/jest-community/vscode-jest/issues/503, in a multiline view, snapshot diffs should be much more readable.