### PR TITLE
Adjust test result indicator for colorblind people

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug-fixes within the same version aren't needed
 * Improve global and local detection for Jest executable on `win32` platform - [@rfgamaral](https://github.com/rfgamaral)
 * Set `"extensionKind": "workspace"` in `package.json` to support remote developement - [@rfgamaral](https://github.com/rfgamaral)
 * Fix remove ANSI characters from test messages - [@jmarceli](https://github.com/jmarceli)
+* Adjust test result indicators for colorblind people - [@jmarceli](https://github.com/jmarceli)
 
 -->
 

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -47,13 +47,13 @@ export function passingItName() {
     light: {
       before: {
         color: '#3BB26B',
-        contentText: '● ',
+        contentText: '✔ ',
       },
     },
     dark: {
       before: {
         color: '#2F8F51',
-        contentText: '● ',
+        contentText: '✔ ',
       },
     },
     rangeBehavior: DecorationRangeBehavior.ClosedClosed,

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -7,13 +7,13 @@ export function failingItName() {
     light: {
       before: {
         color: '#FF564B',
-        contentText: '● ',
+        contentText: '✘ ',
       },
     },
     dark: {
       before: {
         color: '#AD322D',
-        contentText: '● ',
+        contentText: '✘ ',
       },
     },
     rangeBehavior: DecorationRangeBehavior.ClosedClosed,


### PR DESCRIPTION
According to https://github.com/jest-community/vscode-jest/issues/500 it might be beneficial to change the failing test icon to easily distinguish it from the success status without any color information.