### PR TITLE
Fix for "Invalid arguments" error, when enabling coverage in a .ts file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bug-fixes within the same version aren't needed
 * Fix remove ANSI characters from test messages - [@jmarceli](https://github.com/jmarceli)
 * Adjust test result indicators for colorblind people - [@jmarceli](https://github.com/jmarceli)
 * Use short message instead of terse message in test diagnostic tooltip and tab - [@jmarceli](https://github.com/jmarceli)
+* Fix for when `branch.end.column` is `null`. [@garyking](https://github.com/garyking)
 
 -->
 

--- a/src/Coverage/Formatters/DefaultFormatter.ts
+++ b/src/Coverage/Formatters/DefaultFormatter.ts
@@ -28,9 +28,14 @@ export class DefaultFormatter extends AbstractFormatter {
           return
         }
 
-        ranges.push(
-          new vscode.Range(branch.start.line - 1, branch.start.column, branch.end.line - 1, branch.end.column)
-        )
+        let endColumn = branch.end.column
+
+        // The value is `null`, so set it to the first character on its line.
+        if (!endColumn) {
+          endColumn = 0
+        }
+
+        ranges.push(new vscode.Range(branch.start.line - 1, branch.start.column, branch.end.line - 1, endColumn))
       })
     })
 

--- a/src/Coverage/Formatters/DefaultFormatter.ts
+++ b/src/Coverage/Formatters/DefaultFormatter.ts
@@ -17,7 +17,7 @@ export class DefaultFormatter extends AbstractFormatter {
   formatBranches(editor: vscode.TextEditor, fileCoverage: FileCoverage) {
     const ranges = []
 
-    Object.keys(fileCoverage.b).forEach(branchIndex => {
+    Object.keys(fileCoverage.b).forEach((branchIndex) => {
       fileCoverage.b[branchIndex].forEach((hitCount, locationIndex) => {
         if (hitCount > 0) {
           return
@@ -28,12 +28,9 @@ export class DefaultFormatter extends AbstractFormatter {
           return
         }
 
-        let endColumn = branch.end.column
-
-        // The value is `null`, so set it to the first character on its line.
-        if (!endColumn) {
-          endColumn = 0
-        }
+        // If the value is `null`, then set it to the first character on its
+        // line.
+        const endColumn = branch.end.column || 0
 
         ranges.push(new vscode.Range(branch.start.line - 1, branch.start.column, branch.end.line - 1, endColumn))
       })

--- a/tests/Coverage/Formatters/DefaultFormatter.test.ts
+++ b/tests/Coverage/Formatters/DefaultFormatter.test.ts
@@ -180,6 +180,42 @@ describe('DefaultFormatter', () => {
 
       expect(editor.setDecorations).toBeCalledWith(undefined, expected)
     })
+
+    it('should handle when the end column is `null`', () => {
+      ;(isValidLocation as jest.Mock<any>).mockReturnValueOnce(true)
+
+      const coverageMapProvider: any = {}
+      const editor: any = {
+        setDecorations: jest.fn(),
+      }
+
+      const fileCoverage: any = {
+        b: {
+          0: [0],
+        },
+        branchMap: {
+          0: {
+            locations: [
+              {
+                start: {
+                  line: 2,
+                  column: 2,
+                },
+                end: {
+                  line: 4,
+                  column: null,
+                },
+              },
+            ],
+          },
+        },
+      }
+
+      const sut = new DefaultFormatter(coverageMapProvider)
+      sut.formatBranches(editor, fileCoverage)
+
+      expect(vscode.Range).toBeCalledWith(1, 2, 3, 0)
+    })
   })
 
   describe('formatUncoveredLines()', () => {


### PR DESCRIPTION
This fixes the error mentioned [in this post](https://github.com/jest-community/vscode-jest/issues/499#issuecomment-554079535), which I also experience (my error message is the same). This bug made me unable to show coverage in certain TypeScript files.

The cause is because sometimes, `branch.end.column`'s value is `null`.

The test code I have is:

`index.ts`:

```ts
function getSomething(arg: number): string {
  // if (arg === 1) {
  //   return 'a';
  // }

  return 'b';
}

export { getSomething };

export default function index(): boolean {
  return true;
}
```

`index.test.ts`:

```ts
import index from '.';

describe('index', () => {
  test('do test', () => {
    expect(index()).toBe(true);
  });
});
```

Therefore, `getSomething` is intentionally not tested. 

With the code above, the output file at `/var/folders/d_/zgsjht515tdf44dsqc9cdb000000gn/T/jest_runner_ts_jest_test.json` is:

```json
{
  "numFailedTestSuites": 0,
  "numFailedTests": 0,
  "numPassedTestSuites": 1,
  "numPassedTests": 1,
  "numPendingTestSuites": 0,
  "numPendingTests": 0,
  "numRuntimeErrorTestSuites": 0,
  "numTodoTests": 0,
  "numTotalTestSuites": 1,
  "numTotalTests": 1,
  "openHandles": [],
  "snapshot": {
    "added": 0,
    "didUpdate": false,
    "failure": false,
    "filesAdded": 0,
    "filesRemoved": 0,
    "filesRemovedList": [],
    "filesUnmatched": 0,
    "filesUpdated": 0,
    "matched": 0,
    "total": 0,
    "unchecked": 0,
    "uncheckedKeysByFile": [],
    "unmatched": 0,
    "updated": 0
  },
  "startTime": 1573857629509,
  "success": true,
  "testResults": [
    {
      "assertionResults": [
        {
          "ancestorTitles": [
            "index"
          ],
          "failureMessages": [],
          "fullName": "index do test",
          "location": {
            "column": 2,
            "line": 4
          },
          "status": "passed",
          "title": "do test"
        }
      ],
      "endTime": 1573857630015,
      "message": "",
      "name": "/Users/gary/Downloads/Unsorted/Code/ts-jest-test/src/index.test.ts",
      "startTime": 1573857629515,
      "status": "passed",
      "summary": ""
    }
  ],
  "wasInterrupted": false,
  "coverageMap": {
    "/Users/gary/Downloads/Unsorted/Code/ts-jest-test/src/index.ts": {
      "path": "/Users/gary/Downloads/Unsorted/Code/ts-jest-test/src/index.ts",
      "statementMap": {
        "0": {
          "start": {
            "line": 6,
            "column": 2
          },
          "end": {
            "line": 6,
            "column": 13
          }
        },
        "1": {
          "start": {
            "line": 9,
            "column": 9
          },
          "end": {
            "line": 9,
            "column": 21
          }
        },
        "2": {
          "start": {
            "line": 12,
            "column": 2
          },
          "end": {
            "line": 12,
            "column": 14
          }
        },
        "3": {
          "start": {
            "line": 11,
            "column": 0
          },
          "end": {
            "line": 11,
            "column": 24
          }
        }
      },
      "fnMap": {
        "0": {
          "name": "getSomething",
          "decl": {
            "start": {
              "line": 1,
              "column": 9
            },
            "end": {
              "line": 1,
              "column": 21
            }
          },
          "loc": {
            "start": {
              "line": 1,
              "column": 33
            },
            "end": {
              "line": 7,
              "column": 1
            }
          }
        },
        "1": {
          "name": "index",
          "decl": {
            "start": {
              "line": 11,
              "column": 24
            },
            "end": {
              "line": 11,
              "column": 29
            }
          },
          "loc": {
            "start": {
              "line": 11,
              "column": 29
            },
            "end": {
              "line": 13,
              "column": 1
            }
          }
        }
      },
      "branchMap": {},
      "s": {
        "0": 0,
        "1": 1,
        "2": 1,
        "3": 1
      },
      "f": {
        "0": 0,
        "1": 1
      },
      "b": {}
    }
  }
}
```

Replace `index.ts` with:

```ts
function getSomething(arg: number): string {
  if (arg === 1) {
    return 'a';
  }

  return 'b';
}

export { getSomething };

export default function index(): boolean {
  return true;
}
```

And now the output file becomes:

```json
{
  "numFailedTestSuites": 0,
  "numFailedTests": 0,
  "numPassedTestSuites": 1,
  "numPassedTests": 1,
  "numPendingTestSuites": 0,
  "numPendingTests": 0,
  "numRuntimeErrorTestSuites": 0,
  "numTodoTests": 0,
  "numTotalTestSuites": 1,
  "numTotalTests": 1,
  "openHandles": [],
  "snapshot": {
    "added": 0,
    "didUpdate": false,
    "failure": false,
    "filesAdded": 0,
    "filesRemoved": 0,
    "filesRemovedList": [],
    "filesUnmatched": 0,
    "filesUpdated": 0,
    "matched": 0,
    "total": 0,
    "unchecked": 0,
    "uncheckedKeysByFile": [],
    "unmatched": 0,
    "updated": 0
  },
  "startTime": 1573866135216,
  "success": true,
  "testResults": [
    {
      "assertionResults": [
        {
          "ancestorTitles": [
            "index"
          ],
          "failureMessages": [],
          "fullName": "index do test",
          "location": {
            "column": 2,
            "line": 4
          },
          "status": "passed",
          "title": "do test"
        }
      ],
      "endTime": 1573866135822,
      "message": "",
      "name": "/Users/gary/Downloads/Unsorted/Code/ts-jest-test/src/index.test.ts",
      "startTime": 1573866135222,
      "status": "passed",
      "summary": ""
    }
  ],
  "wasInterrupted": false,
  "coverageMap": {
    "/Users/gary/Downloads/Unsorted/Code/ts-jest-test/src/index.ts": {
      "path": "/Users/gary/Downloads/Unsorted/Code/ts-jest-test/src/index.ts",
      "statementMap": {
        "0": {
          "start": {
            "line": 2,
            "column": 2
          },
          "end": {
            "line": 4,
            "column": null
          }
        },
        "1": {
          "start": {
            "line": 3,
            "column": 4
          },
          "end": {
            "line": 3,
            "column": 15
          }
        },
        "2": {
          "start": {
            "line": 6,
            "column": 2
          },
          "end": {
            "line": 6,
            "column": 13
          }
        },
        "3": {
          "start": {
            "line": 9,
            "column": 9
          },
          "end": {
            "line": 9,
            "column": 21
          }
        },
        "4": {
          "start": {
            "line": 12,
            "column": 2
          },
          "end": {
            "line": 12,
            "column": 14
          }
        },
        "5": {
          "start": {
            "line": 11,
            "column": 0
          },
          "end": {
            "line": 11,
            "column": 24
          }
        }
      },
      "fnMap": {
        "0": {
          "name": "getSomething",
          "decl": {
            "start": {
              "line": 1,
              "column": 9
            },
            "end": {
              "line": 1,
              "column": 21
            }
          },
          "loc": {
            "start": {
              "line": 1,
              "column": 33
            },
            "end": {
              "line": 7,
              "column": 1
            }
          }
        },
        "1": {
          "name": "index",
          "decl": {
            "start": {
              "line": 11,
              "column": 24
            },
            "end": {
              "line": 11,
              "column": 29
            }
          },
          "loc": {
            "start": {
              "line": 11,
              "column": 29
            },
            "end": {
              "line": 13,
              "column": 1
            }
          }
        }
      },
      "branchMap": {
        "0": {
          "loc": {
            "start": {
              "line": 2,
              "column": 2
            },
            "end": {
              "line": 4,
              "column": null
            }
          },
          "type": "if",
          "locations": [
            {
              "start": {
                "line": 2,
                "column": 2
              },
              "end": {
                "line": 4,
                "column": null
              }
            },
            {
              "start": {
                "line": 2,
                "column": 2
              },
              "end": {
                "line": 4,
                "column": null
              }
            }
          ]
        }
      },
      "s": {
        "0": 0,
        "1": 0,
        "2": 0,
        "3": 1,
        "4": 1,
        "5": 1
      },
      "f": {
        "0": 0,
        "1": 1
      },
      "b": {
        "0": [
          0,
          0
        ]
      }
    }
  }
}
```

Notice the multiple `end.column: null` values. This PR fixes that. Otherwise, the "Invalid argument" error will appear.