### PR TITLE
Fix `updateStatusBar` defaults (#trivial)

### DIFF
--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -451,7 +451,7 @@ export class JestExt {
     this.updateStatusBar('initial', undefined, false)
   }
 
-  private updateStatusBar(status: Status, details?: string, watchMode?: boolean) {
+  private updateStatusBar(status: Status, details?: string, watchMode: boolean = true) {
     const modes: Mode[] = []
     if (this.coverageOverlay.enabled) {
       modes.push('coverage')


### PR DESCRIPTION
In #527 we introduced new StatusBar messages. Unfortunately while moving some code, I forgot to include one argment's default value. This PR fixes it, sorry for that.