### PR TITLE
document: Add install through Visual Studio Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Orta Therox ([@orta](https://github.com/orta)), Sean Poulter ([@seanpoulter](htt
 
 ## How to get it?
 
-Open up VS Code, go search for the extension "Jest".
+Open up VS Code, go search for the extension "Jest".  
+As an alternative, install with 1-click through [Visual Studio Marketplace - Orta.vscode-jest](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest).
 
 ## How to get it set up?
 


### PR DESCRIPTION
Add alternative install method to README.md, which use Visual Studio Marketplace.  
Simple 'search' in VSCode's extention tab force people judge which extetion is this extention.  
Visual Studio Marketplace enable installation of specified extention, so remove this pain.  