### PR TITLE
Fix StatusBarItem in case no active editor is open on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bug-fixes within the same version aren't needed
 * quoting default "pathToJest" to preserve special characters, if any. - @connectdotz
 * Fix for when `branch.end.column` is `null`. [@garyking](https://github.com/garyking)
 * Fix several jest coverage issues and improve usability. - @connectdotz
+* Fix StatusBarItem when starting Jest without active text editor but only one workspace folder - @stephtr
 
 -->
 

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -127,14 +127,14 @@ export class StatusBar {
   }
 
   private get activeFolder() {
+    if (!this._activeFolder && vscode.workspace.workspaceFolders.length === 1) {
+      this._activeFolder = vscode.workspace.workspaceFolders[0].name
+    }
     if (!this._activeFolder && vscode.window.activeTextEditor) {
       const folder = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)
       if (folder) {
         this._activeFolder = folder.name
       }
-    }
-    if (!this._activeFolder && vscode.workspace.workspaceFolders.length === 1) {
-      this._activeFolder = vscode.workspace.workspaceFolders[0].name
     }
     return this._activeFolder
   }

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -127,13 +127,16 @@ export class StatusBar {
   }
 
   private get activeFolder() {
-    if (!this._activeFolder && vscode.workspace.workspaceFolders.length === 1) {
-      this._activeFolder = vscode.workspace.workspaceFolders[0].name
-    }
-    if (!this._activeFolder && vscode.window.activeTextEditor) {
-      const folder = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)
-      if (folder) {
-        this._activeFolder = folder.name
+    if (!this._activeFolder) {
+      if (vscode.workspace.workspaceFolders.length === 1) {
+        // there's only one workspaceFolder, so let's take it
+        this._activeFolder = vscode.workspace.workspaceFolders[0].name
+      } else if (vscode.window.activeTextEditor) {
+        // otherwise select correct workspaceFolder based on the currently open textEditor
+        const folder = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)
+        if (folder) {
+          this._activeFolder = folder.name
+        }
       }
     }
     return this._activeFolder

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -133,6 +133,9 @@ export class StatusBar {
         this._activeFolder = folder.name
       }
     }
+    if (!this._activeFolder && vscode.workspace.workspaceFolders.length === 1) {
+      this._activeFolder = vscode.workspace.workspaceFolders[0].name
+    }
     return this._activeFolder
   }
 

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -4,11 +4,12 @@ import { Runner, ProjectWorkspace } from 'jest-editor-support'
 import { JestProcess } from '../../src/JestProcessManagement/JestProcess'
 import { EventEmitter } from 'events'
 import { WatchMode } from '../../src/Jest'
+import { normalize } from 'path'
 jest.unmock('path')
 jest.mock('vscode', () => ({
   extensions: {
     getExtension: () => {
-      return { extensionPath: '/my/vscode/extensions' }
+      return { extensionPath: normalize('/my/vscode/extensions') }
     },
   },
 }))
@@ -35,7 +36,7 @@ describe('JestProcess', () => {
       new JestProcess(projectWorkspaceMock)
       expect(runnerMock).toHaveBeenCalledWith(undefined, {
         noColor: true,
-        reporters: ['default', '/my/vscode/extensions/out/reporter.js'],
+        reporters: ['default', normalize('/my/vscode/extensions/out/reporter.js')],
       })
     })
   })


### PR DESCRIPTION
When having no active text editor opened while Jest starts, the StatusBarItem shows `Jest status of 'undefined'` as a tooltip and can't be clicked to open the summary.
Since there's no ambiguity when there is only a single WorkspaceFolder (and the summary view only takes over for more than one WorkspaceFolder), it is optimal to take that WorkspaceFolder as `activeFolder`.