### PR TITLE
quote reporter path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* fix reporter failed to load due to whitespace in path - connectdotz
 
 -->
 

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -75,7 +75,7 @@ export class JestProcess {
 
     const options = {
       noColor: true,
-      reporters: ['default', reporterPath],
+      reporters: ['default', `'${reporterPath}'`],
     }
     this.runner = new Runner(this.projectWorkspace, options)
 

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -75,7 +75,7 @@ export class JestProcess {
 
     const options = {
       noColor: true,
-      reporters: ['default', `'${reporterPath}'`],
+      reporters: ['default', `"${reporterPath}"`],
     }
     this.runner = new Runner(this.projectWorkspace, options)
 

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -36,7 +36,7 @@ describe('JestProcess', () => {
       new JestProcess(projectWorkspaceMock)
       expect(runnerMock).toHaveBeenCalledWith(undefined, {
         noColor: true,
-        reporters: ['default', `'${normalize('/my/vscode/extensions/out/reporter.js')}'`],
+        reporters: ['default', `"${normalize('/my/vscode/extensions/out/reporter.js')}"`],
       })
     })
   })

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -36,7 +36,7 @@ describe('JestProcess', () => {
       new JestProcess(projectWorkspaceMock)
       expect(runnerMock).toHaveBeenCalledWith(undefined, {
         noColor: true,
-        reporters: ['default', normalize('/my/vscode/extensions/out/reporter.js')],
+        reporters: ['default', `'${normalize('/my/vscode/extensions/out/reporter.js')}'`],
       })
     })
   })


### PR DESCRIPTION
reporter path needs to be in quotes to make sure whitespace in user path won't truncate the command. 

fix #545