### PR TITLE
orphan process: fix multi-staged process leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-
+* prevent auto starting watch-mode jest process when the parent process is stopped, which can lead to orphan process during deactivation among others. - @connectdotz
+  
 -->
 
 ### 3.1.1

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "istanbul-lib-coverage": "^1.1.1",
     "istanbul-lib-source-maps": "^1.1.0",
     "jest": "^24.7.0",
-    "jest-editor-support": "^27.1.1",
+    "jest-editor-support": "^27.2.0",
     "jest-snapshot": "^24.7.0",
     "lint-staged": "^4.2.3",
     "prettier": "^1.17.0",

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -137,7 +137,9 @@ export class JestExt {
         } else {
           this.updateStatusBar('stopped', undefined, false)
           if (!jestProcess.stopRequested()) {
-            let msg = `Starting Jest in Watch mode failed too many times and has been stopped.`
+            let msg = `(${
+              this.workspaceFolder.name
+            }) Starting Jest in Watch mode failed too many times and has been stopped.`
             if (this.instanceSettings.multirootEnv) {
               msg += `\nConsider adding this workspace folder to disabledWorkspaceFolders`
             }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -120,6 +120,8 @@ export class JestExt {
 
   public startProcess() {
     if (this.jestProcessManager.numberOfProcesses > 0) {
+      // tslint:disable-next-line no-console
+      console.warn(`process is already running, will not start a new process.`)
       return
     }
 
@@ -137,11 +139,10 @@ export class JestExt {
         } else {
           this.updateStatusBar('stopped', undefined, false)
           if (!jestProcess.stopRequested()) {
-            let msg = `(${
-              this.workspaceFolder.name
-            }) Starting Jest in Watch mode failed too many times and has been stopped.`
+            let msg = 'Starting Jest in Watch mode failed too many times and has been stopped.'
             if (this.instanceSettings.multirootEnv) {
-              msg += `\nConsider adding this workspace folder to disabledWorkspaceFolders`
+              const folder = this.workspaceFolder.name
+              msg = `(${folder}) ${msg}\nIf this is expected, consider adding '${folder}' to disabledWorkspaceFolders`
             }
             this.channel.appendLine(`${msg}\n see troubleshooting: ${messaging.TROUBLESHOOTING_URL}`)
             this.channel.show(true)

--- a/src/JestProcessManagement/JestProcessManager.ts
+++ b/src/JestProcessManagement/JestProcessManager.ts
@@ -31,15 +31,17 @@ export class JestProcessManager {
   } = {}): JestProcess {
     if (watchMode !== WatchMode.None && this.runAllTestsFirstInWatchMode) {
       return this.runAllTestsFirst(exitedJestProcess => {
-        if (!exitedJestProcess.stopRequested()) {
-          this.removeJestProcessReference(exitedJestProcess)
-          const jestProcessInWatchMode = this.run({
-            watchMode: WatchMode.Watch,
-            keepAlive,
-            exitCallback,
-          })
-          exitCallback(exitedJestProcess, jestProcessInWatchMode)
+        // cancel the rest execution if stop() has been requested.
+        if (exitedJestProcess.stopRequested()) {
+          return
         }
+        this.removeJestProcessReference(exitedJestProcess)
+        const jestProcessInWatchMode = this.run({
+          watchMode: WatchMode.Watch,
+          keepAlive,
+          exitCallback,
+        })
+        exitCallback(exitedJestProcess, jestProcessInWatchMode)
       })
     } else {
       return this.run({

--- a/src/JestProcessManagement/JestProcessManager.ts
+++ b/src/JestProcessManagement/JestProcessManager.ts
@@ -4,9 +4,13 @@ import { WatchMode } from '../Jest'
 
 export type ExitCallback = (exitedJestProcess: JestProcess, jestProcessInWatchMode?: JestProcess) => void
 
+interface ProcessInfo {
+  process: JestProcess
+  cancel: () => Promise<void>
+}
 export class JestProcessManager {
   private projectWorkspace: ProjectWorkspace
-  private jestProcesses: JestProcess[] = []
+  private jestProcesses: ProcessInfo[] = []
   private runAllTestsFirstInWatchMode: boolean
 
   constructor({
@@ -29,21 +33,37 @@ export class JestProcessManager {
     watchMode?: WatchMode
     keepAlive?: boolean
   } = {}): JestProcess {
-    if (watchMode !== WatchMode.None && this.runAllTestsFirstInWatchMode) {
-      return this.runAllTestsFirst(exitedJestProcess => {
+    const keepAliveCallback: ExitCallback = (exitedJestProcess: JestProcess) => {
+      exitCallback(exitedJestProcess)
+      if (!exitedJestProcess.keepAlive) {
         this.removeJestProcessReference(exitedJestProcess)
-        const jestProcessInWatchMode = this.run({
-          watchMode: WatchMode.Watch,
-          keepAlive,
-          exitCallback,
-        })
-        exitCallback(exitedJestProcess, jestProcessInWatchMode)
+      }
+    }
+    if (watchMode !== WatchMode.None && this.runAllTestsFirstInWatchMode) {
+      let isCancelled = false
+      return this.runJest({
+        watchMode: WatchMode.None,
+        keepAlive: false,
+        onCancel: () => {
+          isCancelled = true
+        },
+        exitCallback: exitedJestProcess => {
+          this.removeJestProcessReference(exitedJestProcess)
+          if (!isCancelled) {
+            const jestProcessInWatchMode = this.runJest({
+              watchMode: WatchMode.Watch,
+              keepAlive,
+              exitCallback: keepAliveCallback,
+            })
+            exitCallback(exitedJestProcess, jestProcessInWatchMode)
+          }
+        },
       })
     } else {
-      return this.run({
+      return this.runJest({
         watchMode,
         keepAlive,
-        exitCallback,
+        exitCallback: keepAliveCallback,
       })
     }
   }
@@ -51,21 +71,26 @@ export class JestProcessManager {
   public stopAll() {
     const processesToRemove = [...this.jestProcesses]
     this.jestProcesses = []
-    return Promise.all(processesToRemove.map(jestProcess => jestProcess.stop()))
+    return Promise.all(processesToRemove.map(p => p.cancel()))
   }
 
   public stopJestProcess(jestProcess: JestProcess) {
-    this.removeJestProcessReference(jestProcess)
+    const pInfo = this.removeJestProcessReference(jestProcess)
+    if (pInfo) {
+      return pInfo.cancel()
+    }
+    // is this a valid situation?
     return jestProcess.stop()
   }
 
   public get numberOfProcesses() {
     return this.jestProcesses.length
   }
-  private removeJestProcessReference(jestProcess: JestProcess) {
-    const index = this.jestProcesses.indexOf(jestProcess)
+
+  private removeJestProcessReference(jestProcess: JestProcess): ProcessInfo | undefined {
+    const index = this.jestProcesses.findIndex(jp => jp.process === jestProcess)
     if (index !== -1) {
-      this.jestProcesses.splice(index, 1)
+      return this.jestProcesses.splice(index, 1)[0]
     }
   }
 
@@ -73,10 +98,12 @@ export class JestProcessManager {
     watchMode,
     keepAlive,
     exitCallback,
+    onCancel,
   }: {
     watchMode: WatchMode
     keepAlive: boolean
     exitCallback: ExitCallback
+    onCancel?: () => void
   }) {
     const jestProcess = new JestProcess({
       projectWorkspace: this.projectWorkspace,
@@ -84,38 +111,18 @@ export class JestProcessManager {
       keepAlive,
     })
 
-    this.jestProcesses.unshift(jestProcess)
+    const pInfo = {
+      process: jestProcess,
+      cancel: () => {
+        if (onCancel) {
+          onCancel()
+        }
+        return jestProcess.stop()
+      },
+    }
+    this.jestProcesses.unshift(pInfo)
 
     jestProcess.onExit(exitCallback)
     return jestProcess
-  }
-
-  private run({
-    watchMode,
-    keepAlive,
-    exitCallback,
-  }: {
-    watchMode: WatchMode
-    keepAlive: boolean
-    exitCallback: ExitCallback
-  }) {
-    return this.runJest({
-      watchMode,
-      keepAlive,
-      exitCallback: (exitedJestProcess: JestProcess) => {
-        exitCallback(exitedJestProcess)
-        if (!exitedJestProcess.keepAlive) {
-          this.removeJestProcessReference(exitedJestProcess)
-        }
-      },
-    })
-  }
-
-  private runAllTestsFirst(onExit: ExitCallback) {
-    return this.runJest({
-      watchMode: WatchMode.None,
-      keepAlive: false,
-      exitCallback: onExit,
-    })
   }
 }

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -29,7 +29,7 @@ import * as messaging from '../src/messaging'
 
 describe('JestExt', () => {
   const getConfiguration = workspace.getConfiguration as jest.Mock<any>
-  const workspaceFolder = {} as any
+  const workspaceFolder = { name: 'test-folder' } as any
   let projectWorkspace: ProjectWorkspace
   const channelStub = { appendLine: jest.fn(), clear: jest.fn(), show: jest.fn() } as any
   const extensionSettings = { debugCodeLens: {} } as any
@@ -679,7 +679,7 @@ describe('JestExt', () => {
       mockProcess.onJestEditorSupportEvent.mockReturnValue(mockProcess)
       return mockProcess
     }
-    const createJestExt = (settings: any) => {
+    const createJestExt = (settings: any, instanceSettings = { multirootEnv: false }) => {
       ;(JestProcessManager as jest.Mock).mockClear()
       const mockProcess: any = mockJestProcess()
 
@@ -692,7 +692,7 @@ describe('JestExt', () => {
         debugCodeLensProvider,
         debugConfigurationProvider,
         null,
-        { multirootEnv: false }
+        instanceSettings
       )
       const mockProcessManager: any = (JestProcessManager as jest.Mock).mock.instances[0]
       mockProcessManager.startJestProcess.mockReturnValue(mockProcess)
@@ -722,8 +722,9 @@ describe('JestExt', () => {
       sut.startProcess()
       expect(mockProcessManager.startJestProcess).toHaveBeenCalled()
     })
+
     describe('exitCallback', () => {
-      const [sut, mockProcessManager] = createJestExt(extensionSettings)
+      const [sut, mockProcessManager] = createJestExt(extensionSettings, { multirootEnv: true })
       sut.startProcess()
       const { exitCallback } = mockProcessManager.startJestProcess.mock.calls[0][0]
 
@@ -742,6 +743,8 @@ describe('JestExt', () => {
         exitCallback(p1)
         expect(p1.onJestEditorSupportEvent).not.toHaveBeenCalled()
         expect(messaging.systemErrorMessage).toHaveBeenCalled()
+        const msg: string = (messaging.systemErrorMessage as jest.Mock).mock.calls[0][0]
+        expect(msg.includes(workspaceFolder.name)).toBeTruthy()
       })
     })
   })

--- a/tests/JestProcessManagement/JestProcessManager.test.ts
+++ b/tests/JestProcessManagement/JestProcessManager.test.ts
@@ -43,7 +43,7 @@ describe('JestProcessManager', () => {
     it('creates JestProcess', () => {
       jestProcessManager.startJestProcess()
 
-      expect(jestProcessMock.mock.instances.length).toBe(1)
+      expect(jestProcessMock).toHaveBeenCalledTimes(1)
     })
 
     it('returns an instance of JestProcess', () => {
@@ -259,7 +259,7 @@ describe('JestProcessManager', () => {
 
       expect(stopAll).toBeInstanceOf(Promise)
       return stopAll.then(() => {
-        expect(jestProcessMock.mock.instances.length).toBe(2)
+        expect(jestProcessMock).toHaveBeenCalledTimes(2)
         expect(mockImplementation.stop).toHaveBeenCalledTimes(2)
         expect(jestProcessManager.numberOfProcesses).toBe(0)
       })
@@ -283,15 +283,15 @@ describe('JestProcessManager', () => {
       })
       it('normally the watch-mode process will auto-start when first process exit', () => {
         const p = jestProcessManager.startJestProcess(startOptions)
-        expect(jestProcessMock.mock.instances.length).toBe(1)
+        expect(jestProcessMock).toHaveBeenCalledTimes(1)
 
         eventEmitter.emit('debuggerProcessExit', p)
 
-        expect(jestProcessMock.mock.instances.length).toBe(2)
+        expect(jestProcessMock).toHaveBeenCalledTimes(2)
       })
       it('stopAll will prevent auto start the watch mode process', async () => {
         const p = jestProcessManager.startJestProcess(startOptions)
-        expect(jestProcessMock.mock.instances.length).toBe(1)
+        expect(jestProcessMock).toHaveBeenCalledTimes(1)
         expect(jestProcessManager.numberOfProcesses).toBe(1)
 
         await jestProcessManager.stopAll()
@@ -299,11 +299,11 @@ describe('JestProcessManager', () => {
 
         eventEmitter.emit('debuggerProcessExit', p)
         expect(jestProcessManager.numberOfProcesses).toBe(0)
-        expect(jestProcessMock.mock.instances.length).toBe(1)
+        expect(jestProcessMock).toHaveBeenCalledTimes(1)
       })
       it('stopJestProcess will prevent auto start the watch mode process', async () => {
         const p = jestProcessManager.startJestProcess(startOptions)
-        expect(jestProcessMock.mock.instances.length).toBe(1)
+        expect(jestProcessMock).toHaveBeenCalledTimes(1)
         expect(jestProcessManager.numberOfProcesses).toBe(1)
 
         await jestProcessManager.stopJestProcess(p)
@@ -311,7 +311,7 @@ describe('JestProcessManager', () => {
 
         eventEmitter.emit('debuggerProcessExit', p)
         expect(jestProcessManager.numberOfProcesses).toBe(0)
-        expect(jestProcessMock.mock.instances.length).toBe(1)
+        expect(jestProcessMock).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -327,7 +327,7 @@ describe('JestProcessManager', () => {
 
       expect(stopAll).toBeInstanceOf(Promise)
       return stopAll.then(() => {
-        expect(jestProcessMock.mock.instances.length).toBe(0)
+        expect(jestProcessMock).toHaveBeenCalledTimes(0)
         expect(mockImplementation.stop).not.toHaveBeenCalled()
         expect(jestProcessManager.numberOfProcesses).toBe(0)
       })
@@ -499,7 +499,7 @@ describe('JestProcessManager', () => {
 
       eventEmitter.emit('debuggerProcessExit', jestProcess)
 
-      expect(jestProcessMock.mock.instances.length).toBe(1)
+      expect(jestProcessMock).toHaveBeenCalledTimes(1)
 
       expect(jestProcessMock.mock.calls[0]).toEqual([
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,10 +2948,10 @@ jest-each@^24.7.1:
     jest-util "^24.7.1"
     pretty-format "^24.7.0"
 
-jest-editor-support@^27.1.1:
-  version "27.1.1"
-  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-27.1.1.tgz#eb0d09002d3e03bfcd9c13aa5b979cdfc12bd625"
-  integrity sha512-G9KtLpmuIwHPGKIuOcSuWmXk7Q6Sd/w6XcEsAfdp5+jpzEh/puXX6h++2Lk/N9FhGQ1hteng3jzeGXokJPnKLA==
+jest-editor-support@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-27.2.0.tgz#4f4308180ce9b77529a77503882c32cbe0381bca"
+  integrity sha512-sJ0aAcKq81HFACyCJUfyuJ+9SFMU71UH9o3XHbbX95jCdoZ21SWyTHkGdn8afi7xRbccKPguCLqGSaMph6SoYA==
   dependencies:
     "@babel/traverse" "^7.6.2"
     "@jest/types" "^24.8.0"


### PR DESCRIPTION
fixes #550 

This PR address the first scenario mentioned [here](https://github.com/jest-community/vscode-jest/issues/550#issuecomment-615930298):

> if I close the workspace before jest can complete the run, I see all jest child process became orphan processes ...

## Summary
Turns out if the first run-all-test process is stopped, it will not prevent the subsequent "watch" process from starting. This means if we close the workspace or stop the jest-process before the "watch" run starts, these watch processes will be leaked...

The fix here is to add an `isCancelled` check before starting the "watch" process and wrap the stop function to set this flag accordingly.

## TODO
To fully address #550, we also need jest-community/jest-editor-support#39. Once `jest-editor-support` released the new version, I will update the package.json here accordingly.