### PR TITLE
Use --watchAll when using submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-  
+* Improve the detection of cases in which Jest needs to be restarted with `--watchAll` - [@lordofthelake](https://github.com/lordofthelake)  
 -->
 
 ### 3.2.0

--- a/src/Jest/index.ts
+++ b/src/Jest/index.ts
@@ -5,7 +5,7 @@ export enum WatchMode {
 }
 
 const IS_OUTSIDE_REPOSITORY_REGEXP = /Test suite failed to run[\s\S]*fatal:[\s\S]*is outside repository/im;
-const WATCH_IS_NOT_SUPPORTED_REGEXP = new RegExp('^s*--watch is not supported without git/hg, please use --watchAlls*', 'im');
+const WATCH_IS_NOT_SUPPORTED_REGEXP = /^s*--watch is not supported without git\/hg, please use --watchAlls*/im;
 
 export const isWatchNotSupported = (str = '') =>
   IS_OUTSIDE_REPOSITORY_REGEXP.test(str) || WATCH_IS_NOT_SUPPORTED_REGEXP.test(str)

--- a/src/Jest/index.ts
+++ b/src/Jest/index.ts
@@ -4,5 +4,8 @@ export enum WatchMode {
   WatchAll = 'watchAll',
 }
 
+const IS_OUTSIDE_REPOSITORY_REGEXP = /Test suite failed to run[\s\S]*fatal:[\s\S]*is outside repository/im;
+const WATCH_IS_NOT_SUPPORTED_REGEXP = new RegExp('^s*--watch is not supported without git/hg, please use --watchAlls*', 'im');
+
 export const isWatchNotSupported = (str = '') =>
-  new RegExp('^s*--watch is not supported without git/hg, please use --watchAlls*', 'im').test(str)
+  IS_OUTSIDE_REPOSITORY_REGEXP.test(str) || WATCH_IS_NOT_SUPPORTED_REGEXP.test(str)

--- a/tests/Jest/index.test.ts
+++ b/tests/Jest/index.test.ts
@@ -6,6 +6,16 @@ describe('isWatchNotSupported', () => {
     const str = '\n--watch is not supported without git/hg, please use --watchAll \n'
     expect(isWatchNotSupported(str)).toBe(true)
   })
+  
+  it('returns true when matching an "out of the repository" message', () => {
+    const str = `
+      Determining test suites to run...
+
+      ● Test suite failed to run
+
+        fatal: ../packages/a-dependency-outside-the-submodule: '../packages/a-dependency-outside-the-submodule' is outside repository`
+    expect(isWatchNotSupported(str)).toBe(true)
+  })
 
   it('returns false otherwise', () => {
     expect(isWatchNotSupported()).toBe(false)


### PR DESCRIPTION
Updates the RegExp used to detect when jest should be restarted using `--watchAll`.
Closes #558.