### PR TITLE
eslint: add reportUnusedDisableDirectives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,4 +27,5 @@ module.exports = {
       },
     },
   ],
+  reportUnusedDisableDirectives: true,
 };


### PR DESCRIPTION
I would suggest enabling `reportUnusedDisableDirectives` in eslint, which warns about `eslint-disable` comments which aren't in use anymore.