### PR TITLE
fix: Supporting double quotes in tests names

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -11,7 +11,8 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
    */
   public prepareTestRun(fileNameToRun: string, testToRun: string) {
     this.fileNameToRun = fileNameToRun;
-    this.testToRun = testToRun;
+    const escapedTestToRun = testToRun.replace(/"/g, '\\"');
+    this.testToRun = escapedTestToRun;
   }
 
   resolveDebugConfiguration(

--- a/tests/DebugConfigurationProvider.test.ts
+++ b/tests/DebugConfigurationProvider.test.ts
@@ -52,4 +52,21 @@ describe('DebugConfigurationProvider', () => {
     expect(configuration.env && configuration.env.CI).toBeTruthy();
     expect(configuration.args).toEqual(expected);
   });
+
+  it('should handle "test" names with double quotes', () => {
+    const fileName = 'fileName';
+    const testNamePattern = 'some "double quotes" test name';
+    const escapedFileNamePattern = 'some \\"double quotes\\" test name';
+    const expected = [fileName, '--testNamePattern', escapedFileNamePattern];
+    let configuration: any = { name: 'vscode-jest-tests' };
+
+    const sut = new DebugConfigurationProvider();
+    sut.prepareTestRun(fileName, testNamePattern);
+
+    configuration = sut.resolveDebugConfiguration(undefined, configuration);
+
+    expect(configuration).toBeDefined();
+    expect(configuration.env && configuration.env.CI).toBeTruthy();
+    expect(configuration.args).toEqual(expected);
+  });
 });


### PR DESCRIPTION
Seems like tests with double quotes are being skipped because it's not passed down to the terminal.
It was fixed back in 2018 but probably reintroduced after some refactoring I suppose
https://github.com/jest-community/vscode-jest/pull/249