### PR TITLE
Provide public API to subscribe to test results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 
+* add public api to expose interface for other vscode extensions to subscribe to test results updates.
 
 -->
 

--- a/__mocks__/supports-color.ts
+++ b/__mocks__/supports-color.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  supportsColor: () => false,
+};

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -17,6 +17,7 @@ const window = {
   showWorkspaceFolderPick: jest.fn(),
   onDidChangeActiveTextEditor: jest.fn(),
   showInformationMessage: jest.fn(),
+  visibleTextEditors: [],
 }
 
 const workspace = {

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -77,7 +77,8 @@ export class JestExt {
     debugConfigurationProvider: DebugConfigurationProvider,
     failDiagnostics: vscode.DiagnosticCollection,
     instanceSettings: InstanceSettings,
-    coverageCodeLensProvider: CoverageCodeLensProvider
+    coverageCodeLensProvider: CoverageCodeLensProvider,
+    private onTestResultsChanged: (results: JestTotalResults) => void
   ) {
     this.workspaceFolder = workspaceFolder;
     this.jestWorkspace = jestWorkspace;
@@ -515,6 +516,10 @@ export class JestExt {
   private updateWithData(data: JestTotalResults): void {
     const noAnsiData = resultsWithoutAnsiEscapeSequence(data);
     const normalizedData = resultsWithLowerCaseWindowsDriveLetters(noAnsiData);
+
+    // notify that there are new test results.
+    this.onTestResultsChanged(normalizedData);
+
     this._updateCoverageMap(normalizedData.coverageMap);
 
     const statusList = this.testResultProvider.updateTestResults(normalizedData);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,9 @@ import { registerSnapshotCodeLens, registerSnapshotPreview } from './SnapshotCod
 
 let extensionManager: ExtensionManager;
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(
+  context: vscode.ExtensionContext
+): ReturnType<typeof ExtensionManager.prototype.getPublicApi> {
   extensionManager = new ExtensionManager(context);
 
   const languages = [
@@ -82,6 +84,8 @@ export function activate(context: vscode.ExtensionContext): void {
       extensionManager
     )
   );
+
+  return extensionManager.getPublicApi();
 }
 
 export function deactivate(): void {

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -79,7 +79,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
 
       sut.canUpdateActiveEditor = jest.fn().mockReturnValueOnce(true);
@@ -145,7 +146,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
       const editor: any = {
         document: { fileName: 'file.js' },
@@ -196,7 +198,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
       ((sut.debugConfigurationProvider
         .provideDebugConfigurations as unknown) as jest.Mock<{}>).mockReturnValue([
@@ -230,7 +233,8 @@ describe('JestExt', () => {
       debugConfigurationProvider,
       null,
       null,
-      null
+      null,
+      () => {}
     );
     const document = {} as any;
     sut.removeCachedTestResults = jest.fn();
@@ -259,7 +263,8 @@ describe('JestExt', () => {
       debugConfigurationProvider,
       null,
       null,
-      null
+      null,
+      () => {}
     );
     sut.testResultProvider.removeCachedResults = jest.fn();
 
@@ -295,7 +300,8 @@ describe('JestExt', () => {
       debugConfigurationProvider,
       null,
       null,
-      null
+      null,
+      () => {}
     );
 
     beforeEach(() => {
@@ -331,7 +337,8 @@ describe('JestExt', () => {
       debugConfigurationProvider,
       null,
       null,
-      null
+      null,
+      () => {}
     );
     sut.triggerUpdateActiveEditor = jest.fn();
 
@@ -369,7 +376,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
     });
 
@@ -447,7 +455,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
       sut.triggerUpdateSettings = jest.fn();
       sut.toggleCoverageOverlay();
@@ -467,7 +476,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
       expect(projectWorkspace.collectCoverage).toBe(true);
 
@@ -496,7 +506,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
       sut.triggerUpdateActiveEditor(editor);
 
@@ -513,7 +524,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
       sut.updateDecorators = jest.fn();
       const mockEditor: any = {
@@ -554,7 +566,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
     });
     it('will skip if there is no document in editor', () => {
@@ -613,7 +626,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
 
       mockEditor.setDecorations = jest.fn();
@@ -685,7 +699,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
 
       mockEditor.setDecorations = jest.fn();
@@ -725,7 +740,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         instanceSettings,
-        null
+        null,
+        () => {}
       );
       const mockProcessManager: any = (JestProcessManager as jest.Mock).mock.instances[0];
       mockProcessManager.startJestProcess.mockReturnValue(mockProcess);
@@ -809,7 +825,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        null
+        null,
+        () => {}
       );
     });
 
@@ -851,7 +868,8 @@ describe('JestExt', () => {
         debugConfigurationProvider,
         null,
         null,
-        coverageCodeLensProvider
+        coverageCodeLensProvider,
+        () => {}
       );
       await sut._updateCoverageMap({});
       expect(coverageCodeLensProvider.coverageChanged).toBeCalled();

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -28,11 +28,13 @@ const jestInstance = {
   restartProcess: jest.fn(),
 };
 
+const publicApi = {};
+
 const extensionManager = {
   register: jest.fn(),
   getByName: jest.fn().mockReturnValue(jestInstance),
   get: jest.fn().mockReturnValue(jestInstance),
-  getPublicApi: jest.fn(),
+  getPublicApi: jest.fn().mockReturnValue(publicApi),
   unregisterAll: jest.fn(),
   registerCommand: jest.fn().mockImplementation((...args) => args),
 };
@@ -114,6 +116,15 @@ describe('Extension', () => {
 
       expect(vscode.workspace.onDidChangeWorkspaceFolders).toBeCalled();
       expect(context.subscriptions.push.mock.calls[0]).toContain('onDidChangeWorkspaceFolders');
+    });
+
+    it('should return ExtensionManager.getPublicApi', () => {
+      extensionManager.getPublicApi.mockClear();
+
+      const api = activate(context);
+
+      expect(extensionManager.getPublicApi).toHaveBeenCalledTimes(1);
+      expect(api).toBe(publicApi);
     });
 
     describe('should register a command', () => {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -32,6 +32,7 @@ const extensionManager = {
   register: jest.fn(),
   getByName: jest.fn().mockReturnValue(jestInstance),
   get: jest.fn().mockReturnValue(jestInstance),
+  getPublicApi: jest.fn(),
   unregisterAll: jest.fn(),
   registerCommand: jest.fn().mockImplementation((...args) => args),
 };


### PR DESCRIPTION
This PR exposes a public API from this extension which other extensions may retrieve and utilize.  Currently it merely provides an object that has a subscribe method to receive updated test results.  This enables other extension authors to benefit from the test results without having to run the tests themselves.

