### PR TITLE
Add JSON schema support for Jest configuration files and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,16 @@
         "path": "./syntaxes/jest-snapshot.tmLanguage"
       }
     ],
+    "jsonValidation": [
+      {
+        "fileMatch": "jest.*json",
+        "url": "https://askirmas.github.io/jest.schema.json"
+      },
+      {
+        "fileMatch": "package.json",
+        "url": "./schemas/package.schema.json"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Jest configuration",

--- a/schemas/package.schema.json
+++ b/schemas/package.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Jest contributions to package.json",
+  "type": "object",
+  "properties": {
+    "jest": {
+      "$ref": "https://askirmas.github.io/jest.schema.json"
+    }
+  }
+}


### PR DESCRIPTION
Provides tooltips, autocomplete, and validation of Jest configuration files. 

`package.json`:

![image](https://user-images.githubusercontent.com/831617/102054383-8fb80780-3da6-11eb-9878-c6cff4e6d640.png)

`jest.*json`:

![image](https://user-images.githubusercontent.com/831617/102054668-f50bf880-3da6-11eb-8499-d3739003f38e.png)
