### PR TITLE
support the new jestCommandLine setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* add a new setting for "jest.jestCommandLine" that supersede "jest.pathToJest" and "jest.pathToConfig" - @connectdotz
 
 -->
 

--- a/package.json
+++ b/package.json
@@ -71,14 +71,19 @@
           "default": true,
           "scope": "resource"
         },
+        "jest.jestCommandLine": {
+          "description": "The command line to start jest tests. It should be the same command line users run jest tests from a terminal/shell, with ability to append extra arguments (by the extension at runtime)",
+          "type": "string",
+          "scope": "resource"
+        },
         "jest.pathToJest": {
-          "description": "The path to the Jest binary, or an npm command to run tests suffixed with `--` e.g. `node_modules/.bin/jest` or `npm test --`",
+          "description": "(deprecated) The path to the Jest binary, or an npm command to run tests suffixed with `--` e.g. `node_modules/.bin/jest` or `npm test --`",
           "type": "string",
           "default": null,
           "scope": "resource"
         },
         "jest.pathToConfig": {
-          "description": "The path to your Jest configuration file",
+          "description": "(deprecated) The path to your Jest configuration file",
           "type": "string",
           "default": "",
           "scope": "resource"

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -12,7 +12,7 @@ import {
   resultsWithLowerCaseWindowsDriveLetters,
   SortedTestResults,
 } from './TestResults';
-import { pathToJest, pathToConfig, cleanAnsi } from './helpers';
+import { cleanAnsi, getJestCommandSettings } from './helpers';
 import { CoverageMapProvider, CoverageCodeLensProvider } from './Coverage';
 import {
   updateDiagnostics,
@@ -204,8 +204,11 @@ export class JestExt {
     this.pluginSettings = updatedSettings;
 
     this.jestWorkspace.rootPath = updatedSettings.rootPath;
-    this.jestWorkspace.jestCommandLine = pathToJest(updatedSettings);
-    this.jestWorkspace.pathToConfig = pathToConfig(updatedSettings);
+
+    //TODO remove pathToConfig once we fully deprecated them
+    [this.jestWorkspace.jestCommandLine, this.jestWorkspace.pathToConfig] = getJestCommandSettings(
+      updatedSettings
+    );
 
     // debug
     this.jestWorkspace.debug = updatedSettings.debugMode;

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -5,6 +5,7 @@ export interface PluginResourceSettings {
   autoEnable?: boolean;
   enableInlineErrorMessages?: boolean;
   enableSnapshotUpdateMessages?: boolean;
+  jestCommandLine?: string;
   pathToConfig?: string;
   pathToJest?: string;
   restartJestOnSnapshotUpdate?: boolean;

--- a/src/extensionManager.ts
+++ b/src/extensionManager.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { ProjectWorkspace } from 'jest-editor-support';
-import { pathToJest, pathToConfig } from './helpers';
+import { getJestCommandSettings } from './helpers';
 import { JestExt } from './JestExt';
 import { DebugCodeLensProvider, TestState } from './DebugCodeLens';
 import { DebugConfigurationProvider } from './DebugConfigurationProvider';
@@ -30,6 +30,7 @@ export function getExtensionResourceSettings(uri: vscode.Uri): PluginResourceSet
     enableInlineErrorMessages: config.get<boolean>('enableInlineErrorMessages'),
     enableSnapshotUpdateMessages: config.get<boolean>('enableSnapshotUpdateMessages'),
     pathToConfig: config.get<string>('pathToConfig'),
+    jestCommandLine: config.get<string>('jestCommandLine'),
     pathToJest: config.get<string>('pathToJest'),
     restartJestOnSnapshotUpdate: config.get<boolean>('restartJestOnSnapshotUpdate'),
     rootPath: path.join(uri.fsPath, config.get<string>('rootPath')),
@@ -74,8 +75,8 @@ export class ExtensionManager {
       return;
     }
     const pluginSettings = getExtensionResourceSettings(workspaceFolder.uri);
-    const jestPath = pathToJest(pluginSettings);
-    const configPath = pathToConfig(pluginSettings);
+    const [jestCommandLine, pathToConfig] = getJestCommandSettings(pluginSettings);
+
     const currentJestVersion = 20;
     const debugMode = pluginSettings.debugMode;
     const instanceSettings = {
@@ -83,8 +84,8 @@ export class ExtensionManager {
     };
     const jestWorkspace = new ProjectWorkspace(
       pluginSettings.rootPath,
-      jestPath,
-      configPath,
+      jestCommandLine,
+      pathToConfig,
       currentJestVersion,
       workspaceFolder.name,
       null,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -161,4 +161,20 @@ export function prepareIconFile(
   return resultIconPath;
 }
 
+/**
+ * This method retrieve a jest command line, if available, otherwise fall back to the legacy
+ * settings for pathToJest and pathToConfig.
+ *
+ * @param settings
+ */
+//TODO remove pathToJest and pathToConfig once we fully deprecated them
+export function getJestCommandSettings(
+  settings: PluginResourceSettings
+): [string, string | undefined] {
+  if (settings.jestCommandLine?.length > 0) {
+    return [settings.jestCommandLine, undefined];
+  }
+  return [pathToJest(settings), pathToConfig(settings)];
+}
+
 export default prepareIconFile;

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -1,9 +1,12 @@
 jest.unmock('events');
 jest.unmock('../src/JestExt');
+
+const mockGetJestCommandSettings = jest.fn();
 jest.mock('../src/helpers', () => ({
   cleanAnsi: (str: string) => str,
   pathToJest: jest.fn(),
   pathToConfig: jest.fn(),
+  getJestCommandSettings: mockGetJestCommandSettings,
 }));
 
 jest.mock('../src/DebugCodeLens', () => ({
@@ -58,6 +61,7 @@ describe('JestExt', () => {
 
     projectWorkspace = new ProjectWorkspace(null, null, null, null);
     getConfiguration.mockReturnValue({});
+    mockGetJestCommandSettings.mockReturnValue([]);
   });
 
   describe('resetInlineErrorDecorators()', () => {

--- a/tests/extensionManager.test.ts
+++ b/tests/extensionManager.test.ts
@@ -20,6 +20,7 @@ import {
 import { TestState } from '../src/DebugCodeLens';
 import { readFileSync } from 'fs';
 import { PluginWindowSettings } from '../src/Settings';
+import { getJestCommandSettings } from '../src/helpers';
 
 vscode.workspace.getConfiguration = jest.fn().mockImplementation((section) => {
   const data = readFileSync('./package.json');
@@ -36,6 +37,8 @@ vscode.workspace.getConfiguration = jest.fn().mockImplementation((section) => {
     get: jest.fn().mockImplementation((key) => defaults[`${section}.${key}`]),
   };
 });
+
+(getJestCommandSettings as jest.Mocked<any>).mockReturnValue([]);
 
 describe('InstancesManager', () => {
   let extensionManager: ExtensionManager;
@@ -365,11 +368,13 @@ describe('InstancesManager', () => {
         enableSnapshotUpdateMessages: true,
         pathToConfig: '',
         pathToJest: null,
+        jestCommandLine: undefined,
         restartJestOnSnapshotUpdate: false,
         rootPath: 'workspaceFolder1',
         runAllTestsFirst: true,
         showCoverageOnLoad: false,
         debugMode: false,
+        coverageColors: undefined,
       });
     });
   });

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -29,6 +29,8 @@ import {
   nodeBinExtension,
   cleanAnsi,
   prepareIconFile,
+  getJestCommandSettings,
+  pathToConfig,
 } from '../src/helpers';
 
 // Manually (forcefully) set the executable's file extension to test its addition independendly of the operating system.
@@ -201,6 +203,27 @@ describe('ModuleHelpers', () => {
 
       prepareIconFile(context, 'red', '<svg fill="currentColor"></svg>', 'red');
       expect((mockWriteFileSync as jest.Mock).mock.calls[2][1]).toBe('<svg fill="red"></svg>');
+    });
+  });
+  describe('getJestCommandSettings', () => {
+    it('without jestCommandLine, returns pathToJest and pathToConfig', () => {
+      const settings: any = {
+        pathToJest: 'abc',
+        pathToConfig: 'whatever',
+        rootPath: '',
+      };
+      expect(getJestCommandSettings(settings)).toEqual([
+        pathToJest(settings),
+        pathToConfig(settings),
+      ]);
+    });
+    it('with jestCommandLine, ignore both pathToJest and pathToConfig', () => {
+      const settings: any = {
+        jestCommandLine: 'jest --coverage',
+        pathToJest: 'abc',
+        pathToConfig: 'whatever',
+      };
+      expect(getJestCommandSettings(settings)).toEqual([settings.jestCommandLine, undefined]);
     });
   });
 });


### PR DESCRIPTION
This PR mainly to kick start the jestCommandLine transition in `vscode-jest` per jest-community/jest-editor-support#44 and pave the way for setup wizard.

To summarize: 
- adding the new setting "jest.jestCommandLine" that should eventually replace "jest.pathToJest" and "jest.pathToConfig".
- marking "jest.pathToJest" and "jest.pathToConfig" to be deprecated 
- modify `JestExt` and `extensionManager` of consider `jestCommandLine` over the legacy settings so it is completely backward compatible.

Note:
- unlike `pathToJest`, there is no "guessing" logic or default value for `jestCommandLine`. 
- I did not change the README yet, plan to update it in the wizard PR later.
