### PR TITLE
Full parameterized tests support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* fully support parameterized tests in matching, diagnosis and debugging - @connectdotz
+* optimization: remove stop/start the internal jest tests process during debug - @connectdotz
 * add a new setting for "jest.jestCommandLine" that supersede "jest.pathToJest" and "jest.pathToConfig" - @connectdotz
 
 -->

--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
   "dependencies": {
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",
-    "jest-editor-support": "^28.0.0",
+    "jest-editor-support": "^28.1.0",
     "jest-snapshot": "^25.5.0",
     "vscode-codicons": "^0.0.4"
   },

--- a/src/DebugCodeLens/DebugCodeLens.ts
+++ b/src/DebugCodeLens/DebugCodeLens.ts
@@ -1,19 +1,30 @@
 import * as vscode from 'vscode';
+import { TestIdentifier } from '../TestResults';
 
+export type DebugTestIdentifier = string | TestIdentifier;
 export class DebugCodeLens extends vscode.CodeLens {
   readonly fileName: string;
-  readonly testName: string;
+  readonly testIds: DebugTestIdentifier[];
   readonly document: vscode.TextDocument;
 
+  /**
+   *
+   * @param document
+   * @param range
+   * @param fileName
+   * @param testIds test name/pattern.
+   *  Because a test block can have multiple test results, such as for paramertized tests (i.e. test.each/describe.each), there could be multiple debuggable candidates, thus it takes multiple test identifiers.
+   *  Noite: If a test id is a string array, it should represent the hierarchiical relationship of a test structure, such as [describe-id, test-id].
+   */
   constructor(
     document: vscode.TextDocument,
     range: vscode.Range,
     fileName: string,
-    testName: string
+    ...testIds: DebugTestIdentifier[]
   ) {
     super(range);
     this.document = document;
     this.fileName = fileName;
-    this.testName = testName;
+    this.testIds = testIds;
   }
 }

--- a/src/DebugCodeLens/DebugCodeLensProvider.ts
+++ b/src/DebugCodeLens/DebugCodeLensProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { extensionName } from '../appGlobals';
 import { basename } from 'path';
 import { DebugCodeLens } from './DebugCodeLens';
-import { TestReconciliationState } from '../TestResults';
+import { TestReconciliationStateType } from '../TestResults';
 import { TestState, TestStateByTestReconciliationState } from './TestState';
 import { GetJestExtByURI } from '../extensionManager';
 
@@ -59,7 +59,7 @@ export class DebugCodeLensProvider implements vscode.CodeLensProvider {
     return result;
   }
 
-  showCodeLensAboveTest(test: { status: TestReconciliationState }): boolean {
+  showCodeLensAboveTest(test: { status: TestReconciliationStateType }): boolean {
     const state = TestStateByTestReconciliationState[test.status];
     return this._showWhenTestStateIn.includes(state);
   }

--- a/src/DebugCodeLens/DebugCodeLensProvider.ts
+++ b/src/DebugCodeLens/DebugCodeLensProvider.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { extensionName } from '../appGlobals';
-import { escapeRegExp } from '../helpers';
 import { basename } from 'path';
 import { DebugCodeLens } from './DebugCodeLens';
 import { TestReconciliationState } from '../TestResults';
@@ -18,7 +17,7 @@ export class DebugCodeLensProvider implements vscode.CodeLensProvider {
     this.onDidChange = new vscode.EventEmitter();
   }
 
-  get showWhenTestStateIn() {
+  get showWhenTestStateIn(): TestState[] {
     return this._showWhenTestStateIn;
   }
 
@@ -31,7 +30,7 @@ export class DebugCodeLensProvider implements vscode.CodeLensProvider {
     return this.onDidChange.event;
   }
 
-  provideCodeLenses(document: vscode.TextDocument, _: vscode.CancellationToken): vscode.CodeLens[] {
+  provideCodeLenses(document: vscode.TextDocument, _: vscode.CancellationToken): DebugCodeLens[] {
     const result = [];
     const ext = this.getJestExt(document.uri);
     if (!ext || this._showWhenTestStateIn.length === 0 || document.isUntitled) {
@@ -43,20 +42,24 @@ export class DebugCodeLensProvider implements vscode.CodeLensProvider {
     const fileName = basename(document.fileName);
 
     for (const test of testResults) {
-      if (!this.showCodeLensAboveTest(test)) {
+      const results = test.multiResults ? [test, ...test.multiResults] : [test];
+      const allIds = results.filter((r) => this.showCodeLensAboveTest(r)).map((r) => r.identifier);
+
+      if (!allIds.length) {
         continue;
       }
 
       const start = new vscode.Position(test.start.line, test.start.column);
       const end = new vscode.Position(test.end.line, test.start.column + 5);
       const range = new vscode.Range(start, end);
-      result.push(new DebugCodeLens(document, range, fileName, test.name));
+
+      result.push(new DebugCodeLens(document, range, fileName, ...allIds));
     }
 
     return result;
   }
 
-  showCodeLensAboveTest(test: { status: TestReconciliationState }) {
+  showCodeLensAboveTest(test: { status: TestReconciliationState }): boolean {
     const state = TestStateByTestReconciliationState[test.status];
     return this._showWhenTestStateIn.includes(state);
   }
@@ -67,16 +70,16 @@ export class DebugCodeLensProvider implements vscode.CodeLensProvider {
   ): vscode.ProviderResult<vscode.CodeLens> {
     if (codeLens instanceof DebugCodeLens) {
       codeLens.command = {
-        arguments: [codeLens.document, codeLens.fileName, escapeRegExp(codeLens.testName)],
+        arguments: [codeLens.document, codeLens.fileName, ...codeLens.testIds],
         command: `${extensionName}.run-test`,
-        title: 'Debug',
+        title: codeLens.testIds.length > 1 ? `Debug(${codeLens.testIds.length})` : 'Debug',
       };
     }
 
     return codeLens;
   }
 
-  didChange() {
+  didChange(): void {
     this.onDidChange.fire();
   }
 }

--- a/src/DebugCodeLens/index.ts
+++ b/src/DebugCodeLens/index.ts
@@ -1,2 +1,3 @@
 export { DebugCodeLensProvider } from './DebugCodeLensProvider';
 export { TestState } from './TestState';
+export { DebugTestIdentifier } from './DebugCodeLens';

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -12,6 +12,7 @@ import {
   resultsWithLowerCaseWindowsDriveLetters,
   SortedTestResults,
   TestResultStatusInfo,
+  TestReconciliationStateType,
 } from './TestResults';
 import {
   cleanAnsi,
@@ -585,11 +586,11 @@ export class JestExt {
 
   private generateDotsForItBlocks(
     blocks: TestResult[],
-    state: TestReconciliationState
+    state: TestReconciliationStateType
   ): DecorationOptions[] {
     return blocks.map((it) => ({
       range: new vscode.Range(it.start.line, it.start.column, it.start.line, it.start.column + 1),
-      hoverMessage: TestResultStatusInfo.get(state).desc,
+      hoverMessage: TestResultStatusInfo[state].desc,
       identifier: it.name,
     }));
   }

--- a/src/TestResults/TestReconciliationState.ts
+++ b/src/TestResults/TestReconciliationState.ts
@@ -1,9 +1,11 @@
-export type TestReconciliationState = 'Unknown' | 'KnownSuccess' | 'KnownFail' | 'KnownSkip';
+export type TestReconciliationStateType = 'Unknown' | 'KnownSuccess' | 'KnownFail' | 'KnownSkip';
 
 // tslint:disable-next-line variable-name
-export const TestReconciliationState = {
-  Unknown: 'Unknown' as TestReconciliationState,
-  KnownSuccess: 'KnownSuccess' as TestReconciliationState,
-  KnownFail: 'KnownFail' as TestReconciliationState,
-  KnownSkip: 'KnownSkip' as TestReconciliationState,
+export const TestReconciliationState: {
+  [key in TestReconciliationStateType]: TestReconciliationStateType;
+} = {
+  Unknown: 'Unknown',
+  KnownSuccess: 'KnownSuccess',
+  KnownFail: 'KnownFail',
+  KnownSkip: 'KnownSkip',
 };

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -17,14 +17,14 @@ export interface LocationRange {
   end: Location;
 }
 
+export interface TestIdentifier {
+  title: string;
+  ancestorTitles: string[];
+}
 export interface TestResult extends LocationRange {
   name: string;
 
-  names: {
-    src: string;
-    assertionTitle?: string;
-    assertionFullName?: string;
-  };
+  identifier: TestIdentifier;
 
   status: TestReconciliationState;
   shortMessage?: string;
@@ -32,6 +32,9 @@ export interface TestResult extends LocationRange {
 
   /** Zero-based line number */
   lineNumberOfError?: number;
+
+  // multiple results for the given range, common for parameterized (.each) tests
+  multiResults?: TestResult[];
 }
 
 export const withLowerCaseWindowsDriveLetter = (filePath: string): string | undefined => {
@@ -131,3 +134,22 @@ export const resultsWithoutAnsiEscapeSequence = (data: JestTotalResults): JestTo
     })),
   };
 };
+
+// export type StatusInfo<T> = {[key in TestReconciliationState]: T};
+export interface StatusInfo {
+  precedence: number;
+  desc: string;
+}
+
+export const TestResultStatusInfo: Map<TestReconciliationState, StatusInfo> = new Map([
+  [TestReconciliationState.KnownFail, { precedence: 1, desc: 'Failed' }],
+  [
+    TestReconciliationState.Unknown,
+    {
+      precedence: 2,
+      desc: 'Test has not run yet, due to Jest only running tests related to changes.',
+    },
+  ],
+  [TestReconciliationState.KnownSkip, { precedence: 3, desc: 'Skipped' }],
+  [TestReconciliationState.KnownSuccess, { precedence: 4, desc: 'Passed' }],
+]);

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -1,4 +1,4 @@
-import { TestReconciliationState } from './TestReconciliationState';
+import { TestReconciliationStateType } from './TestReconciliationState';
 import { JestFileResults, JestTotalResults } from 'jest-editor-support';
 import { FileCoverage } from 'istanbul-lib-coverage';
 import * as path from 'path';
@@ -26,7 +26,7 @@ export interface TestResult extends LocationRange {
 
   identifier: TestIdentifier;
 
-  status: TestReconciliationState;
+  status: TestReconciliationStateType;
   shortMessage?: string;
   terseMessage?: string;
 
@@ -141,15 +141,12 @@ export interface StatusInfo {
   desc: string;
 }
 
-export const TestResultStatusInfo: Map<TestReconciliationState, StatusInfo> = new Map([
-  [TestReconciliationState.KnownFail, { precedence: 1, desc: 'Failed' }],
-  [
-    TestReconciliationState.Unknown,
-    {
-      precedence: 2,
-      desc: 'Test has not run yet, due to Jest only running tests related to changes.',
-    },
-  ],
-  [TestReconciliationState.KnownSkip, { precedence: 3, desc: 'Skipped' }],
-  [TestReconciliationState.KnownSuccess, { precedence: 4, desc: 'Passed' }],
-]);
+export const TestResultStatusInfo: { [key in TestReconciliationStateType]: StatusInfo } = {
+  KnownFail: { precedence: 1, desc: 'Failed' },
+  Unknown: {
+    precedence: 2,
+    desc: 'Test has not run yet, due to Jest only running tests related to changes.',
+  },
+  KnownSkip: { precedence: 3, desc: 'Skipped' },
+  KnownSuccess: { precedence: 4, desc: 'Passed' },
+};

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -23,9 +23,7 @@ const sortByStatus = (a: TestResult, b: TestResult): number => {
   if (a.status === b.status) {
     return 0;
   }
-  return (
-    TestResultStatusInfo.get(a.status).precedence - TestResultStatusInfo.get(b.status).precedence
-  );
+  return TestResultStatusInfo[a.status].precedence - TestResultStatusInfo[b.status].precedence;
 };
 export class TestResultProvider {
   verbose: boolean;

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -51,6 +51,7 @@ export class TestResultProvider {
     // build a range based map
     const byRange: Map<string, TestResult[]> = new Map();
     results.forEach((r) => {
+      // Q: is there a better/efficient way to index the range?
       const key = `${r.start.line}-${r.start.column}-${r.end.line}-${r.end.column}`;
       const list = byRange.get(key);
       if (!list) {

--- a/src/TestResults/index.ts
+++ b/src/TestResults/index.ts
@@ -1,3 +1,8 @@
 export * from './TestReconciliationState';
-export { TestResult, resultsWithLowerCaseWindowsDriveLetters } from './TestResult';
+export {
+  TestResult,
+  resultsWithLowerCaseWindowsDriveLetters,
+  TestResultStatusInfo,
+  TestIdentifier,
+} from './TestResult';
 export * from './TestResultProvider';

--- a/src/TestResults/match-by-context.ts
+++ b/src/TestResults/match-by-context.ts
@@ -162,7 +162,7 @@ const ContextMatch = (messaging: Messaging): ContextMatchAlgorithm => {
         return [toMatchResult(itBlock, assertion)];
       }
       default: {
-        // 1-to-many
+        // 1-to-many: parameterized tests
         return a.data.map((a) => toMatchResult(itBlock, a));
       }
     }

--- a/src/TestResults/match-by-context.ts
+++ b/src/TestResults/match-by-context.ts
@@ -74,10 +74,9 @@ export const toMatchResult = (
   // Note the shift from one-based to zero-based line number and columns
   return {
     name: assertion?.fullName ?? assertion?.title ?? test.name,
-    names: {
-      src: test.name,
-      assertionTitle: assertion?.title,
-      assertionFullName: assertion?.fullName,
+    identifier: {
+      title: assertion?.title,
+      ancestorTitles: assertion?.ancestorTitles,
     },
     start: adjustLocation(test.start),
     end: adjustLocation(test.end),
@@ -90,7 +89,7 @@ export const toMatchResult = (
 
 /** mark all data and child containers unmatched */
 const toUnmatchedResults = (tContainer: ContainerNode<ItBlock>, err: string): TestResult[] => {
-  const results = tContainer.childData.map((n) => toMatchResult(n.only(), err));
+  const results = tContainer.childData.map((n) => toMatchResult(n.single(), err));
   tContainer.childContainers.forEach((c) => results.push(...toUnmatchedResults(c, err)));
   return results;
 };
@@ -146,31 +145,25 @@ const ContextMatch = (messaging: Messaging): ContextMatchAlgorithm => {
   const handleTestBlockMatch = (
     t: DataNode<ItBlock>,
     matched: DataNode<TestAssertionStatus>[]
-  ): TestResult => {
+  ): TestResult[] => {
     if (matched.length !== 1) {
-      return toMatchResult(t.only(), `found ${matched.length} matched assertion(s)`);
+      return [toMatchResult(t.single(), `found ${matched.length} matched assertion(s)`)];
     }
     const a = matched[0];
-    const itBlock = t.only();
+    const itBlock = t.single();
     switch (a.data.length) {
       case 0:
         throw new TypeError(`invalid state: assertion data should not be empty if it is a match!`);
       case 1: {
-        const assertion = a.only();
+        const assertion = a.single();
         if (a.name !== t.name && !matchPos(itBlock, assertion)) {
           messaging('unusual-match', 'data', t, a, 'neither name nor line matched');
         }
-        return toMatchResult(itBlock, assertion);
+        return [toMatchResult(itBlock, assertion)];
       }
       default: {
         // 1-to-many
-        messaging('unusual-match', 'data', t, a, '1-to-many match, jest.each perhaps?');
-
-        // TODO: support multiple errorLine
-        // until we support multiple errors, choose the first error assertion, if any
-        const assertions =
-          a.data.find((assertion) => assertion.status === 'KnownFail') || a.first();
-        return toMatchResult(itBlock, assertions);
+        return a.data.map((a) => toMatchResult(itBlock, a));
       }
     }
   };
@@ -231,11 +224,15 @@ const ContextMatch = (messaging: Messaging): ContextMatchAlgorithm => {
   ): TestResult[] => {
     const matchResults: TestResult[] = [];
     matchChildren('data', tContainer, aContainer, (t, a) =>
-      matchResults.push(handleTestBlockMatch(t, a))
+      matchResults.push(...handleTestBlockMatch(t, a))
     );
     matchChildren('container', tContainer, aContainer, (t, a) =>
       matchResults.push(...handleDescribeBlockMatch(t, a))
     );
+
+    if (aContainer.group) {
+      aContainer.group.forEach((c) => matchResults.push(...matchContainers(tContainer, c)));
+    }
 
     return matchResults;
   };

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -4,12 +4,17 @@
  */
 import * as vscode from 'vscode';
 import { existsSync } from 'fs';
-// import { DiagnosticCollection, Uri, Diagnostic, Range, DiagnosticSeverity } from 'vscode'
 import { TestFileAssertionStatus } from 'jest-editor-support';
 import { TestReconciliationState, TestResult } from './TestResults';
+import { testIdString } from './helpers';
 
-function createDiagnosticWithRange(message: string, range: vscode.Range): vscode.Diagnostic {
-  const diag = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
+function createDiagnosticWithRange(
+  message: string,
+  range: vscode.Range,
+  testName?: string
+): vscode.Diagnostic {
+  const msg = testName ? `${testName}\n-----\n${message}` : message;
+  const diag = new vscode.Diagnostic(range, msg, vscode.DiagnosticSeverity.Error);
   diag.source = 'Jest';
   return diag;
 }
@@ -17,35 +22,42 @@ function createDiagnosticWithRange(message: string, range: vscode.Range): vscode
 function createDiagnostic(
   message: string,
   lineNumber: number,
+  name?: string,
   startCol = 0,
   endCol = Number.MAX_SAFE_INTEGER
 ): vscode.Diagnostic {
   const line = lineNumber > 0 ? lineNumber - 1 : 0;
-  return createDiagnosticWithRange(message, new vscode.Range(line, startCol, line, endCol));
+  return createDiagnosticWithRange(message, new vscode.Range(line, startCol, line, endCol), name);
 }
 
 // update diagnostics for the active editor
 // it will utilize the parsed test result to mark actual text position.
 export function updateCurrentDiagnostics(
-  testResult: TestResult[],
-  diagnostics: vscode.DiagnosticCollection,
+  testResults: TestResult[],
+  collection: vscode.DiagnosticCollection,
   editor: vscode.TextEditor
-) {
+): void {
   const uri = editor.document.uri;
 
-  if (!testResult.length) {
-    diagnostics.delete(uri);
+  if (!testResults.length) {
+    collection.delete(uri);
     return;
   }
+  const allDiagnostics = testResults.reduce((list, tr) => {
+    const allResults = tr.multiResults ? [tr, ...tr.multiResults] : [tr];
+    const diagnostics = allResults
+      .filter((r) => r.status === TestReconciliationState.KnownFail)
+      .map((r) => {
+        const line = r.lineNumberOfError || r.end.line;
+        const textLine = editor.document.lineAt(line);
+        const name = testIdString('display', r.identifier);
+        return createDiagnosticWithRange(r.shortMessage, textLine.range, name);
+      });
+    list.push(...diagnostics);
+    return list;
+  }, []);
 
-  diagnostics.set(
-    uri,
-    testResult.map((r) => {
-      const line = r.lineNumberOfError || r.end.line;
-      const textLine = editor.document.lineAt(line);
-      return createDiagnosticWithRange(r.shortMessage, textLine.range);
-    })
-  );
+  collection.set(uri, allDiagnostics);
 }
 
 // update all diagnosis with jest test results
@@ -56,20 +68,21 @@ export function updateCurrentDiagnostics(
 
 export function updateDiagnostics(
   testResults: TestFileAssertionStatus[],
-  diagnostics: vscode.DiagnosticCollection
-) {
-  function addTestFileError(result: TestFileAssertionStatus, uri: vscode.Uri) {
-    const diag = createDiagnostic(result.message || 'test file error', 0, 0, 0);
-    diagnostics.set(uri, [diag]);
+  collection: vscode.DiagnosticCollection
+): void {
+  function addTestFileError(result: TestFileAssertionStatus, uri: vscode.Uri): void {
+    const diag = createDiagnostic(result.message || 'test file error', 0, undefined, 0, 0);
+    collection.set(uri, [diag]);
   }
 
-  function addTestsError(result: TestFileAssertionStatus, uri: vscode.Uri) {
+  function addTestsError(result: TestFileAssertionStatus, uri: vscode.Uri): void {
     const asserts = result.assertions.filter((a) => a.status === TestReconciliationState.KnownFail);
-    diagnostics.set(
+    collection.set(
       uri,
-      asserts.map((assertion) =>
-        createDiagnostic(assertion.shortMessage || assertion.message, assertion.line)
-      )
+      asserts.map((assertion) => {
+        const name = testIdString('display', assertion);
+        return createDiagnostic(assertion.shortMessage || assertion.message, assertion.line, name);
+      })
     );
   }
 
@@ -84,24 +97,24 @@ export function updateDiagnostics(
         }
         break;
       default:
-        diagnostics.delete(uri);
+        collection.delete(uri);
         break;
     }
   });
 
   // Remove diagnostics for files no longer in existence
   const toBeDeleted = [];
-  diagnostics.forEach((uri) => {
+  collection.forEach((uri) => {
     if (!existsSync(uri.fsPath)) {
       toBeDeleted.push(uri);
     }
   });
   toBeDeleted.forEach((uri) => {
-    diagnostics.delete(uri);
+    collection.delete(uri);
   });
 }
 
-export function resetDiagnostics(diagnostics: vscode.DiagnosticCollection) {
+export function resetDiagnostics(diagnostics: vscode.DiagnosticCollection): void {
   diagnostics.clear();
 }
 export function failedSuiteCount(diagnostics: vscode.DiagnosticCollection): number {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { extensionName } from './appGlobals';
 import { statusBar } from './StatusBar';
 import { ExtensionManager, getExtensionWindowSettings } from './extensionManager';
 import { registerSnapshotCodeLens, registerSnapshotPreview } from './SnapshotCodeLens';
+import { DebugTestIdentifier } from './DebugCodeLens';
 
 let extensionManager: ExtensionManager;
 
@@ -39,9 +40,9 @@ export function activate(context: vscode.ExtensionContext): void {
     ),
     vscode.commands.registerCommand(
       `${extensionName}.run-test`,
-      (document: vscode.TextDocument, filename: string, identifier: string) => {
+      (document: vscode.TextDocument, filename: string, ...identifiers: DebugTestIdentifier[]) => {
         const workspace = vscode.workspace.getWorkspaceFolder(document.uri);
-        extensionManager.getByName(workspace.name).runTest(workspace, filename, identifier);
+        extensionManager.getByName(workspace.name).runTest(workspace, filename, ...identifiers);
       }
     ),
     ...registerSnapshotCodeLens(getExtensionWindowSettings().enableSnapshotPreviews),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -111,6 +111,13 @@ export function pathToConfig(pluginSettings: PluginResourceSettings): string {
 }
 
 /**
+ *  Taken From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+ */
+export function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+/**
  * ANSI colors/characters cleaning based on http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
  */
 export function cleanAnsi(str: string): string {
@@ -119,13 +126,6 @@ export function cleanAnsi(str: string): string {
     /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
     ''
   );
-}
-
-/**
- *  Taken From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
- */
-export function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
 export type IdStringType = 'display' | 'display-reverse' | 'full-name';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,6 +4,7 @@ import { normalize, join } from 'path';
 import { ExtensionContext } from 'vscode';
 
 import { PluginResourceSettings, hasUserSetPathToJest } from './Settings';
+import { TestIdentifier } from './TestResults';
 
 /**
  * Known binary names of `react-scripts` forks
@@ -83,7 +84,7 @@ function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
  * @returns {string}
  */
 // tslint:disable-next-line no-shadowed-variable
-export function pathToJest({ pathToJest, rootPath }: PluginResourceSettings) {
+export function pathToJest({ pathToJest, rootPath }: PluginResourceSettings): string {
   if (hasUserSetPathToJest(pathToJest)) {
     return normalize(pathToJest);
   }
@@ -101,19 +102,12 @@ export function pathToJest({ pathToJest, rootPath }: PluginResourceSettings) {
  *
  * @returns {string}
  */
-export function pathToConfig(pluginSettings: PluginResourceSettings) {
+export function pathToConfig(pluginSettings: PluginResourceSettings): string {
   if (pluginSettings.pathToConfig !== '') {
     return normalize(pluginSettings.pathToConfig);
   }
 
   return '';
-}
-
-/**
- *  Taken From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
- */
-export function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
 /**
@@ -125,6 +119,29 @@ export function cleanAnsi(str: string): string {
     /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
     ''
   );
+}
+
+/**
+ *  Taken From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+ */
+export function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+export type IdStringType = 'display' | 'display-reverse' | 'full-name';
+export function testIdString(type: IdStringType, identifier: TestIdentifier): string {
+  if (!identifier.ancestorTitles.length) {
+    return identifier.title;
+  }
+  const parts = [...identifier.ancestorTitles, identifier.title];
+  switch (type) {
+    case 'display':
+      return parts.join(' > ');
+    case 'display-reverse':
+      return parts.reverse().join(' < ');
+    case 'full-name':
+      return parts.join(' ');
+  }
 }
 
 /**
@@ -176,5 +193,3 @@ export function getJestCommandSettings(
   }
   return [pathToJest(settings), pathToConfig(settings)];
 }
-
-export default prepareIconFile;

--- a/tests/DebugCodeLens/DebugCodeLens.test.ts
+++ b/tests/DebugCodeLens/DebugCodeLens.test.ts
@@ -29,6 +29,6 @@ describe('DebugCodeLens', () => {
   });
 
   it('should specify the test name', () => {
-    expect(sut.testName).toBe(testName);
+    expect(sut.testIds).toEqual([testName]);
   });
 });

--- a/tests/TestResults/match-by-context.test.ts
+++ b/tests/TestResults/match-by-context.test.ts
@@ -4,7 +4,7 @@ jest.unmock('../test-helper');
 
 import * as helper from '../test-helper';
 import * as match from '../../src/TestResults/match-by-context';
-import { TestReconciliationState } from '../../src/TestResults';
+import { TestReconciliationStateType } from '../../src/TestResults';
 import { TestAssertionStatus, ParsedNode } from 'jest-editor-support';
 
 describe('buildAssertionContainer', () => {
@@ -257,14 +257,14 @@ describe('matchTestAssertions', () => {
   });
   describe('1-many (jest.each) match', () => {
     const createTestData = (
-      statusList: (TestReconciliationState | [TestReconciliationState, number])[]
+      statusList: (TestReconciliationStateType | [TestReconciliationStateType, number])[]
     ): [ParsedNode, TestAssertionStatus[]] => {
       const t1 = helper.makeItBlock('', [12, 1, 20, 1]);
       const sourceRoot = helper.makeRoot([t1]);
 
       // this match jest.each with 2 assertions
       const assertions = statusList.map((s, idx) => {
-        let state: TestReconciliationState;
+        let state: TestReconciliationStateType;
         let override: Partial<TestAssertionStatus>;
         if (typeof s === 'string') {
           state = s;

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -29,8 +29,10 @@ import {
   nodeBinExtension,
   cleanAnsi,
   prepareIconFile,
+  testIdString,
   getJestCommandSettings,
   pathToConfig,
+  escapeRegExp,
 } from '../src/helpers';
 
 // Manually (forcefully) set the executable's file extension to test its addition independendly of the operating system.
@@ -225,5 +227,34 @@ describe('ModuleHelpers', () => {
       };
       expect(getJestCommandSettings(settings)).toEqual([settings.jestCommandLine, undefined]);
     });
+  });
+});
+
+describe('escapeRegExp', () => {
+  it.each`
+    str                    | expected
+    ${'no special char'}   | ${'no special char'}
+    ${'with (a)'}          | ${'with \\(a\\)'}
+    ${'with {} and $sign'} | ${'with \\{\\} and \\$sign'}
+    ${'with []'}           | ${'with \\[\\]'}
+  `('escapeRegExp: $str', ({ str, expected }) => {
+    expect(escapeRegExp(str)).toEqual(expected);
+  });
+});
+describe('testIdString', () => {
+  it.each`
+    type                 | id                                                            | expected
+    ${'display'}         | ${{ title: 'test', ancestorTitles: [] }}                      | ${'test'}
+    ${'display-reverse'} | ${{ title: 'test', ancestorTitles: [] }}                      | ${'test'}
+    ${'full-name'}       | ${{ title: 'test', ancestorTitles: [] }}                      | ${'test'}
+    ${'display'}         | ${{ title: 'regexp (a) $x/y', ancestorTitles: [] }}           | ${'regexp (a) $x/y'}
+    ${'display-reverse'} | ${{ title: 'regexp (a) $x/y', ancestorTitles: [] }}           | ${'regexp (a) $x/y'}
+    ${'full-name'}       | ${{ title: 'regexp (a) $x/y', ancestorTitles: [] }}           | ${'regexp (a) $x/y'}
+    ${'display'}         | ${{ title: 'test', ancestorTitles: ['d-1', 'd-1-1'] }}        | ${'d-1 > d-1-1 > test'}
+    ${'display-reverse'} | ${{ title: 'test', ancestorTitles: ['d-1', 'd-1-1'] }}        | ${'test < d-1-1 < d-1'}
+    ${'full-name'}       | ${{ title: 'test', ancestorTitles: ['d-1', 'd-1-1'] }}        | ${'d-1 d-1-1 test'}
+    ${'full-name'}       | ${{ title: 'regexp ($a)', ancestorTitles: ['d-1', 'd-1-1'] }} | ${'d-1 d-1-1 regexp ($a)'}
+  `('$type: $expected', ({ type, id, expected }) => {
+    expect(testIdString(type, id)).toEqual(expected);
   });
 });

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -66,3 +66,20 @@ export const makeAssertion = (
     location: location ? makeLocation(location) : EmptyLocation,
     ...(override || {}),
   } as TestAssertionStatus);
+
+export const makeTestResult = (
+  title: string,
+  status: TestReconciliationState,
+  ancestorTitles: string[] = [],
+  range?: [number, number, number, number],
+  override?: Partial<TestResult>
+): TestResult => ({
+  name: [...ancestorTitles, title].join(' '),
+  status,
+  identifier: {
+    title,
+    ancestorTitles,
+  },
+  ...(range ? makePositionRange(range) : EmptyLocationRange),
+  ...(override || {}),
+});

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 import { Location, LocationRange, TestResult } from '../src/TestResults/TestResult';
-import { TestReconciliationState } from '../src/TestResults';
+import { TestReconciliationStateType } from '../src/TestResults';
 import { ItBlock, TestAssertionStatus } from 'jest-editor-support';
 
 export const EmptyLocation = {
@@ -53,7 +53,7 @@ export const makeRoot = (children: any[]): any => ({
 });
 export const makeAssertion = (
   title: string,
-  status: TestReconciliationState,
+  status: TestReconciliationStateType,
   ancestorTitles: string[] = [],
   location?: [number, number],
   override?: Partial<TestAssertionStatus>
@@ -69,7 +69,7 @@ export const makeAssertion = (
 
 export const makeTestResult = (
   title: string,
-  status: TestReconciliationState,
+  status: TestReconciliationStateType,
   ancestorTitles: string[] = [],
   range?: [number, number, number, number],
   override?: Partial<TestResult>

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,7 +499,7 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^24.8.0", "@jest/types@^24.9.0":
+"@jest/types@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
   integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
@@ -3950,15 +3950,15 @@ jest-each@^26.6.2:
     jest-util "^26.6.2"
     pretty-format "^26.6.2"
 
-jest-editor-support@^28.0.0:
-  version "28.0.0"
-  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-28.0.0.tgz#bef5f030c8ce725e34eabb81238d5b2c39b7dafd"
-  integrity sha512-Q4dc96HI0Y9eBkN0RwZL4PEZhKU4VHOKetsu1AsuNe+aypV44p2wa9RrYgZN0JQQ6FSyV00cSX/2BfPiOsutNw==
+jest-editor-support@^28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-28.1.0.tgz#983b067436be81075907b47a9136265c5a59da69"
+  integrity sha512-h6Afk3+B+30HHq/UBmJdRqVC7B6rzw9lmFnlEvoKe2Bq73+Cr9FxuxSzi/znezi97nmVuS0AMcynFkemk9gmkg==
   dependencies:
     "@babel/parser" "^7.8.3"
     "@babel/traverse" "^7.6.2"
     "@babel/types" "^7.8.3"
-    "@jest/types" "^24.8.0"
+    "@jest/types" "^26.6.2"
     core-js "^3.2.1"
     jest-snapshot "^24.7.0"
 


### PR DESCRIPTION
This PR adds full parameterized test support across the extension:

## test-matching
  - upgrade to the [jest-editor-support@28.1](https://github.com/jest-community/jest-editor-support/releases/tag/v28.1.0) to pick up the parser fix for full parameterized test syntax support 
  - the matching logic is enhanced to handle parameterized describe blocks, in addition to parameterized test blocks. All parameterized test results are exposed to the rest of the system.
  - 
## decorators 
  - all flavor of parameterized tests should show (computed) test status in the gutter
  - all parameterized test errors will be marked with decorators, therefore, a parameterized test block might have multiple error decorators or a single line might have multiple error messages.
  - 
## diagnosis
  - all parameterized test errors show up in the PROBLEMS area as well as hovering messages. Each with the full test name.
 
## debug
  - If there are multiple debuggable tests for the given test block, DebugCodeLens display the number of debuggable tests and will ask the user to choose which test to debug.
  - run-test command API change (backward compatible)
  - optimization: remove stop/start the internal jest tests process during debugging. (see the open question below)

## Open Questions
- I was surprised to see that we stop and restart jest process in `JestExt.runTest`. Looks like this logic was there since runTest is introduced (#172). Could not see any discussion about why that was needed... Concern that it could be a very expensive overhead especially for large projects. I tried without stop/start logic and all seem fine. So I figure unless we knew the explicit use case to justify the overhead, it is better to leave them out... 

## Notes
- There is a known issue in jest that parameterized tests have incorrect locations (facebook/jest#10412). The fix (facebook/jest#10413) was merged in [jest-26.5.0](https://github.com/facebook/jest/releases/tag/v26.5.0). Therefore, the minimal jest version for projects with parameterized tests should be >= 26.5.0 
- to eat our own dog food, I have added a few parameterized tests in our own test suites. You can build the extension with this PR to try out.
- This PR does touch quite a few files, but most are not too complicated. I have tested this for a couple of days, but more tests especially from different platforms will be needed. Hopefully, we can release this soon so more people can help testing it.
---

fixes #427 (see [comments](https://github.com/jest-community/vscode-jest/issues/427#issuecomment-760886768))
