### PR TITLE
update doc to warn potential partial coverage in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* update doc to give warning on potential incorrect coverage in watch mode - @connectdotz
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The coverage mode, along with watch mode, are shown in StatusBar:
 _(The initial coverage mode is `off` but can be changed by adding `"jest.showCoverageOnLoad": true` in settings.)_ 
 
 
+**Warning**
+Coverage info might be less than what it actual is in "watch" mode (with `--watch` flag), where only changed files/tests are run (see facebook/jest#1284). To ensure absolutely correct coverage, we did consider using `--watchAll` with coverage, which could have significant performance impact. Not sure which problem is worse, therefore no change has been made, we are still default to `--watch` even with coverage on. (Maybe a new customization setting to override it if enough people want it... PR is welcome.)
 ### How to customize coverage overlay
 Coverage overlay determines how the coverage info is shown to users. This extension provides 2 customization points: 
 1. coverage style via `jest.coverageFormatter` 

--- a/src/JestProcessManagement/JestProcessManager.ts
+++ b/src/JestProcessManagement/JestProcessManager.ts
@@ -42,7 +42,7 @@ export class JestProcessManager {
         }
         this.removeJestProcessReference(exitedJestProcess);
         const jestProcessInWatchMode = this.run({
-          watchMode: WatchMode.Watch,
+          watchMode,
           keepAlive,
           exitCallback,
         });


### PR DESCRIPTION
Noticed the coverage sometimes is incorrect in watch mode, depends on what files are changed and their relationship with the target file. It does make sense with the `--watch` flag that it will only run tests that changed and thus produce partial coverage sometimes. See more detailed discussion in facebook/jest#1284.

In theory, we can pass `--watchAll` to ensure the coverage is correct, but it could have a significant performance implication especially for large projects. I don't recall many issues related to this kind of inconsistency, so not sure if it justifies the change/impact. One other possible solution is to introduce a customization flag for using `--watchAll` with coverage. Should be pretty straightforward if there are enough use cases. 

Anyway, I ended up just updated the README to give a warning and corrected a bug I found during the investigation.