### PR TITLE
Fix alpha3: unknown location assertions and missing debug codeLens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 * update doc to give warning on potential incorrect coverage in watch mode - @connectdotz
+* fix unknown location bug such as for jest.todo tests (#657) - @connectdotz
+* fix no debug codeLens if autoEnable is false (#658) - @connectdotz
 
 -->
 

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -21,6 +21,13 @@ export interface TestIdentifier {
   title: string;
   ancestorTitles: string[];
 }
+
+export type MatchResultReason =
+  | 'match-by-context'
+  | 'match-by-name'
+  | 'duplicate-names'
+  | 'no-matched-assertion';
+
 export interface TestResult extends LocationRange {
   name: string;
 
@@ -35,6 +42,8 @@ export interface TestResult extends LocationRange {
 
   // multiple results for the given range, common for parameterized (.each) tests
   multiResults?: TestResult[];
+  // record match or unmatch reason for this test result
+  reason?: MatchResultReason;
 }
 
 export const withLowerCaseWindowsDriveLetter = (filePath: string): string | undefined => {
@@ -78,12 +87,15 @@ function fileCoverageWithLowerCaseWindowsDriveLetter(fileCoverage: FileCoverage)
   return fileCoverage;
 }
 
-export const coverageMapWithLowerCaseWindowsDriveLetters = (data: JestTotalResults) => {
+// TODO should fix jest-editor-support type declaration, the coverageMap should not be "any"
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const coverageMapWithLowerCaseWindowsDriveLetters = (data: JestTotalResults): any => {
   if (!data.coverageMap) {
     return;
   }
 
-  const result = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: any = {};
   const filePaths = Object.keys(data.coverageMap);
   for (const filePath of filePaths) {
     const newFileCoverage = fileCoverageWithLowerCaseWindowsDriveLetter(data.coverageMap[filePath]);

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -28,8 +28,8 @@ const sortByStatus = (a: TestResult, b: TestResult): number => {
 export class TestResultProvider {
   verbose: boolean;
   private reconciler: TestReconciler;
-  private resultsByFilePath: TestResultsMap = {};
-  private sortedResultsByFilePath: SortedTestResultsMap = {};
+  private resultsByFilePath!: TestResultsMap;
+  private sortedResultsByFilePath!: SortedTestResultsMap;
 
   constructor(verbose = false) {
     this.reconciler = new TestReconciler();


### PR DESCRIPTION
# summary
- when assertion has no location info, such as the "todo" tests, it messed up the context matching assumptions that all assertions have location info... fix this by moving these assertions to the "invalid" assertion list and match them only by name, while the rest can still be matched by context
- fix debug codeLens crash in accessing test identity. Turns out we are assigning undefined to a not-nullable property, the reason the typescript compiler didn't spot it is because we never did turn on the "strict" mode ("alwaysStrict" is not the same as "strict"). But there are simply too many files that need to be fixed once the strict mode is on, so I will tackle that in a separate PR. This one just focuses on correcting identity assignment in the matching code. 
- adding a "reason" code to the test result to capture how the result is matched or unmatched for easier testing and debugging.
- change the result provider to always parse the file even when there is no assertion presented, so all tests will be marked "Unknown" and could still be debugged, in a somewhat limited fashion. This is useful for use cases that disables the "jest.autoEnable"

resolves #657 
resolves #658