### PR TITLE
fix listTestFiles for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ generated-icons/
 
 **/.DS_Store
 *.vsix
+*.zip

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -24,3 +24,4 @@ images/**
 node_modules
 webpack.config.js
 generated-icons/
+*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-* fix internal debug issue with webpack 5.x - @connectdotz
-* 
+* fix test files not found in testFile list on windows after v4 migration - @connectdotz
+* do not report error if no test file found - @connectdotz
 -->
 
 ### 4.0.0

--- a/src/JestExt/process-session.ts
+++ b/src/JestExt/process-session.ts
@@ -11,10 +11,11 @@ import { RunTestListener, ListTestFileListener } from './process-listeners';
 import { JestExtProcessContext } from './types';
 
 type InternalProcessType = 'list-test-files' | 'update-snapshot';
+export type OnListTestFilesResult = (fileNames?: string[], error?: string | Error) => void;
 export type InternalRequestBase =
   | {
       type: Extract<InternalProcessType, 'list-test-files'>;
-      onResult: (fileNames?: string[], error?: string | Error) => void;
+      onResult: OnListTestFilesResult;
     }
   | {
       type: Extract<InternalProcessType, 'update-snapshot'>;


### PR DESCRIPTION
- fix listTestFile report fileNames that is different than vscode.URI scheme in windows
- listTestFile will not report error if no test file is found
- exclude check-in/package of zip files