### PR TITLE
Change related tests shortcut to Ctrl-Alt-T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-* change *Run Related Tests* default keybinding to Ctrl-Alt/Option-T to avoid overriding default shortcuts.
+* change *Run Related Tests* default keybinding to Ctrl-Alt/Option-T to avoid overriding default shortcuts. @Agalin
 -->
 
 ### 4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* change *Run Related Tests* default keybinding to Ctrl-Alt/Option-T to avoid overriding default shortcuts.
 -->
 
 ### 4.0.1

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ One can assign keyboard shortcut to any of these commands, see [vscode Key Bindi
 In interactive mode, user can trigger the following action from the text editor context-menu
 |menu|description|keyboard shortcut
 |---|---|---|
-|Jest: Run Related Tests| if in test file, run all tests in the file; if in source file, run all tests with dependency to the file|Ctrl-Option-t or Ctrl-Alt-t|
+|Jest: Run Related Tests| if in test file, run all tests in the file; if in source file, run all tests with dependency to the file|Ctrl-Option-t (Mac) or Ctrl-Alt-t|
 
 Please see [vscode Key Bindings](https://code.visualstudio.com/docs/getstarted/keybindings) if you want to change the keyboard shortcut. 
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ One can assign keyboard shortcut to any of these commands, see [vscode Key Bindi
 In interactive mode, user can trigger the following action from the text editor context-menu
 |menu|description|keyboard shortcut
 |---|---|---|
-|Jest: Run Related Tests| if in test file, run all tests in the file; if in source file, run all tests with dependency to the file|Cmd-t or Ctrl-t|
+|Jest: Run Related Tests| if in test file, run all tests in the file; if in source file, run all tests with dependency to the file|Ctrl-Option-t or Ctrl-Alt-t|
 
 Please see [vscode Key Bindings](https://code.visualstudio.com/docs/getstarted/keybindings) if you want to change the keyboard shortcut. 
 

--- a/package.json
+++ b/package.json
@@ -292,8 +292,8 @@
     "keybindings": [
       {
         "command": "io.orta.jest.editor.run-all-tests",
-        "key": "ctrl+t",
-        "mac": "cmd+t",
+        "key": "ctrl+alt+t",
+        "mac": "ctrl+alt+t",
         "when": "jest:run.interactive && editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact)/ "
       }
     ],


### PR DESCRIPTION
Currently used Ctrl/Cmd+T is bound by default to symbol search.
Ctrl-Alt/Option-T is unbound on both Windows and macOS.
Cmd-Option-T is bound as well so no ctrl->cmd translation.