### PR TITLE
add --watchAll=false to non-watch tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug-fixes within the same version aren't needed
 ### 4.0.2
 * fix debug problem for windows users (#707) - @connectdotz
 * change *Run Related Tests* default keybinding to Ctrl-Alt/Option-T to avoid overriding default shortcuts. (#704) - @Agalin
+* add `--watchAll=false` to non-watch tasks - @connectdotz
 
 ### 4.0.1
 * fix test files not found in testFile list on windows after v4 migration - @connectdotz (#696)

--- a/src/JestExt/process-listeners.ts
+++ b/src/JestExt/process-listeners.ts
@@ -212,7 +212,7 @@ export class RunTestListener extends AbstractProcessListener {
     ) {
       const msg = prefixWorkspace(
         this.session.context,
-        `Jest process "${process.request.type}" failed unexpectedly`
+        `Jest process "${process.request.type}" ended unexpectedly`
       );
       this.logging('warn', msg);
 

--- a/src/JestExt/process-session.ts
+++ b/src/JestExt/process-session.ts
@@ -138,7 +138,7 @@ export const createProcessSession = (context: JestExtProcessContext): ProcessSes
         return {
           ...request,
           type: 'not-test',
-          args: ['--listTests', '--json'],
+          args: ['--listTests', '--json', '--watchAll=false'],
           listener: new ListTestFileListener(listenerSession, request.onResult),
           schedule,
         };

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -106,12 +106,12 @@ export class JestProcess {
     switch (this.request.type) {
       case 'all-tests':
         if (this.request.updateSnapshot) {
-          options.args = { args: ['--updateSnapshot'] };
+          options.args = { args: ['--updateSnapshot', '--watchAll=false'] };
         }
         break;
       case 'by-file': {
         options.testFileNamePattern = this.quoteFileName(this.request.testFileNamePattern);
-        const args: string[] = ['--findRelatedTests'];
+        const args: string[] = ['--findRelatedTests', '--watchAll=false'];
         if (this.request.updateSnapshot) {
           args.push('--updateSnapshot');
         }
@@ -122,7 +122,7 @@ export class JestProcess {
       case 'by-file-test': {
         options.testFileNamePattern = this.quoteFileName(this.request.testFileNamePattern);
         options.testNamePattern = this.request.testNamePattern;
-        const args: string[] = ['--runTestsByPath'];
+        const args: string[] = ['--runTestsByPath', '--watchAll=false'];
         if (this.request.updateSnapshot) {
           args.push('--updateSnapshot');
         }

--- a/tests/JestExt/process-listeners.test.ts
+++ b/tests/JestExt/process-listeners.test.ts
@@ -61,12 +61,13 @@ describe('jest process listeners', () => {
 
   describe('ListTestFileListener', () => {
     it.each`
-      output                                               | expectedFiles
-      ${[]}                                                | ${[]}
-      ${['whatever\n', '["file1", "file', '2", "file3"]']} | ${['file1', 'file2', 'file3']}
-      ${['["/a/b", "a/c"]']}                               | ${['/a/b', 'a/c']}
-      ${['["/a/b", "a/c"]\n', '["a","b","c"]']}            | ${'unexpected result'}
-      ${['[a, b]']}                                        | ${'Unexpected token'}
+      output                                                          | expectedFiles
+      ${[]}                                                           | ${[]}
+      ${['whatever\n', '["file1", "file', '2", "file3"]']}            | ${['file1', 'file2', 'file3']}
+      ${['["/a/b", "a/c"]']}                                          | ${['/a/b', 'a/c']}
+      ${['["/a/b", "a/c"]\n', '["a","b","c"]']}                       | ${'unexpected result'}
+      ${['[a, b]']}                                                   | ${'Unexpected token'}
+      ${['on windows with some error\n', '["C:\\\\a\\\\b.test.js"]']} | ${['C:\\a\\b.test.js']}
     `('can extract and notify file list from valid $output', ({ output, expectedFiles }) => {
       expect.hasAssertions();
 

--- a/tests/JestExt/process-session.test.ts
+++ b/tests/JestExt/process-session.test.ts
@@ -31,7 +31,7 @@ describe('ProcessSession', () => {
     ${'watch-tests'}     | ${undefined}                      | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}     | ${undefined}
     ${'watch-all-tests'} | ${undefined}                      | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}     | ${undefined}
     ${'by-file'}         | ${{ testFileNamePattern: 'abc' }} | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}     | ${undefined}
-    ${'list-test-files'} | ${undefined}                      | ${{ queue: 'non-blocking', dedup: { filterByStatus: ['pending'] } }} | ${{ type: 'not-test', args: ['--listTests', '--json'] }}
+    ${'list-test-files'} | ${undefined}                      | ${{ queue: 'non-blocking', dedup: { filterByStatus: ['pending'] } }} | ${{ type: 'not-test', args: ['--listTests', '--json', '--watchAll=false'] }}
   `(
     'can schedule "$type" request with ProcessManager',
     ({ type, inputProperty, expectedSchedule, expectedExtraProperty }) => {

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -137,9 +137,9 @@ describe('JestProcess', () => {
       ${'all-tests'}       | ${undefined}                                                     | ${[false, false]} | ${true}         | ${undefined}
       ${'watch-tests'}     | ${undefined}                                                     | ${[true, false]}  | ${true}         | ${undefined}
       ${'watch-all-tests'} | ${undefined}                                                     | ${[true, true]}   | ${true}         | ${undefined}
-      ${'by-file'}         | ${{ testFileNamePattern: '"c:\\a\\b.ts"' }}                      | ${[false, false]} | ${true}         | ${{ args: { args: ['--findRelatedTests'] }, testFileNamePattern: '"C:\\a\\b.ts"' }}
-      ${'by-file-test'}    | ${{ testFileNamePattern: '"/a/b.js"', testNamePattern: 'test' }} | ${[false, false]} | ${true}         | ${{ args: { args: ['--runTestsByPath'] }, testFileNamePattern: '"/a/b.js"' }}
-      ${'not-test'}        | ${{ args: ['--listTests'] }}                                     | ${[false, false]} | ${false}        | ${{ args: { args: ['--listTests'], replace: true } }}
+      ${'by-file'}         | ${{ testFileNamePattern: '"c:\\a\\b.ts"' }}                      | ${[false, false]} | ${true}         | ${{ args: { args: ['--findRelatedTests', '--watchAll=false'] }, testFileNamePattern: '"C:\\a\\b.ts"' }}
+      ${'by-file-test'}    | ${{ testFileNamePattern: '"/a/b.js"', testNamePattern: 'test' }} | ${[false, false]} | ${true}         | ${{ args: { args: ['--runTestsByPath', '--watchAll=false'] }, testFileNamePattern: '"/a/b.js"' }}
+      ${'not-test'}        | ${{ args: ['--listTests', '--watchAll=false'] }}                 | ${[false, false]} | ${false}        | ${{ args: { args: ['--listTests', '--watchAll=false'], replace: true } }}
     `(
       'supports jest process request: $type',
       async ({ type, extraProperty, startArgs, includeReporter, extraRunnerOptions }) => {


### PR DESCRIPTION
add `--watchAll=false` to all non-watch tasks to ensure the tasks won't get stuck since some test script automatically adds `--watch` flag like the react test script.