### PR TITLE
split save operations to SaveTextDocument event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-
+* move save related operations to new SaveTextDocument event listeners to prevent duplicate firing and losing test state for watch-mode + clean-doc-save combination. - @connectdotz
 -->
 
 ### 4.0.2

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -30,6 +30,8 @@ const workspace = {
   onDidCreateFiles: jest.fn(),
   onDidDeleteFiles: jest.fn(),
   onDidRenameFiles: jest.fn(),
+  onDidSaveTextDocument: jest.fn(),
+  onWillSaveTextDocument: jest.fn(),
 };
 
 const OverviewRulerLane = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,15 @@ const addSubscriptions = (context: vscode.ExtensionContext): void => {
     ),
     vscode.workspace.onDidCreateFiles(extensionManager.onDidCreateFiles, extensionManager),
     vscode.workspace.onDidRenameFiles(extensionManager.onDidRenameFiles, extensionManager),
-    vscode.workspace.onDidDeleteFiles(extensionManager.onDidDeleteFiles, extensionManager)
+    vscode.workspace.onDidDeleteFiles(extensionManager.onDidDeleteFiles, extensionManager),
+    vscode.workspace.onDidSaveTextDocument(
+      extensionManager.onDidSaveTextDocument,
+      extensionManager
+    ),
+    vscode.workspace.onWillSaveTextDocument(
+      extensionManager.onWillSaveTextDocument,
+      extensionManager
+    )
   );
 };
 

--- a/src/extensionManager.ts
+++ b/src/extensionManager.ts
@@ -230,6 +230,19 @@ export class ExtensionManager {
       ext.onDidChangeTextDocument(event);
     }
   }
+
+  onWillSaveTextDocument(event: vscode.TextDocumentWillSaveEvent): void {
+    const ext = this.getByDocUri(event.document.uri);
+    if (ext) {
+      ext.onWillSaveTextDocument(event);
+    }
+  }
+  onDidSaveTextDocument(document: vscode.TextDocument): void {
+    const ext = this.getByDocUri(document.uri);
+    if (ext) {
+      ext.onDidSaveTextDocument(document);
+    }
+  }
   private onFilesChange(files: readonly vscode.Uri[], handler: (ext: JestExt) => void) {
     const exts = files.map((f) => this.getByDocUri(f)).filter((ext) => ext != null) as JestExt[];
     const set = new Set<JestExt>(exts);

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -106,6 +106,9 @@ describe('Extension', () => {
 
       expect(vscode.workspace.onDidChangeTextDocument).toBeCalled();
       expect(context.subscriptions.push.mock.calls[0]).toContain('onDidChangeTextDocument');
+
+      expect(vscode.workspace.onDidSaveTextDocument).toBeCalled();
+      expect(vscode.workspace.onWillSaveTextDocument).toBeCalled();
     });
 
     it('should register an event handler to handle when an extension configuration changed', () => {

--- a/tests/extensionManager.test.ts
+++ b/tests/extensionManager.test.ts
@@ -37,6 +37,8 @@ const makeJestExt = (workspace: vscode.WorkspaceFolder): any => {
     onDidCreateFiles: jest.fn(),
     onDidRenameFiles: jest.fn(),
     onDidDeleteFiles: jest.fn(),
+    onDidSaveTextDocument: jest.fn(),
+    onWillSaveTextDocument: jest.fn(),
     triggerUpdateSettings: jest.fn(),
     workspace,
   };
@@ -527,6 +529,37 @@ describe('ExtensionManager', () => {
       extensionManager.onDidRenameFiles(event);
       expect(ext1.onDidRenameFiles).toBeCalledTimes(1);
       expect(ext2.onDidRenameFiles).toBeCalledTimes(ext2Call);
+    });
+  });
+  describe('listen for save events', () => {
+    let ext1, ext2;
+    beforeEach(() => {
+      extensionManager = createExtensionManager(['ws-1', 'ws-2']);
+      jest.clearAllMocks();
+      ext1 = extensionManager.getByName('ws-1');
+      ext2 = extensionManager.getByName('ws-2');
+    });
+    it('onDidSaveTextDocument', () => {
+      const document: any = { uri: 'ws-1' };
+      extensionManager.onDidSaveTextDocument(document);
+      expect(ext1.onDidSaveTextDocument).toBeCalledTimes(1);
+      expect(ext2.onDidSaveTextDocument).toBeCalledTimes(0);
+
+      document.uri = 'ws-2';
+      extensionManager.onDidSaveTextDocument(document);
+      expect(ext1.onDidSaveTextDocument).toBeCalledTimes(1);
+      expect(ext2.onDidSaveTextDocument).toBeCalledTimes(1);
+    });
+    it('onWillSaveTextDocument', () => {
+      const event: any = { document: { uri: 'ws-1' } };
+      extensionManager.onWillSaveTextDocument(event);
+      expect(ext1.onWillSaveTextDocument).toBeCalledTimes(1);
+      expect(ext2.onWillSaveTextDocument).toBeCalledTimes(0);
+
+      event.document.uri = 'ws-2';
+      extensionManager.onWillSaveTextDocument(event);
+      expect(ext1.onWillSaveTextDocument).toBeCalledTimes(1);
+      expect(ext2.onWillSaveTextDocument).toBeCalledTimes(1);
     });
   });
   describe('activate', () => {


### PR DESCRIPTION
We were using `onDidChangeTextDocument` to handle document changes upon save. However, even after all the checks added there, this `handleOnSaveRun` within still got invoked twice when a document is saved, which caused #698.

Instead of doing more checks or maintaining another state, figure it will be more correct to just split the save-related logic to the actual save event listeners. 

I have seen cases that when saving a clean document, jest watcher might not re-run the test. If we clear the state blindly this test file will all be marked "unknown", therefore need to know if the document is dirty thus invoke this in the `onWillSaveTextDocument`.

Did not remove `onDidChangeTextDocument` because not sure if there any other use cases need it. This will cause some inefficiency that the editor might be refreshed couple more times than it needed to be. But probably not too bad as vscode had buffered these rapid UI changes. If anybody knows the history of `onDidChangeTextDocument` and is sure it is not needed for anything else then we could remove it.

---

fixes #698