### PR TITLE
consolidate testFiles state in TestResultProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* add `--watchAll=false` to non-watch tasks - @connectdotz
 * move save related operations to new SaveTextDocument event listeners to prevent duplicate firing and losing test state for watch-mode + clean-doc-save combination. - @connectdotz
+* move testFile state to ResultProvider that provides a union of test-files and actual results, to be more robust even when there is a race condition when fileList comes after test run. - @connectdotz 
 -->
 
 ### 4.0.2
 * fix debug problem for windows users (#707) - @connectdotz
 * change *Run Related Tests* default keybinding to Ctrl-Alt/Option-T to avoid overriding default shortcuts. (#704) - @Agalin
-* add `--watchAll=false` to non-watch tasks - @connectdotz
 
 ### 4.0.1
 * fix test files not found in testFile list on windows after v4 migration - @connectdotz (#696)

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -92,6 +92,16 @@ export class TestResultProvider implements JestExtSessionAware {
     this.testSuites = {};
   }
 
+  isTestFile(fileName: string): 'yes' | 'no' | 'unknown' {
+    if (this.testFiles?.includes(fileName) || this.testSuites[fileName] != null) {
+      return 'yes';
+    }
+    if (!this.testFiles) {
+      return 'unknown';
+    }
+    return 'no';
+  }
+
   private matchResults(filePath: string, { root, itBlocks }: IParseResults): TestSuiteResult {
     try {
       const assertions = this.reconciler.assertionsForTestFile(filePath);
@@ -117,13 +127,6 @@ export class TestResultProvider implements JestExtSessionAware {
   }
 
   /**
-   * if we have test file list, returns true if the file is NOT in the list; otherwise always returns false since we can't be sure
-   * @param filePath
-   */
-  private notTestFile(filePath: string): boolean {
-    return (this.testFiles && !this.testFiles.includes(filePath)) ?? false;
-  }
-  /**
    * returns matched test results for the given file
    * @param filePath
    * @returns valid test result list or undefined if the file is not a test.
@@ -136,7 +139,7 @@ export class TestResultProvider implements JestExtSessionAware {
       return results;
     }
 
-    if (this.notTestFile(filePath)) {
+    if (this.isTestFile(filePath) === 'no') {
       return;
     }
 
@@ -168,7 +171,7 @@ export class TestResultProvider implements JestExtSessionAware {
       return cached;
     }
 
-    if (this.notTestFile(filePath)) {
+    if (this.isTestFile(filePath) === 'no') {
       return;
     }
 

--- a/tests/TestResults/TestResultProvider.test.ts
+++ b/tests/TestResults/TestResultProvider.test.ts
@@ -822,4 +822,36 @@ describe('TestResultProvider', () => {
       expect(mockReconciler.assertionsForTestFile).toHaveBeenCalledTimes(1);
     });
   });
+  describe('isTestFile', () => {
+    const target = 'file-1';
+    beforeEach(() => {
+      mockReconciler.updateFileWithJestStatus.mockClear();
+    });
+    it.each`
+      testFiles               | testResults   | expected
+      ${undefined}            | ${undefined}  | ${'unknown'}
+      ${undefined}            | ${['file-2']} | ${'unknown'}
+      ${[]}                   | ${[]}         | ${'no'}
+      ${[]}                   | ${['file-1']} | ${'yes'}
+      ${[]}                   | ${['file-2']} | ${'no'}
+      ${['file-1']}           | ${undefined}  | ${'yes'}
+      ${['file-2']}           | ${undefined}  | ${'no'}
+      ${['file-1', 'file-2']} | ${undefined}  | ${'yes'}
+      ${['file-1']}           | ${['file-1']} | ${'yes'}
+      ${['file-2']}           | ${['file-1']} | ${'yes'}
+      ${['file-2']}           | ${['file-2']} | ${'no'}
+    `('$testFiles, $testResults => $expected', ({ testFiles, testResults, expected }) => {
+      const sut = new TestResultProvider();
+      if (testFiles) {
+        sut.updateTestFileList(testFiles);
+      }
+      if (testResults) {
+        const mockResults = testResults.map((file) => ({ file, status: 'KnownSuceess' }));
+        mockReconciler.updateFileWithJestStatus.mockReturnValueOnce(mockResults);
+        sut.updateTestResults({} as any);
+      }
+
+      expect(sut.isTestFile(target)).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
This is to address the test file being ignored (no test status indicator) when "list-test-files" either error out or delayed even though the test runner itself ran fine. 

This PR consolidates the "isTestFile" logic into TestResultProvider, which lookup both "list-test-files" results and the regular test run results to determine if the given file is a test file. 

---
fix 710