### PR TITLE
convert ProjectWorkspace rootPath to upper-case drive-letter in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug-fixes within the same version aren't needed
 * add `--watchAll=false` to non-watch tasks - @connectdotz
 * move save related operations to new SaveTextDocument event listeners to prevent duplicate firing and losing test state for watch-mode + clean-doc-save combination. - @connectdotz
 * move testFile state to ResultProvider that provides a union of test-files and actual results, to be more robust even when there is a race condition when fileList comes after test run. - @connectdotz 
+* convert to upper-case drive letter for ProjectWorkspace rootPath - @connectdotz
 -->
 
 ### 4.0.2

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -7,7 +7,7 @@ import { ProjectWorkspace } from 'jest-editor-support';
 import { JestProcessRequest } from '../JestProcessManagement';
 import { PluginResourceSettings, JestExtAutoRunConfig } from '../Settings';
 import { AutoRunMode } from '../StatusBar';
-import { pathToJest, pathToConfig } from '../helpers';
+import { pathToJest, pathToConfig, toFilePath } from '../helpers';
 import { workspaceLogging } from '../logging';
 import { AutoRunAccessor, JestExtContext } from './types';
 import { CoverageColors } from '../Coverage';
@@ -81,7 +81,7 @@ export const createJestExtContext = (
   const currentJestVersion = 20;
   const [jestCommandLine, pathToConfig] = getJestCommandSettings(settings);
   const runnerWorkspace = new ProjectWorkspace(
-    settings.rootPath,
+    toFilePath(settings.rootPath),
     jestCommandLine,
     pathToConfig,
     currentJestVersion,

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -11,6 +11,7 @@ import { ProjectWorkspace } from 'jest-editor-support';
 import { workspaceLogging } from '../../src/logging';
 import { pathToJest, pathToConfig } from '../../src/helpers';
 import { mockProjectWorkspace } from '../test-helper';
+import { toFilePath } from '../../src/helpers';
 
 describe('createJestExtContext', () => {
   const workspaceFolder: any = { name: 'workspace' };
@@ -84,11 +85,14 @@ describe('createJestExtContext', () => {
     });
   });
   it('will create runnerWorkspace', () => {
-    const settings: any = {};
-    (ProjectWorkspace as jest.Mocked<any>).mockReturnValue({});
+    const rootPath = 'abc';
+    const settings: any = { rootPath };
+    const mockRunnerWorkspace = { rootPath };
+    (ProjectWorkspace as jest.Mocked<any>).mockReturnValue(mockRunnerWorkspace);
     const context = createJestExtContext(workspaceFolder, settings);
     expect(ProjectWorkspace).toBeCalled();
-    expect(context.runnerWorkspace).toEqual({});
+    expect(toFilePath).toBeCalledWith(rootPath);
+    expect(context.runnerWorkspace).toEqual(mockRunnerWorkspace);
   });
   it('will create logging factory', () => {
     const settings: any = {};


### PR DESCRIPTION
this ProjectWorkspace.rootPath is used by `jest-editor-support` Runner to spawn process as the "cwd". On windows, if the drive-letter is lowercase, jest process could fail under some configurations. To make it more fault-tolerant, we should convert it to uppercase.