### PR TITLE
Improve test result match fallback in the imperfect world

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ git:
 jobs:
   - stage: "verify"
     name: "verify"
-    node_js: "10"
+    node_js: "12"
     os: osx
     script: yarn danger ci
 
 node_js:
-  - "10"
+  - "12"
   - "lts/*"
 
 os:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,10 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
+  "jest.debugMode": true,
+  "jest.debugCodeLens.showWhenTestStateIn": [
+    "fail",
+    "pass",
+    "unknown"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,11 +14,5 @@
   "eslint.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  },
-  "jest.debugMode": true,
-  "jest.debugCodeLens.showWhenTestStateIn": [
-    "fail",
-    "pass",
-    "unknown"
-  ]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-
+* add `--watchAll=false` to non-watch tasks - @connectdotz
+* in matching: improve match-by-name for incorrect grouping case - @connectdotz
 -->
 
 ### 4.0.2
 * fix debug problem for windows users (#707) - @connectdotz
 * change *Run Related Tests* default keybinding to Ctrl-Alt/Option-T to avoid overriding default shortcuts. (#704) - @Agalin
-* add `--watchAll=false` to non-watch tasks - @connectdotz
 
 ### 4.0.1
 * fix test files not found in testFile list on windows after v4 migration - @connectdotz (#696)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Bug-fixes within the same version aren't needed
 * add `--watchAll=false` to non-watch tasks - @connectdotz
 * move save related operations to new SaveTextDocument event listeners to prevent duplicate firing and losing test state for watch-mode + clean-doc-save combination. - @connectdotz
 * move testFile state to ResultProvider that provides a union of test-files and actual results, to be more robust even when there is a race condition when fileList comes after test run. - @connectdotz 
-* in matching: improve match-by-name for incorrect grouping case - @connectdotz
+* in matching: improve fallback mechanism for incorrect grouping and describe-hierarchy - @connectdotz
 -->
 
 ### 4.0.2

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "4.0.2",
+  "version": "4.0.3-rc.2",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.45.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.45.0"

--- a/package.json
+++ b/package.json
@@ -388,7 +388,7 @@
   "dependencies": {
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",
-    "jest-editor-support": "^28.2.0",
+    "jest-editor-support": "^29.0.0",
     "jest-snapshot": "^25.5.0",
     "vscode-codicons": "^0.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "4.0.3-rc.2",
+  "version": "4.0.2",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.45.0"

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -25,8 +25,9 @@ export interface TestIdentifier {
 export type MatchResultReason =
   | 'match-by-context'
   | 'match-by-name'
-  | 'duplicate-names'
-  | 'no-matched-assertion';
+  | 'match-by-fullName'
+  | 'duplicate-name'
+  | 'match-failed';
 
 export interface TestResult extends LocationRange {
   name: string;

--- a/src/TestResults/TestResult.ts
+++ b/src/TestResults/TestResult.ts
@@ -3,6 +3,7 @@ import { JestFileResults, JestTotalResults } from 'jest-editor-support';
 import { FileCoverage } from 'istanbul-lib-coverage';
 import * as path from 'path';
 import { cleanAnsi, toLowerCaseDriveLetter } from '../helpers';
+import { MatchEvent } from './match-node';
 
 export interface Location {
   /** Zero-based column number */
@@ -22,13 +23,6 @@ export interface TestIdentifier {
   ancestorTitles: string[];
 }
 
-export type MatchResultReason =
-  | 'match-by-context'
-  | 'match-by-name'
-  | 'match-by-fullName'
-  | 'duplicate-name'
-  | 'match-failed';
-
 export interface TestResult extends LocationRange {
   name: string;
 
@@ -43,8 +37,10 @@ export interface TestResult extends LocationRange {
 
   // multiple results for the given range, common for parameterized (.each) tests
   multiResults?: TestResult[];
-  // record match or unmatch reason for this test result
-  reason?: MatchResultReason;
+
+  // matching process history
+  sourceHistory?: MatchEvent[];
+  assertionHistory?: MatchEvent[];
 }
 
 function testResultWithLowerCaseWindowsDriveLetter(testResult: JestFileResults): JestFileResults {

--- a/src/TestResults/TestResultProvider.ts
+++ b/src/TestResults/TestResultProvider.ts
@@ -120,9 +120,7 @@ export class TestResultProvider implements JestExtSessionAware {
     // no need to do groupByRange as the source block will not have blocks under the same location
     return {
       status: 'Unknown',
-      results: itBlocks.map((t) =>
-        match.toMatchResult(t, 'no assertion found', 'no-matched-assertion')
-      ),
+      results: itBlocks.map((t) => match.toMatchResult(t, 'no assertion found', 'match-failed')),
     };
   }
 

--- a/src/TestResults/match-by-context.ts
+++ b/src/TestResults/match-by-context.ts
@@ -40,7 +40,9 @@ export const buildAssertionContainer = (
         a.ancestorTitles,
         (name: string) => new ContainerNode(name, { isGroup: 'maybe' })
       );
-      const zeroBasedLine = a.location?.line ? a.location.line - 1 : -1;
+      // regardless the document: https://jestjs.io/docs/26.x/cli#--testlocationinresults
+      // the location are actually zero-based, but the "line" attribute is 1-based.
+      const zeroBasedLine = a.location ? a.location.line : a.line ? a.line - 1 : -1;
       container?.addDataNode(
         new DataNode(a.title, zeroBasedLine, a, {
           fullName: a.fullName,

--- a/src/TestResults/match-by-context.ts
+++ b/src/TestResults/match-by-context.ts
@@ -25,7 +25,6 @@ import {
   ContextType,
   ChildNodeType,
   ROOT_NODE_NAME,
-  flatten,
   OptionalAttributes,
   MatchEvent,
 } from './match-node';
@@ -191,11 +190,7 @@ const ContextMatch = (): ContextMatchAlgorithm => {
       return [];
     }
 
-    return flatten(
-      matched.map((a) => {
-        return a.getAll().map((aa) => toMatchResult(t, aa, reason));
-      })
-    );
+    return matched.flatMap((a) => a.getAll().map((aa) => toMatchResult(t, aa, reason)));
   };
 
   const handleDescribeBlockMatch = (result: MatchResultType<'container'>): TestResult[] => {
@@ -205,12 +200,10 @@ const ContextMatch = (): ContextMatchAlgorithm => {
     }
 
     t.addEvent(reason);
-    return flatten(
-      matched.map((a) => {
-        a.addEvent(reason);
-        return matchContainers(t, a);
-      })
-    );
+    return matched.flatMap((a) => {
+      a.addEvent(reason);
+      return matchContainers(t, a);
+    });
   };
 
   // match methods
@@ -346,13 +339,11 @@ const ContextMatch = (): ContextMatchAlgorithm => {
       }
 
       let aList = aContainer.unmatchedNodes(type, { ungroup: true });
-      const matched = flatten(
-        (['by-name', 'by-location'] as ClassicMatchType[]).map((matchType) => {
-          const matchResult = classicMatch(matchType, tList, aList);
-          tList = matchResult.unmatchedT;
-          return flatten(matchResult.results.map(onResult));
-        })
-      );
+      const matched = (['by-name', 'by-location'] as ClassicMatchType[]).flatMap((matchType) => {
+        const matchResult = classicMatch(matchType, tList, aList);
+        tList = matchResult.unmatchedT;
+        return matchResult.results.flatMap(onResult);
+      });
 
       // const matched = flatten(results.map(onResult));
       aList = aList.filter((a) => !a.isMatched);
@@ -378,7 +369,7 @@ const ContextMatch = (): ContextMatchAlgorithm => {
   };
 
   const toUnmatchedResults = (nodes: DataNode<ItBlock>[]): TestResult[] =>
-    flatten(nodes.map((t) => handleTestBlockMatch([t, [], 'match-failed'], true)));
+    nodes.flatMap((t) => handleTestBlockMatch([t, [], 'match-failed'], true));
 
   const match = (
     tContainer: ContainerNode<ItBlock>,

--- a/src/TestResults/match-node.ts
+++ b/src/TestResults/match-node.ts
@@ -235,9 +235,6 @@ export interface UnmatchedOptions {
 }
 export type ContextType = 'container' | 'data';
 
-export const flatten = <T>(lists: T[][]): T[] =>
-  lists.reduce((finalList, list) => finalList.concat(list), [] as T[]);
-
 export class ContainerNode<T> extends BaseNode {
   public childContainers: ContainerNode<T>[] = [];
   public childData: DataNode<T>[] = [];
@@ -321,15 +318,15 @@ export class ContainerNode<T> extends BaseNode {
   private allChildNodes<C extends ContextType>(type: C): ChildNodeType<T, C>[] {
     const allNodes: ChildNodeType<T, C>[] = [];
 
-    const allContainerNodes = flatten(this.childContainers.map((c) => c.getAll()));
+    const allContainerNodes = this.childContainers.flatMap((c) => c.getAll());
     if (type === 'container') {
       allNodes.push(...(allContainerNodes as ChildNodeType<T, C>[]));
     } else {
-      const allDataNodes = flatten(this.childData.map((c) => c.getAll()));
+      const allDataNodes = this.childData.flatMap((c) => c.getAll());
       allNodes.push(...(allDataNodes as ChildNodeType<T, C>[]));
     }
 
-    const childrenNodes = flatten(allContainerNodes.map((c) => c.allChildNodes(type)));
+    const childrenNodes = allContainerNodes.flatMap((c) => c.allChildNodes(type));
     return allNodes.concat(childrenNodes);
   }
   public checkDuplicateName(): void {

--- a/src/TestResults/match-node.ts
+++ b/src/TestResults/match-node.ts
@@ -2,94 +2,63 @@
  * internal classes used by `match-by-context`
  */
 
-export interface PositionNode {
-  zeroBasedLine: number;
-}
-
 type IsGroupType = 'yes' | 'no' | 'maybe';
-export interface BaseNodeType extends PositionNode {
-  readonly name: string;
-  readonly isGroup?: IsGroupType;
-  readonly ancestorTitles: string[];
-  readonly fullName: string;
-  readonly hasDynamicName?: boolean;
-}
+
+const IsMatchedEvents = ['match-by-context', 'match-by-name', 'match-by-location'] as const;
+
+export type IsMatchedEvent = typeof IsMatchedEvents[number];
+
+export type MatchEvent =
+  | IsMatchedEvent
+  | 'match-failed'
+  | 'match-failed:1-to-many'
+  | 'duplicate-name'
+  | 'invalid-location'
+  | 'missing-ancestor-info';
 
 export interface MatchOptions {
-  /**If true, will match by fullName instead of name */
-  byFullName?: boolean;
-  /** if true, will ignore name/fullName difference */
-  ignoreDynamicNameDiff?: boolean;
+  /** if true, will ignore name difference if both nodes have NonLiteral names */
+  ignoreNonLiteralNameDiff?: boolean;
   /** if true, will ignore isGroupNode() difference */
   ignoreGroupDiff?: boolean;
-  /** if true will immediately mark nodes' isMatched flag */
-  markImmediately?: boolean;
-}
-export interface GroupableNodeType<T> extends BaseNodeType {
-  merge: (another: this, forced?: boolean) => boolean;
-
-  /**
-   * return all grouped nodes including self
-   * @param resetGroup if true, the group will be reset after flatten
-   **/
-  getAll: () => this[];
-
-  /** returns true if the node is a group node, i.e. either has non-zero group member or lastProperty === 'each' */
-  isGroupNode: () => IsGroupType;
-
-  // is any element in the group (not including self) matches the give name
-  isInGroup: (name: string) => boolean;
-
-  /**
-   * try to match "other" based on the filter type:
-   * "by-name": match by name of the nodes
-   * "by-group": if the node has a group, then the "other" node should have 'each' lastProperty.
-   *
-   * the matched node will be linked and returns true; otherwise false
-   *
-   * If other already matched, returns true as well.
-   **/
-  match: (other: T, options?: MatchOptions) => boolean;
-
-  /** note: setting isMatch will set its group members, if any, match-state as well */
-  isMatched: boolean;
+  /** if true, will perform position check to see if "this" is enclosed within "other" node */
+  checkIsWithin?: boolean;
 }
 
-export const hasUnknownLocation = (node: PositionNode): boolean => node.zeroBasedLine < 0;
-
-const sortByLine = (n1: PositionNode, n2: PositionNode): number =>
-  n1.zeroBasedLine - n2.zeroBasedLine;
+const sortByLine = (n1: BaseNode, n2: BaseNode): number => n1.zeroBasedLine - n2.zeroBasedLine;
 
 // group nodes after sort
-const groupNodes = <N extends GroupableNodeType<GroupableNode>>(list: N[], node: N): N[] => {
+const groupNodes = <N extends BaseNode>(list: N[], node: N): N[] => {
   if (list.length <= 0) {
     return [node];
   }
-  // if not able to merge with previous node, i.e . can not group, add it to the list
-  if (!list[list.length - 1].merge(node)) {
+  if (node.hasEvent('invalid-location')) {
     list.push(node);
+  } else {
+    // if not able to merge with previous node, i.e . can not group, add it to the list
+    if (!list[list.length - 1].merge(node)) {
+      list.push(node);
+    }
   }
   return list;
 };
-
-export interface HasTitle {
-  title: string;
-}
 
 export const ROOT_NODE_NAME = '__root__';
 
 export interface OptionalAttributes {
   fullName?: string;
   isGroup?: IsGroupType;
-  hasDynamicName?: boolean;
+  nonLiteralName?: boolean;
+  // zero-based line range
+  range?: { start: number; end: number };
 }
-export class GroupableNode implements GroupableNodeType<GroupableNode> {
+export class BaseNode {
   name: string;
   zeroBasedLine: number;
   group: this[];
   attrs: OptionalAttributes;
+  events: Set<MatchEvent>;
 
-  private _matched: boolean;
   private _ancestorTitles: string[];
 
   constructor(name: string, zeroBasedLine: number, attrs?: OptionalAttributes) {
@@ -100,28 +69,45 @@ export class GroupableNode implements GroupableNodeType<GroupableNode> {
 
     this.group = [];
     this._ancestorTitles = [];
-    this._matched = false;
+    this.events = new Set();
   }
 
+  hasUnknownLocation(): boolean {
+    return this.zeroBasedLine < 0;
+  }
+
+  // events
+  history(additional?: MatchEvent): MatchEvent[] {
+    if (additional) {
+      this.addEvent(additional);
+    }
+    return Array.from(this.events.values());
+  }
+
+  /** check if the target node is in the matched nodes list; if no target, check if there is any matched node. */
+  get isMatched(): boolean {
+    return IsMatchedEvents.find((e) => this.events.has(e)) != null;
+  }
+
+  addEvent(event: MatchEvent): void {
+    this.getAll().forEach((n) => n.events.add(event));
+  }
+  hasEvent(event: MatchEvent): boolean {
+    return this.events.has(event);
+  }
+
+  // fullName
   get ancestorTitles(): string[] {
     return this._ancestorTitles;
   }
   get fullName(): string {
     if (!this.attrs.fullName) {
-      this.attrs.fullName = [...this._ancestorTitles.filter((t) => t.length > 0), this.name].join(
-        ' '
-      );
+      this.attrs.fullName = this._ancestorTitles
+        .concat(this.name)
+        .filter((t) => t)
+        .join(' ');
     }
     return this.attrs.fullName;
-  }
-
-  set isMatched(value: boolean) {
-    this.getAll().forEach((n) => (n._matched = value));
-  }
-
-  /** check if the target node is in the matched nodes list; if no target, check if there is any matched node. */
-  get isMatched(): boolean {
-    return this._matched;
   }
 
   // only update fullName if it is undefined
@@ -132,12 +118,22 @@ export class GroupableNode implements GroupableNodeType<GroupableNode> {
     }
   }
 
+  contains(another: BaseNode): boolean {
+    if (!this.attrs?.range || !another.attrs?.range) {
+      return false;
+    }
+    return (
+      this.attrs.range.start <= another.attrs.range.start &&
+      this.attrs.range.end >= another.attrs.range.end
+    );
+  }
+
   merge(another: this, forced = false): boolean {
     //can not merge if the location is unknown
     if (
       !forced &&
-      (hasUnknownLocation(this) ||
-        hasUnknownLocation(another) ||
+      (this.hasUnknownLocation() ||
+        another.hasUnknownLocation() ||
         another.zeroBasedLine !== this.zeroBasedLine)
     ) {
       return false;
@@ -151,31 +147,31 @@ export class GroupableNode implements GroupableNodeType<GroupableNode> {
     return [this, ...this.group];
   }
   // flatten node with grouping into an array including self
-  flatten(): this[] {
-    const members = this.getAll();
+  ungroup(): this[] {
+    const nodes = this.getAll();
     this.group = [];
-    return members;
+    return nodes;
   }
 
-  /** returns true if the node is a group node, i.e. either has non-zero group member or lastProperty === 'each' */
+  /**
+   * returns true if the node is a group node, i.e. either has non-zero group member or lastProperty === 'each'.
+   * If the node can not know it determinstically before matching, it should return "maybe".
+   */
   isGroupNode(): 'yes' | 'no' | 'maybe' {
-    if (this.attrs.isGroup === 'yes' || this.group.length > 0) {
+    if (this.group.length > 0 && this.attrs.isGroup !== 'no') {
       return 'yes';
     }
     return this.attrs.isGroup ?? 'no';
   }
 
-  // is any element in the group (not including self) matches the give name
-  isInGroup(name: string): boolean {
-    return this.group.find((n) => n.name === name) != null;
-  }
-
   addGroupMember(member: this): void {
-    this.group.push(...member.flatten());
+    this.group.push(...member.ungroup());
   }
 
-  private nameMaybeDynamic(): boolean {
-    return this.attrs.hasDynamicName || this.isGroupNode() !== 'no';
+  private maybeNonLiteralName(): boolean {
+    // a group node (such as test.each) could have a literal name that contains variable therefore could
+    // genrate different test names per parameter set
+    return this.attrs.nonLiteralName || this.isGroupNode() !== 'no';
   }
 
   /**
@@ -184,39 +180,48 @@ export class GroupableNode implements GroupableNodeType<GroupableNode> {
    * @returns true if matched, even if it is already matched; otherwise false.
    **/
 
-  match(other: GroupableNode, options?: MatchOptions): boolean {
-    const nameMatched = options?.byFullName
-      ? this.fullName === other.fullName
-      : this.name === other.name;
-
-    if (
-      !nameMatched &&
-      !(options?.ignoreDynamicNameDiff && (this.nameMaybeDynamic() || other.nameMaybeDynamic()))
-    ) {
-      return false;
-    }
-
-    if (
+  match(other: BaseNode, options?: MatchOptions): boolean {
+    const posNotMatch = options?.checkIsWithin && !other.contains(this);
+    const matchedAsNonLiteralName =
+      options?.ignoreNonLiteralNameDiff &&
+      this.maybeNonLiteralName() &&
+      other.maybeNonLiteralName();
+    const nameNotMatch = this.fullName !== other.fullName && !matchedAsNonLiteralName;
+    const groupNotMatch =
       !options?.ignoreGroupDiff &&
       !(
         this.isGroupNode() === 'maybe' ||
         other.isGroupNode() === 'maybe' ||
         this.isGroupNode() === other.isGroupNode()
-      )
-    ) {
+      );
+
+    return !(posNotMatch || nameNotMatch || groupNotMatch);
+  }
+
+  /**
+   * check if a node is structurally "valid", i.e. is the ancestorTitle, location info are populated. This does not check
+   * across the nodes, just the node itself.
+   * @returns true if no itegrity issue otherwise false and the node.history will be updated accordingly
+   */
+  checkIntegrity(): boolean {
+    const issues: MatchEvent[] = [];
+    if (this.name !== this.fullName && this._ancestorTitles.length <= 0) {
+      issues.push('missing-ancestor-info');
+    }
+
+    if (this.hasUnknownLocation()) {
+      issues.push('invalid-location');
+    }
+
+    if (issues.length > 0) {
+      issues.forEach((e) => this.addEvent(e));
       return false;
     }
-
-    if (options?.markImmediately) {
-      this.isMatched = true;
-      other.isMatched = true;
-    }
-
     return true;
   }
 }
 /* interface implementation */
-export class DataNode<T> extends GroupableNode {
+export class DataNode<T> extends BaseNode {
   data: T;
 
   constructor(name: string, zeroBasedLine: number, data: T, attrs?: OptionalAttributes) {
@@ -226,22 +231,16 @@ export class DataNode<T> extends GroupableNode {
 }
 
 export interface UnmatchedOptions {
-  flatten?: boolean;
-  skipInvalid?: boolean;
+  ungroup?: boolean;
 }
 export type ContextType = 'container' | 'data';
 
 export const flatten = <T>(lists: T[][]): T[] =>
   lists.reduce((finalList, list) => finalList.concat(list), [] as T[]);
 
-export class ContainerNode<T> extends GroupableNode {
+export class ContainerNode<T> extends BaseNode {
   public childContainers: ContainerNode<T>[] = [];
   public childData: DataNode<T>[] = [];
-
-  // childContainers without location info
-  public invalidChildContainers?: ContainerNode<T>[] = [];
-  // childData without location info
-  public invalidChildData?: DataNode<T>[];
 
   constructor(name: string, attrs?: OptionalAttributes) {
     super(name, -1, attrs);
@@ -260,15 +259,8 @@ export class ContainerNode<T> extends GroupableNode {
       titles: [...this.ancestorTitles, this.name],
       isGroup: this.attrs.isGroup,
     });
-    if (hasUnknownLocation(dataNode)) {
-      if (this.invalidChildData) {
-        this.invalidChildData.push(dataNode);
-      } else {
-        this.invalidChildData = [dataNode];
-      }
-    } else {
-      this.childData.push(dataNode);
-    }
+    dataNode.checkIntegrity();
+    this.childData.push(dataNode);
   }
 
   public findContainer(
@@ -299,18 +291,13 @@ export class ContainerNode<T> extends GroupableNode {
     }
 
     // recursive to sort childContainers, which will update its lineNumber, remove the invalid container then then sort the list itself
-    const valid: ContainerNode<T>[] = [];
-    const invalid: ContainerNode<T>[] = [];
+    const childContainers: ContainerNode<T>[] = [];
     this.childContainers.forEach((c) => {
       c.sort(grouping);
-      if (hasUnknownLocation(c)) {
-        invalid.push(c);
-      } else {
-        valid.push(c);
-      }
+      c.checkIntegrity();
+      childContainers.push(c);
     });
-    this.childContainers = valid;
-    this.invalidChildContainers = invalid.length > 0 ? invalid : undefined;
+    this.childContainers = childContainers;
 
     this.childContainers.sort(sortByLine);
     if (grouping) {
@@ -318,101 +305,52 @@ export class ContainerNode<T> extends GroupableNode {
     }
 
     // if container doesn't have valid line info, use the first known-location child's
-    if (hasUnknownLocation(this)) {
-      const topLines = [this.childData, this.childContainers]
-        .filter((l) => l.length > 0)
-        .map((l) => l[0].zeroBasedLine);
+    if (this.hasUnknownLocation()) {
+      const topLines = ([this.childData, this.childContainers] as BaseNode[][])
+        .map((nodes) => nodes.find((n) => !n.hasEvent('invalid-location'))?.zeroBasedLine)
+        .filter((n) => n != null) as number[];
       this.zeroBasedLine = topLines.length > 0 ? Math.min(...topLines) : -1;
     }
   }
-  // use conditional type to narrow down exactly the type
 
-  public getChildren<C extends ContextType>(type: C): ChildrenList<T, C> {
-    const valid = type === 'container' ? this.childContainers : this.childData;
-    const invalid = type === 'container' ? this.invalidChildContainers : this.invalidChildData;
-    // has to cast explicitly due to the issue:
+  public getChildren<C extends ContextType>(type: C): ChildNodeType<T, C>[] {
     // https://github.com/microsoft/TypeScript/issues/24929
-    return { valid, invalid } as ChildrenList<T, C>;
+    return (type === 'container' ? this.childContainers : this.childData) as ChildNodeType<T, C>[];
   }
-  /**
-   * invalidate duplicate named nodes
-   *
-   * @returns true if container has been updated; otherwise false
-   */
-  public invalidateDuplicateNameNodes<C extends ContextType>(
-    contextType: ContextType,
-    onDups?: (dups: ChildNodeType<T, C>[]) => void
-  ): boolean {
-    const { valid, invalid } = this.getChildren(contextType);
 
-    const dups = valid.filter((n) => valid.find((nn) => nn !== n && nn.fullName === n.fullName));
-    if (dups.length <= 0) {
-      return false;
-    }
-    const newValid = valid.filter((n) => !dups.includes(n));
-    const newInvalid = invalid || [];
-    newInvalid.push(...dups);
+  private allChildNodes<C extends ContextType>(type: C): ChildNodeType<T, C>[] {
+    const allNodes: ChildNodeType<T, C>[] = [];
 
-    if (contextType === 'container') {
-      this.childContainers = newValid as ContainerNode<T>[];
-      this.invalidChildContainers = newInvalid as ContainerNode<T>[];
+    const allContainerNodes = flatten(this.childContainers.map((c) => c.getAll()));
+    if (type === 'container') {
+      allNodes.push(...(allContainerNodes as ChildNodeType<T, C>[]));
     } else {
-      this.childData = newValid as DataNode<T>[];
-      this.invalidChildData = newInvalid as DataNode<T>[];
+      const allDataNodes = flatten(this.childData.map((c) => c.getAll()));
+      allNodes.push(...(allDataNodes as ChildNodeType<T, C>[]));
     }
 
-    onDups?.(dups as ChildNodeType<T, C>[]);
-
-    return true;
+    const childrenNodes = flatten(allContainerNodes.map((c) => c.allChildNodes(type)));
+    return allNodes.concat(childrenNodes);
   }
-
-  /** move child container to invalid list.
-   * @returns true if container has been updated; otherwise false
-   */
-  public invalidateGroupNode<C extends ContextType>(
-    contextType: ContextType,
-    node: ChildNodeType<T, C>
-  ): boolean {
-    const { valid, invalid } = this.getChildren(contextType);
-    const idx = valid.indexOf(node);
-
-    if (idx < 0) {
-      console.warn(
-        `no child found in parent container for ${contextType}. Not able to fix incorrect grouping`
-      );
-      return false;
-    }
-    valid.splice(idx, 1);
-
-    const newInvalid = invalid || [];
-    newInvalid.push(...node.flatten());
-    if (contextType === 'container') {
-      this.invalidChildContainers = newInvalid as ContainerNode<T>[];
-    } else {
-      this.invalidChildData = newInvalid as DataNode<T>[];
-    }
-
-    return true;
+  public checkDuplicateName(): void {
+    const dataNodes = this.allChildNodes('data');
+    dataNodes.forEach((n) => {
+      const dups = dataNodes.filter((nn) => nn !== n && nn.fullName === n.fullName);
+      if (dups.length > 0) {
+        dups.concat(n).forEach((nn) => nn.addEvent('duplicate-name'));
+      }
+    });
   }
-
   // extract all unmatched data node
-  public unmatchedNodes = (options?: UnmatchedOptions): DataNode<T>[] => {
-    const dataNodes =
-      (options?.skipInvalid !== true && this.invalidChildData?.concat(this.childData)) ||
-      this.childData;
-    let unmatched = dataNodes.filter((n) => !n.isMatched);
+  public unmatchedNodes = <C extends ContextType>(
+    type: C,
+    options?: UnmatchedOptions
+  ): ChildNodeType<T, C>[] => {
+    const unmatched = this.allChildNodes(type).filter((n) => !n.isMatched);
 
-    if (options?.flatten) {
-      unmatched = flatten(unmatched.map((u) => u.flatten()));
+    if (options?.ungroup) {
+      unmatched.forEach((u) => u.ungroup());
     }
-
-    const containerNodes =
-      (options?.skipInvalid !== true &&
-        this.invalidChildContainers?.concat(this.childContainers)) ||
-      this.childContainers;
-    const deepUnmatched = flatten(containerNodes.map((n) => n.unmatchedNodes(options)));
-    unmatched.push(...deepUnmatched);
-
     return unmatched;
   };
 }
@@ -421,7 +359,3 @@ export type NodeType<T> = ContainerNode<T> | DataNode<T>;
 export type ChildNodeType<T, C extends ContextType> = C extends 'container'
   ? ContainerNode<T>
   : DataNode<T>;
-export interface ChildrenList<T, C extends ContextType> {
-  valid: ChildNodeType<T, C>[];
-  invalid?: ChildNodeType<T, C>[];
-}

--- a/tests/TestResults/match-by-context.test.ts
+++ b/tests/TestResults/match-by-context.test.ts
@@ -18,7 +18,7 @@ describe('buildAssertionContainer', () => {
     const root = match.buildAssertionContainer([a1, a3, a2]);
     expect(root.childContainers).toHaveLength(0);
     expect(root.childData).toHaveLength(3);
-    expect(root.childData.map((n) => n.zeroBasedLine)).toEqual([0, 1, 2]);
+    expect(root.childData.map((n) => n.zeroBasedLine)).toEqual([1, 2, 3]);
   });
   it('can build and sort assertions with ancestors', () => {
     const a1 = helper.makeAssertion('test-1', 'KnownSuccess', [], [1, 0]);
@@ -37,10 +37,10 @@ describe('buildAssertionContainer', () => {
     expect(root.childContainers).toHaveLength(2);
     expect(root.childData).toHaveLength(1);
     expect(root.childContainers.map((n) => [n.name, n.zeroBasedLine])).toEqual([
-      ['d-1', 1],
-      ['d-2', 4],
+      ['d-1', 2],
+      ['d-2', 5],
     ]);
-    expect(root.childData.map((n) => [n.name, n.zeroBasedLine])).toEqual([['test-1', 0]]);
+    expect(root.childData.map((n) => [n.name, n.zeroBasedLine])).toEqual([['test-1', 1]]);
     // the original assertion integrity should not be changed
     expect(
       [a1, a5, a3, a2, a4, a6].every((a) => a.fullName === a.title || a.ancestorTitles.length > 0)
@@ -54,7 +54,7 @@ describe('buildAssertionContainer', () => {
     const root = match.buildAssertionContainer([a1, a3, a4, a2]);
     expect(root.childContainers).toHaveLength(0);
     expect(root.childData).toHaveLength(2);
-    expect(root.childData.map((n) => n.zeroBasedLine)).toEqual([1, 4]);
+    expect(root.childData.map((n) => n.zeroBasedLine)).toEqual([2, 5]);
     const groupNode = root.childData[0];
     expect(groupNode.getAll().map((n) => n.data.title)).toEqual(['test-1', 'test-3', 'test-2']);
   });
@@ -66,10 +66,10 @@ describe('buildAssertionContainer', () => {
     const root = match.buildAssertionContainer([a1, a2, a3, a4]);
     expect(root.childContainers).toHaveLength(1);
     expect(root.childData).toHaveLength(1);
-    expect(root.childData[0]).toMatchObject({ zeroBasedLine: 4, name: 'test-2' });
+    expect(root.childData[0]).toMatchObject({ zeroBasedLine: 5, name: 'test-2' });
 
     const describeNode = root.childContainers[0];
-    expect(describeNode).toMatchObject({ zeroBasedLine: 1, name: 'd-1' });
+    expect(describeNode).toMatchObject({ zeroBasedLine: 2, name: 'd-1' });
     expect(describeNode.group?.map((n) => n.name)).toEqual(['d-2', 'd-3']);
   });
 

--- a/tests/TestResults/match-node.test.ts
+++ b/tests/TestResults/match-node.test.ts
@@ -1,0 +1,60 @@
+jest.unmock('../../src/TestResults/match-node');
+jest.unmock('../test-helper');
+
+import { BaseNode } from '../../src/TestResults/match-node';
+// import * as helper from '../test-helper';
+
+describe('BaseNode', () => {
+  describe('match', () => {
+    it.each`
+      attrs1                                    | attrs2                                        | options                                                      | shouldMatch | addGroup
+      ${{ fullName: 'x n1' }}                   | ${{ fullName: 'x n1' }}                       | ${undefined}                                                 | ${true}     | ${false}
+      ${{ fullName: 'x n1' }}                   | ${{ fullName: 'y n1' }}                       | ${undefined}                                                 | ${false}    | ${false}
+      ${{ fullName: 'x n1', isGroup: 'maybe' }} | ${{ fullName: 'x n1', nonLiteralName: true }} | ${undefined}                                                 | ${true}     | ${false}
+      ${{ fullName: 'x n1', isGroup: 'maybe' }} | ${{ fullName: 'y n1', nonLiteralName: true }} | ${undefined}                                                 | ${false}    | ${false}
+      ${{ fullName: 'x n1', isGroup: 'maybe' }} | ${{ fullName: 'y n1', nonLiteralName: true }} | ${{ ignoreNonLiteralNameDiff: true }}                        | ${true}     | ${false}
+      ${{ fullName: 'x n1', isGroup: 'maybe' }} | ${{ fullName: 'y n1' }}                       | ${{ ignoreNonLiteralNameDiff: true }}                        | ${false}    | ${false}
+      ${{ fullName: 'x n1' }}                   | ${{ fullName: 'y n1', nonLiteralName: true }} | ${{ ignoreNonLiteralNameDiff: true }}                        | ${false}    | ${false}
+      ${{ fullName: 'x n1' }}                   | ${{ fullName: 'y n1', nonLiteralName: true }} | ${{ ignoreNonLiteralNameDiff: true }}                        | ${false}    | ${true}
+      ${{ fullName: 'x n1' }}                   | ${{ fullName: 'y n1', nonLiteralName: true }} | ${{ ignoreNonLiteralNameDiff: true, ignoreGroupDiff: true }} | ${true}     | ${true}
+    `(
+      'checks names and groups: $attrs1 and $attrs2 $addGroup => $shouldMatch',
+      ({ attrs1, attrs2, options, shouldMatch, addGroup }) => {
+        const n1 = new BaseNode('n1', 10, attrs1);
+        const n2 = new BaseNode('n2', 20, attrs2);
+        if (addGroup) {
+          n1.addGroupMember(new BaseNode('n3', 10));
+        }
+        expect(n1.match(n2, options)).toEqual(shouldMatch);
+      }
+    );
+    it.each`
+      loc1         | loc2         | options                    | shouldMatch
+      ${[10, 10]}  | ${[0, 1]}    | ${undefined}               | ${true}
+      ${[10, 10]}  | ${[0, 1]}    | ${{ checkIsWithin: true }} | ${false}
+      ${[10, 10]}  | ${[0, 100]}  | ${undefined}               | ${true}
+      ${[10, 10]}  | ${[0, 100]}  | ${{ checkIsWithin: true }} | ${true}
+      ${undefined} | ${undefined} | ${undefined}               | ${true}
+      ${undefined} | ${undefined} | ${{ checkIsWithin: true }} | ${false}
+      ${undefined} | ${[0, 100]}  | ${{ checkIsWithin: true }} | ${false}
+      ${[10, 10]}  | ${undefined} | ${{ checkIsWithin: true }} | ${false}
+      ${[10, 10]}  | ${[10, 10]}  | ${{ checkIsWithin: true }} | ${true}
+      ${[1, 100]}  | ${[1, 1]}    | ${{ checkIsWithin: true }} | ${false}
+    `(
+      'check location: $loc1 isWithin $loc2? $shouldMatch',
+      ({ loc1, loc2, options, shouldMatch }) => {
+        const range1 = loc1 && { start: loc1[0], end: loc1[1] };
+        const range2 = loc2 && { start: loc2[0], end: loc2[1] };
+        const n1 = new BaseNode('n1', 10, {
+          fullName: 'n1',
+          range: range1,
+        });
+        const n2 = new BaseNode('n1', 20, {
+          fullName: 'n1',
+          range: range2,
+        });
+        expect(n1.match(n2, options)).toEqual(shouldMatch);
+      }
+    );
+  });
+});

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -37,18 +37,28 @@ export const findResultForTest = (results: TestResult[], itBlock: ItBlock): Test
 };
 
 // factory method
-export const makeItBlock = (name?: string, pos?: [number, number, number, number]): any => {
+export const makeItBlock = (
+  name?: string,
+  pos?: [number, number, number, number],
+  override?: Partial<ItBlock>
+): any => {
   const loc = pos ? makePositionRange(pos) : EmptyLocationRange;
   return {
     type: 'it',
     name,
     ...loc,
+    ...(override ?? {}),
   };
 };
-export const makeDescribeBlock = (name: string, itBlocks: any[]): any => ({
+export const makeDescribeBlock = (
+  name: string,
+  itBlocks: any[],
+  override?: Partial<ItBlock>
+): any => ({
   type: 'describe',
   name,
   children: itBlocks,
+  ...(override ?? {}),
 });
 export const makeRoot = (children: any[]): any => ({
   type: 'root',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "noUnusedParameters": true,
     "target": "es6",
     "outDir": "out",
-    "lib": ["es6", "es7"],
+    "lib": ["es6", "es7", "es2019"],
     "sourceMap": true,
     "rootDir": ".",
     "plugins": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,6 +126,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
+  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
 "@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
@@ -154,10 +159,10 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
   integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
 
-"@babel/parser@^7.8.3":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
-  integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
+"@babel/parser@^7.14.4":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.5.tgz#4cd2f346261061b2518873ffecdf1612cb032829"
+  integrity sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -282,6 +287,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.14.4":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
+  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -3518,14 +3531,14 @@ jest-each@^26.6.2:
     jest-util "^26.6.2"
     pretty-format "^26.6.2"
 
-jest-editor-support@^28.2.0:
-  version "28.2.0"
-  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-28.2.0.tgz#20e1aa1cfa4f83566d2da7fce5cb17c2ca3a4ba2"
-  integrity sha512-lvhYKh6F4h+XRVLvBPpkN3Dz6Qeh5tlvrc9UZWCI6zoAY6s/UIe/rbKYORKer0uEjbFmLrjHKDNUhclzNTNjkA==
+jest-editor-support@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-29.0.0.tgz#7cf6ed9dd5d508699d1ead2f463a578992807a94"
+  integrity sha512-0+QMBwFs9U2u4TkQTIHkR+ulXr9A2E4D/GQZBacx0p54TSk6KbuijoFbxbZWzGrcRP7EwbxdVnFmzk8L1zN0Ug==
   dependencies:
-    "@babel/parser" "^7.8.3"
+    "@babel/parser" "^7.14.4"
     "@babel/traverse" "^7.6.2"
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.14.4"
     "@jest/types" "^26.6.2"
     core-js "^3.2.1"
     jest-snapshot "^26.6.2"


### PR DESCRIPTION
This PR aims to work around v4 test result match-related issues due to various external factors. Mainly by adding "match-by-name" and "match-by-location" as the fallback mechanism when context-match failed for whatever reason.

This PR has a dependency on jest-community/jest-editor-support#71

-------

fix #719
fix #715
fix #697