### PR TITLE
allow parsing multiple test result arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug-fixes within the same version aren't needed
 * move save related operations to new SaveTextDocument event listeners to prevent duplicate firing and losing test state for watch-mode + clean-doc-save combination. - @connectdotz
 * move testFile state to ResultProvider that provides a union of test-files and actual results, to be more robust even when there is a race condition when fileList comes after test run. - @connectdotz 
 * convert to upper-case drive letter for ProjectWorkspace rootPath - @connectdotz
+* fix test file parsing for multiple array situation (#699) - @connectdotz
 -->
 
 ### 4.0.2

--- a/src/JestExt/process-listeners.ts
+++ b/src/JestExt/process-listeners.ts
@@ -123,15 +123,14 @@ export class ListTestFileListener extends AbstractProcessListener {
         this.logging('debug', 'no test file is found');
         return this.onResult([]);
       }
-      if (json.length === 1) {
-        const files: string[] = JSON.parse(json[0]);
+      const uriFiles = json.reduce((totalFiles, list) => {
+        const files: string[] = JSON.parse(list);
         // convert to uri style filePath to match vscode document names
-        const uriFiles = files.map((f) => vscode.Uri.file(f).fsPath);
-        this.logging('debug', `got ${uriFiles.length} test files`);
+        return totalFiles.concat(files.filter((f) => f).map((f) => vscode.Uri.file(f).fsPath));
+      }, [] as string[]);
 
-        return this.onResult(uriFiles);
-      }
-      throw new Error('unexpected result');
+      this.logging('debug', `got ${uriFiles.length} test files`);
+      return this.onResult(uriFiles);
     } catch (e) {
       this.logging('warn', 'failed to parse result:', this.buffer, 'error=', e);
       return this.onResult(undefined, e);

--- a/tests/JestExt/process-listeners.test.ts
+++ b/tests/JestExt/process-listeners.test.ts
@@ -65,7 +65,9 @@ describe('jest process listeners', () => {
       ${[]}                                                           | ${[]}
       ${['whatever\n', '["file1", "file', '2", "file3"]']}            | ${['file1', 'file2', 'file3']}
       ${['["/a/b", "a/c"]']}                                          | ${['/a/b', 'a/c']}
-      ${['["/a/b", "a/c"]\n', '["a","b","c"]']}                       | ${'unexpected result'}
+      ${['["/a/b", "", "a/c"]']}                                      | ${['/a/b', 'a/c']}
+      ${['["/a/b"]\n[""]\n["a/c"]\n']}                                | ${['/a/b', 'a/c']}
+      ${['["/a/b", "a/c"]\n', '["a","b"]']}                           | ${['/a/b', 'a/c', 'a', 'b']}
       ${['[a, b]']}                                                   | ${'Unexpected token'}
       ${['on windows with some error\n', '["C:\\\\a\\\\b.test.js"]']} | ${['C:\\a\\b.test.js']}
     `('can extract and notify file list from valid $output', ({ output, expectedFiles }) => {


### PR DESCRIPTION
Looks like `jest --listTests --json` could indeed return more than 1 array as seen in #699 ([comment](https://github.com/jest-community/vscode-jest/issues/699#issuecomment-856049660)).

fix the parsing to allow multiple matches.

fix #699