### PR TITLE
Fix type for contributes.configuration.properties.jest.autoRun

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
         },
         "jest.autoRun": {
           "markdownDescription": "Control when jest should run (changed) tests. It supports multiple models, such as fully automated, fully manual and onSave... See [AutoRun](https://github.com/jest-community/vscode-jest/blob/master/README.md#how-to-trigger-the-test-run) for details and examples",
-          "type": "object",
+          "type": ["object", "string"],
           "default": null,
           "scope": "resource"
         }


### PR DESCRIPTION
Per the documentation, this should be a valid configuration:
```json
// settings.json
{
	"jest.autoRun": "off"
}
```

However, I get the following warning when using this configuration:
![image](https://user-images.githubusercontent.com/13475532/122940586-99688c00-d342-11eb-9db6-c5b84ebb36d1.png)

This PR should fix this issue.
