### PR TITLE
make autoRun configuration schema more accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
-* fix type warning in settings.json when using the `{"autoRun": "off"}` option
+* fix type warning in settings.json when using the `{"autoRun": "off"}` option - @tommy
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please add your own contribution below inside the Master section
 Bug-fixes within the same version aren't needed
 
 ## Master
+* fix type warning in settings.json when using the `{"autoRun": "off"}` option
 
 -->
 

--- a/package.json
+++ b/package.json
@@ -190,7 +190,11 @@
         },
         "jest.autoRun": {
           "markdownDescription": "Control when jest should run (changed) tests. It supports multiple models, such as fully automated, fully manual and onSave... See [AutoRun](https://github.com/jest-community/vscode-jest/blob/master/README.md#how-to-trigger-the-test-run) for details and examples",
-          "type": "object",
+          "type": [
+            "object",
+            "string",
+            "null"
+          ],
           "default": null,
           "scope": "resource"
         }


### PR DESCRIPTION
This prevents VSCode from displaying a problem on the settings file for 1) the default configuration value of null, and 2) the "off" setting.

`yarn lint && yarn test && yarn vscode:prepublish` passes, and I've attached a gif showing the new messaging.

![vscode-jest-schema](https://user-images.githubusercontent.com/27465/124034344-ed611980-d9af-11eb-9481-c58e45da8ad8.gif)

Hope you'll consider this small PR, and thanks for maintaining this excellent extension!