### PR TITLE
fix a few match issues and prepare for test provider support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ os:
 
 script:
   - yarn ci
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js -v
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
   - yarn vscode:prepublish
   
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ os:
 
 script:
   - yarn ci
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js -v
   - yarn vscode:prepublish
   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 * fix type warning in settings.json when using the `{"autoRun": "off"}` option - @tommy
+* fix couple of test result matching issues - @connectdotz
+* update match API/attributes to support up-coming vscode test provider API. - @connectdotz
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Bug-fixes within the same version aren't needed
 
 ## Master
 * fix type warning in settings.json when using the `{"autoRun": "off"}` option - @tommy
-* fix couple of test result matching issues - @connectdotz
-* update match API/attributes to support up-coming vscode test provider API. - @connectdotz
+* fix couple of test result matching issues - @connectdotz (#737)
+* update match API/attributes to support up-coming vscode test provider API. - @connectdotz (#737)
 
 -->
 

--- a/src/TestResults/match-by-context.ts
+++ b/src/TestResults/match-by-context.ts
@@ -27,6 +27,8 @@ import {
   ROOT_NODE_NAME,
   OptionalAttributes,
   MatchEvent,
+  NodeType,
+  MatchOptions,
 } from './match-node';
 
 export const buildAssertionContainer = (
@@ -46,7 +48,10 @@ export const buildAssertionContainer = (
         new DataNode(a.title, zeroBasedLine, a, {
           fullName: a.fullName,
           isGroup: 'maybe',
-          range: { start: zeroBasedLine, end: zeroBasedLine },
+          range: {
+            start: { line: zeroBasedLine, column: 0 },
+            end: { line: zeroBasedLine, column: 0 },
+          },
         })
       );
     });
@@ -57,6 +62,7 @@ export const buildAssertionContainer = (
   return root;
 };
 
+const UnknownRange = { start: { line: -1, column: -1 }, end: { line: -1, column: -1 } };
 export const buildSourceContainer = (sourceRoot: ParsedNode): ContainerNode<ItBlock> => {
   const isDescribeBlock = (node: ParsedNode): node is DescribeBlock => node.type === 'describe';
   const isItBlock = (node: ParsedNode): node is ItBlock => node.type === 'it';
@@ -65,7 +71,10 @@ export const buildSourceContainer = (sourceRoot: ParsedNode): ContainerNode<ItBl
     const attrs = (namedNode: NamedBlock): OptionalAttributes => ({
       isGroup: namedNode.lastProperty === 'each' ? 'yes' : 'no',
       nonLiteralName: namedNode.nameType !== 'Literal',
-      range: { start: namedNode.start?.line - 1 ?? -1, end: namedNode.end?.line - 1 ?? -1 },
+      range: {
+        start: namedNode.start ? adjustLocation(namedNode.start) : UnknownRange.start,
+        end: namedNode.end ? adjustLocation(namedNode.end) : UnknownRange.end,
+      },
     });
     if (isDescribeBlock(node)) {
       container = new ContainerNode(node.name, attrs(node));
@@ -95,7 +104,10 @@ const matchPos = (t: ItBlock, a: TestAssertionStatus, forError = false): boolean
 };
 
 // could not use "instanceof" check as it could fail tests that mocked jest-editor-support like in TestResultProvider.test.ts
-const isDataNode = (arg: DataNode<ItBlock> | ItBlock): arg is DataNode<ItBlock> =>
+const isSourceDataNode = (arg: DataNode<ItBlock> | ItBlock): arg is DataNode<ItBlock> =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (arg as any).data;
+const isDataNode = (arg: NodeType<unknown>): arg is DataNode<unknown> =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (arg as any).data;
 
@@ -104,7 +116,7 @@ export const toMatchResult = (
   assertionOrErr: DataNode<TestAssertionStatus> | string,
   reason: MatchEvent
 ): TestResult => {
-  const [test, sourceHistory, sourceName] = isDataNode(source)
+  const [test, sourceHistory, sourceName] = isSourceDataNode(source)
     ? [source.data, source.history(reason), source.fullName]
     : [source, [reason], source.name];
   const [assertion, assertionHistory, err] =
@@ -176,11 +188,28 @@ interface FallbackMatchResult<C extends ContextType> {
 }
 
 type ClassicMatchType = 'by-name' | 'by-location';
+type MaybeTestResult<C extends boolean> = C extends true ? TestResult : undefined;
 
 const ContextMatch = (): ContextMatchAlgorithm => {
+  const onMatch = <C extends boolean>(
+    tNode: NodeType<ItBlock>,
+    aNode: NodeType<TestAssertionStatus>,
+    event: MatchEvent,
+    generateResult: C
+  ): MaybeTestResult<C> => {
+    tNode.addEvent(event);
+    aNode.addEvent(event);
+    aNode.attrs.range = tNode.attrs.range;
+
+    if (generateResult && isDataNode(tNode) && isDataNode(aNode)) {
+      return toMatchResult(tNode, aNode, event) as MaybeTestResult<C>;
+    }
+    return undefined as MaybeTestResult<C>;
+  };
   const handleTestBlockMatch = (
     result: MatchResultType<'data'>,
-    reportUnmatch: boolean
+    reportUnmatch = false,
+    matchGroup = true
   ): TestResult[] => {
     const [t, matched, reason] = result;
     if (matched.length === 0) {
@@ -190,31 +219,45 @@ const ContextMatch = (): ContextMatchAlgorithm => {
       return [];
     }
 
-    return matched.flatMap((a) => a.getAll().map((aa) => toMatchResult(t, aa, reason)));
+    return matched.flatMap((a) =>
+      matchGroup
+        ? a.getAll().map((aa) => onMatch(t, aa, reason, true))
+        : onMatch(t, a, reason, true)
+    );
   };
 
-  const handleDescribeBlockMatch = (result: MatchResultType<'container'>): TestResult[] => {
+  const handleDescribeBlockMatch = (
+    result: MatchResultType<'container'>,
+    matchGroup = true
+  ): TestResult[] => {
     const [t, matched, reason] = result;
     if (matched.length === 0) {
       return [];
     }
-
     t.addEvent(reason);
-    return matched.flatMap((a) => {
-      a.addEvent(reason);
+    const _matchContainers = (a: ContainerNode<TestAssertionStatus>) => {
+      onMatch(t, a, reason, false);
       return matchContainers(t, a);
-    });
+    };
+    return matched.flatMap((a) =>
+      matchGroup ? a.getAll().flatMap(_matchContainers) : _matchContainers(a)
+    );
   };
 
   // match methods
+  const matchByNameOptions: MatchOptions = { ignoreGroupDiff: true };
+  const matchByLocationOptions: MatchOptions = {
+    checkIsWithin: true,
+    ignoreNonLiteralNameDiff: true,
+    ignoreGroupDiff: true,
+  };
   const classicMatch = <C extends ContextType>(
     type: ClassicMatchType,
     tList: ChildNodeType<ItBlock, C>[],
     aList: ChildNodeType<TestAssertionStatus, C>[]
   ): MatchMethodResult<C> => {
     const reason = type === 'by-name' ? 'match-by-name' : 'match-by-location';
-    const options =
-      type === 'by-name' ? undefined : { checkIsWithin: true, ignoreNonLiteralNameDiff: true };
+    const options = type === 'by-name' ? matchByNameOptions : matchByLocationOptions;
     const results: MatchResultType<C>[] = [];
 
     const unmatchedT: ChildNodeType<ItBlock, C>[] = tList.filter((t) => {
@@ -236,15 +279,17 @@ const ContextMatch = (): ContextMatchAlgorithm => {
     return { unmatchedT, results };
   };
 
+  const matchByContextOptions: MatchOptions = {
+    acceptLocalNameMatch: true,
+    ignoreNonLiteralNameDiff: true,
+  };
   const matchByContext = <C extends ContextType>(
     tList: ChildNodeType<ItBlock, C>[],
     aList: ChildNodeType<TestAssertionStatus, C>[]
   ): MatchMethodResult<C> => {
     const results: MatchResultType<C>[] = [];
     if (tList.length === aList.length) {
-      const hasMismatch = tList.find(
-        (t, idx) => !aList[idx].match(t, { ignoreNonLiteralNameDiff: true })
-      );
+      const hasMismatch = tList.find((t, idx) => !aList[idx].match(t, matchByContextOptions));
       if (!hasMismatch) {
         tList.forEach((t, idx) => results.push([t, [aList[idx]], 'match-by-context']));
         return { unmatchedT: [], results };
@@ -304,13 +349,11 @@ const ContextMatch = (): ContextMatchAlgorithm => {
     const matchResults: TestResult[] = [];
 
     matchChildren('data', tContainer, aContainer, (result) =>
-      matchResults.push(...handleTestBlockMatch(result, false))
+      matchResults.push(...handleTestBlockMatch(result))
     );
     matchChildren('container', tContainer, aContainer, (result) =>
       matchResults.push(...handleDescribeBlockMatch(result))
     );
-
-    aContainer.group.forEach((c) => matchResults.push(...matchContainers(tContainer, c)));
 
     return matchResults;
   };
@@ -338,7 +381,7 @@ const ContextMatch = (): ContextMatchAlgorithm => {
         return {};
       }
 
-      let aList = aContainer.unmatchedNodes(type, { ungroup: true });
+      let aList = aContainer.unmatchedNodes(type);
       const matched = (['by-name', 'by-location'] as ClassicMatchType[]).flatMap((matchType) => {
         const matchResult = classicMatch(matchType, tList, aList);
         tList = matchResult.unmatchedT;
@@ -357,10 +400,10 @@ const ContextMatch = (): ContextMatchAlgorithm => {
     // handle unmatched container nodes
     const cFallback = doMatch('container', (r) => {
       const [t] = r;
-      return t.isMatched ? [] : handleDescribeBlockMatch(r);
+      return t.isMatched ? [] : handleDescribeBlockMatch(r, false);
     });
     // handle unmatched data nodes
-    const dFallback = doMatch('data', (r) => handleTestBlockMatch(r, false));
+    const dFallback = doMatch('data', (r) => handleTestBlockMatch(r, false, false));
 
     return {
       ...dFallback,
@@ -369,7 +412,7 @@ const ContextMatch = (): ContextMatchAlgorithm => {
   };
 
   const toUnmatchedResults = (nodes: DataNode<ItBlock>[]): TestResult[] =>
-    nodes.flatMap((t) => handleTestBlockMatch([t, [], 'match-failed'], true));
+    nodes.flatMap((t) => handleTestBlockMatch([t, [], 'match-failed'], true, false));
 
   const match = (
     tContainer: ContainerNode<ItBlock>,
@@ -413,11 +456,11 @@ const { match } = ContextMatch();
 export const matchTestAssertions = (
   fileName: string,
   sourceRoot: ParsedNode,
-  assertions: TestAssertionStatus[],
+  assertions: TestAssertionStatus[] | ContainerNode<TestAssertionStatus>,
   verbose = false
 ): TestResult[] => {
   const tContainer = buildSourceContainer(sourceRoot);
-  const aContainer = buildAssertionContainer(assertions);
+  const aContainer = Array.isArray(assertions) ? buildAssertionContainer(assertions) : assertions;
 
   const messaging = createMessaging(fileName, verbose);
   return match(tContainer, aContainer, messaging);

--- a/tests/TestResults/match-by-context.test.ts
+++ b/tests/TestResults/match-by-context.test.ts
@@ -453,6 +453,30 @@ describe('matchTestAssertions', () => {
           ])
         );
       });
+      it('deeper it.each within describe.each', () => {
+        const t1 = helper.makeItBlock('test.each $x', [1, 0, 5, 0], { lastProperty: 'each' });
+        const d1 = helper.makeDescribeBlock('d-1.each $var', [t1], { lastProperty: 'each' });
+        const d2 = helper.makeDescribeBlock('d-2', [d1]);
+        const t2 = helper.makeItBlock('empty test', [6, 0, 7, 0]);
+
+        const a1 = helper.makeAssertion('`test.each a`', 'KnownSuccess', ['d-1.each 1'], [1, 0]);
+        const a2 = helper.makeAssertion('test.each b', 'KnownFail', ['d-1.each 1'], [1, 0]);
+        const a3 = helper.makeAssertion('test.each a', 'KnownSuccess', ['d-1.each 2'], [1, 0]);
+        const a4 = helper.makeAssertion('test.each b', 'KnownSuccess', ['d-1.each 2'], [1, 0]);
+
+        const sourceRoot = helper.makeRoot([d2, t2]);
+        const matched = match.matchTestAssertions('a file', sourceRoot, [a1, a2, a3, a4]);
+        // expect(matched).toHaveLength(5);
+        expect(matched.map((m) => [m.name, m.start.line, m.status, reason(m)])).toEqual(
+          expect.arrayContaining([
+            [a1.fullName, t1.start.line - 1, a1.status, 'match-by-location'],
+            [a2.fullName, t1.start.line - 1, a2.status, 'match-by-location'],
+            [a3.fullName, t1.start.line - 1, a3.status, 'match-by-location'],
+            [a4.fullName, t1.start.line - 1, a4.status, 'match-by-location'],
+            [t2.name, t2.start.line - 1, 'Unknown', 'match-failed'],
+          ])
+        );
+      });
     });
   });
   it('test name precedence: assertion.fullName > assertion.title > testSource.name', () => {
@@ -847,5 +871,46 @@ describe('matchTestAssertions', () => {
         [a3.fullName, t2.start.line - 1, a3.status, ['match-by-location']],
       ]);
     });
+  });
+  it('matched assertions would be updated with source range', () => {
+    const getRange = (t) => ({
+      start: { line: t.start.line - 1, column: t.start.column - 1 },
+      end: { line: t.end.line - 1, column: t.end.column - 1 },
+    });
+    const t1 = helper.makeItBlock('a test $seq', [2, 5, 6, 51], { lastProperty: 'each' });
+    const d1 = helper.makeDescribeBlock('desc-1', [t1], {
+      start: { line: 1, column: 3 },
+      end: { line: 7, column: 3 },
+    });
+
+    const a1 = helper.makeAssertion('a test 1', 'KnownSuccess', ['desc-1'], [3, 0]);
+    const a2 = helper.makeAssertion('a test 2 ', 'KnownFail', ['desc-1'], [3, 0]);
+
+    const sourceRoot = helper.makeRoot([d1]);
+    const assertionRoot = match.buildAssertionContainer([a1, a2]);
+    const matched = match.matchTestAssertions('a file', sourceRoot, assertionRoot);
+
+    expect(matched.map((m) => toTestResultRecord(m))).toMatchTestResults([
+      [a1.fullName, t1.start.line - 1, a1.status, ['match-by-context']],
+      [a2.fullName, t1.start.line - 1, a2.status, ['match-by-context']],
+    ]);
+    const assertionDescribe = assertionRoot.childContainers[0];
+    expect(assertionDescribe.attrs.range).toEqual(getRange(d1));
+    expect(assertionDescribe.attrs.range).toEqual(getRange(d1));
+    assertionDescribe.childData.forEach((c) => expect(c.attrs.range).toEqual(getRange(t1)));
+  });
+
+  // see https://github.com/jest-community/vscode-jest/issues/608#issuecomment-849770258
+  it('dynamic named describe block should work for match-by-context (#608)', () => {
+    const t1 = helper.makeItBlock('simple test', [1, 0, 6, 0]);
+    const d1 = helper.makeDescribeBlock('`with ${TemplateLiteral}`', [t1]);
+
+    const a1 = helper.makeAssertion('simple test', 'KnownSuccess', ['with whatever'], [1, 0]);
+    const sourceRoot = helper.makeRoot([d1]);
+    const matched = match.matchTestAssertions('a file', sourceRoot, [a1]);
+
+    expect(matched.map((m) => toTestResultRecord(m))).toMatchTestResults([
+      [a1.fullName, t1.start.line - 1, a1.status, ['match-by-context']],
+    ]);
   });
 });

--- a/tests/TestResults/match-by-context.test.ts
+++ b/tests/TestResults/match-by-context.test.ts
@@ -901,7 +901,7 @@ describe('matchTestAssertions', () => {
   });
 
   // see https://github.com/jest-community/vscode-jest/issues/608#issuecomment-849770258
-  it('dynamic named describe block should work for match-by-context (#608)', () => {
+  it('dynamic named describe block should work for match-by-context', () => {
     const t1 = helper.makeItBlock('simple test', [1, 0, 6, 0]);
     const d1 = helper.makeDescribeBlock('`with ${TemplateLiteral}`', [t1]);
 

--- a/tests/TestResults/match-node.test.ts
+++ b/tests/TestResults/match-node.test.ts
@@ -43,8 +43,14 @@ describe('BaseNode', () => {
     `(
       'check location: $loc1 isWithin $loc2? $shouldMatch',
       ({ loc1, loc2, options, shouldMatch }) => {
-        const range1 = loc1 && { start: loc1[0], end: loc1[1] };
-        const range2 = loc2 && { start: loc2[0], end: loc2[1] };
+        const range1 = loc1 && {
+          start: { line: loc1[0], column: 0 },
+          end: { line: loc1[1], column: 0 },
+        };
+        const range2 = loc2 && {
+          start: { line: loc2[0], column: 0 },
+          end: { line: loc2[1], column: 0 },
+        };
         const n1 = new BaseNode('n1', 10, {
           fullName: 'n1',
           range: range1,


### PR DESCRIPTION
- address these match related issues:
  - when describe block has non-literal name, the match-by-context can still fail even the test names matched. (#608)
  - edge case where we could drop parameterized tests during fallback match when "ungroup" tests.

- minor changes in preparing for the up-coming vscode test API:
  - update assertion range for matched nodes
  - allow match API to accept pre-built ContainerNode as well as list of assertions

----
resubmitted to test travis/coveralls
fixes #608