### PR TITLE
migrate ci to github actions

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,102 @@
+name: Node CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+
+  prepare-yarn-cache:
+    name: Prepare yarn cache
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: yarn
+
+      - name: Validate cache
+        run: yarn --immutable
+
+  lint-danger-typecheck:
+    name: Running TypeScript compiler & ESLint
+    runs-on: ubuntu-latest
+    needs: prepare-yarn-cache
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: yarn
+      - name: install
+        run: yarn --immutable
+      - name: Danger
+        run: yarn danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: run tsc
+        run: yarn tsc
+      - name: run eslint
+        run: yarn lint
+      
+  test:
+    name: Testing on ${{ matrix.os }} with Node v${{ matrix.node-version }} 
+    strategy:
+      matrix:
+        node-version: [14.x]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    needs: prepare-yarn-cache
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - name: install
+        run: yarn --immutable
+        
+      - name: test prepublish
+        run: yarn vscode:prepublish
+        
+      - name: test
+        run: yarn test
+          
+  coverage:
+    name: Checking Coverage 
+    runs-on: ubuntu-latest
+    needs: prepare-yarn-cache
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: yarn
+      - name: install
+        run: yarn --immutable
+        
+      - name: test with coverage
+        run: yarn test --coverage
+                
+      - name: Coveralls 
+        uses: coverallsapp/github-action@master
+        env:
+          NODE_COVERALLS_DEBUG: 1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
we have exhausted travis-ci.com free credit, so migrating to github actions for ci testing