### PR TITLE
✏️ fix Typo in command palette action

### DIFF
--- a/src/setup-wizard/tasks/setup-jest-debug.ts
+++ b/src/setup-wizard/tasks/setup-jest-debug.ts
@@ -162,7 +162,7 @@ export const setupJestDebug: SetupTask = async (context: WizardContext): Promise
       actionItem(
         DebugSetupActionId.acceptExisting,
         '$(check) Use current',
-        'aceept then current debug config without change',
+        'accept the current debug config without change',
         () => {
           message('jest debug config did not change');
           return Promise.resolve('success');


### PR DESCRIPTION
This PR purpose is to fix a basic typo that occurs in the command palette.

More information on issue #758 

#trivial