### PR TITLE
remove release message

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Danger
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          DEBUG="*"
         run: yarn danger ci
       - name: run tsc
         run: yarn tsc

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Danger
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
-          DEBUG="*"
         run: yarn danger ci
       - name: run tsc
         run: yarn tsc

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -43,10 +43,13 @@ jobs:
           cache: yarn
       - name: install
         run: yarn --immutable
+
+      # can only post comment from report itself, not from the forked PR
       - name: Danger
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
         run: yarn danger ci
+
       - name: run tsc
         run: yarn tsc
       - name: run eslint

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -44,9 +44,9 @@ jobs:
       - name: install
         run: yarn --immutable
       - name: Danger
-        run: yarn danger ci
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+        run: yarn danger ci
       - name: run tsc
         run: yarn tsc
       - name: run eslint

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -47,7 +47,7 @@ jobs:
       # can only post comment from report itself, not from the forked PR
       - name: Danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn danger ci
 
       - name: run tsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Please add your own contribution below inside the Master section
 * brief change description - @author
 -->
 
+### 4.1.2
+* remove release message - @connectdotz (#763)
+* hacking CI danger file to report error directly - @connectdotz (#763)
 ### 4.1.1
 * show release message once per workspace - @connetdotz (#756)
 ### 4.1.0

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -8,8 +8,8 @@ const isForkedRepo = (): boolean => {
   if (headRepoName !== baseRepoName) {
     // This is shown inline in the output and also integrates with the GitHub
     // Action reporting UI and produces a warning
-    console.warn(
-      "Running from a forked repo. Danger won't be able to post comments, you will most likely see a 403 error below..."
+    console.log(
+      "::warning::Running from a forked repo. Danger won't be able to post comments, you will most likely see a 403 error below..."
     );
     return true;
   }
@@ -38,7 +38,7 @@ if (modifiedAppFiles.length > 0 && !trivialPR && !changelogChanges) {
   const message =
     '**No CHANGELOG added.** If this is a small PR, or a bug-fix for an unreleased bug add `#trivial` to your PR message and re-run CI.';
   if (isForkedRepo()) {
-    console.error(message);
+    console.log(`::error::${message}`);
   }
   fail(message);
 }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,24 +1,49 @@
-import { danger, fail } from 'danger'
-import * as fs from 'fs'
+import { danger, fail } from 'danger';
+import * as fs from 'fs';
 
-const pr = danger.github.pr
-const modified = danger.git.modified_files
-const bodyAndTitle = (pr.body + pr.title).toLowerCase()
-const trivialPR = bodyAndTitle.includes('#trivial')
+const isForkedRepo = (): boolean => {
+  const headRepoName = danger.github.pr.head.repo.full_name;
+  const baseRepoName = danger.github.pr.base.repo.full_name;
 
-const typescriptOnly = (file: string) => file.includes('.ts')
-const filesOnly = (file: string) => fs.existsSync(file) && fs.lstatSync(file).isFile()
+  if (headRepoName !== baseRepoName) {
+    // This is shown inline in the output
+    console.log(
+      "\033[1;31mRunning from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m"
+    );
+
+    // This is shown inline in the output and also integrates with the GitHub
+    // Action reporting UI and produces a warning
+    console.log(
+      "##[warning]Running from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m"
+    );
+    return true;
+  }
+  return false;
+};
+
+const pr = danger.github.pr;
+const modified = danger.git.modified_files;
+const bodyAndTitle = (pr.body + pr.title).toLowerCase();
+const trivialPR = bodyAndTitle.includes('#trivial');
+
+const typescriptOnly = (file: string) => file.includes('.ts');
+const filesOnly = (file: string) => fs.existsSync(file) && fs.lstatSync(file).isFile();
 
 // Custom subsets of known files
-const modifiedAppFiles = modified.filter(p => p.includes('src/')).filter(p => filesOnly(p) && typescriptOnly(p))
+const modifiedAppFiles = modified
+  .filter((p) => p.includes('src/'))
+  .filter((p) => filesOnly(p) && typescriptOnly(p));
 
 // Rules
 
 // When there are app-changes and it's not a PR marked as trivial, expect
 // there to be CHANGELOG changes.
-const changelogChanges = modified.includes('CHANGELOG.md')
+const changelogChanges = modified.includes('CHANGELOG.md');
 if (modifiedAppFiles.length > 0 && !trivialPR && !changelogChanges) {
-  fail(
-    '**No CHANGELOG added.** If this is a small PR, or a bug-fix for an unreleased bug add `#trivial` to your PR message and re-run CI.'
-  )
+  const message =
+    '**No CHANGELOG added.** If this is a small PR, or a bug-fix for an unreleased bug add `#trivial` to your PR message and re-run CI.';
+  if (isForkedRepo()) {
+    console.log(`\033[1;31m${message}\033[0m`);
+  }
+  fail(message);
 }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -6,15 +6,10 @@ const isForkedRepo = (): boolean => {
   const baseRepoName = danger.github.pr.base.repo.full_name;
 
   if (headRepoName !== baseRepoName) {
-    // This is shown inline in the output
-    console.log(
-      "\033[1;31mRunning from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m"
-    );
-
     // This is shown inline in the output and also integrates with the GitHub
     // Action reporting UI and produces a warning
-    console.log(
-      "##[warning]Running from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m"
+    console.warn(
+      "Running from a forked repo. Danger won't be able to post comments, you will most likely see a 403 error below..."
     );
     return true;
   }
@@ -43,7 +38,7 @@ if (modifiedAppFiles.length > 0 && !trivialPR && !changelogChanges) {
   const message =
     '**No CHANGELOG added.** If this is a small PR, or a bug-fix for an unreleased bug add `#trivial` to your PR message and re-run CI.';
   if (isForkedRepo()) {
-    console.log(`\033[1;31m${message}\033[0m`);
+    console.error(message);
   }
   fail(message);
 }

--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
     "@typescript-eslint/parser": "^4.14.2",
     "copy-webpack-plugin": "^8.1.0",
     "coveralls": "^3.1.0",
-    "danger": "^10.1.1",
+    "danger": "^10.6.6",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.59.0"

--- a/src/extensionManager.ts
+++ b/src/extensionManager.ts
@@ -274,31 +274,5 @@ export class ExtensionManager {
         ext.activate();
       }
     }
-    this.showReleaseMessage();
-  }
-  private showReleaseMessage(): void {
-    const key = 'didShowMessage-4.1';
-    const didShow = this.context.workspaceState.get<boolean>(key, false);
-    if (!didShow) {
-      vscode.window
-        .showInformationMessage(
-          `vscode-jest now supports the official vscode test explorer.`,
-          'Show Test Explorer',
-          'See Details'
-        )
-        .then((value) => {
-          if (value === 'Show Test Explorer') {
-            vscode.commands.executeCommand('workbench.view.testing.focus');
-          } else if (value === 'See Details') {
-            vscode.commands.executeCommand(
-              'vscode.open',
-              vscode.Uri.parse(
-                'https://github.com/jest-community/vscode-jest/blob/master/README.md#how-to-use-the-test-explorer'
-              )
-            );
-          }
-        });
-      this.context.workspaceState.update(key, true);
-    }
   }
 }

--- a/tests/extensionManager.test.ts
+++ b/tests/extensionManager.test.ts
@@ -621,49 +621,5 @@ describe('ExtensionManager', () => {
       expect(ext1.onDidChangeActiveTextEditor).not.toBeCalled();
       expect(ext2.onDidChangeActiveTextEditor).not.toBeCalled();
     });
-    describe('can show test explore information once per workspace', () => {
-      beforeEach(() => {
-        (vscode.window.activeTextEditor as any) = undefined;
-      });
-      it('can reveal test explore view', async () => {
-        (vscode.window.showInformationMessage as jest.Mocked<any>).mockReturnValue(
-          Promise.resolve('Show Test Explorer')
-        );
-        await extensionManager.activate();
-        expect(vscode.commands.executeCommand).toBeCalledWith('workbench.view.testing.focus');
-      });
-      it('can show README document', async () => {
-        (vscode.window.showInformationMessage as jest.Mocked<any>).mockReturnValue(
-          Promise.resolve('See Details')
-        );
-        (vscode.Uri.parse as jest.Mocked<any>).mockImplementation((uri) => uri);
-        await extensionManager.activate();
-        expect(vscode.commands.executeCommand).toBeCalledWith(
-          'vscode.open',
-          expect.stringContaining(
-            'jest-community/vscode-jest/blob/master/README.md#how-to-use-the-test-explorer'
-          )
-        );
-      });
-      it('if close without selecting any action, should exit with no-op', async () => {
-        (vscode.window.showInformationMessage as jest.Mocked<any>).mockReturnValue(
-          Promise.resolve(undefined)
-        );
-        await extensionManager.activate();
-        expect(vscode.commands.executeCommand).not.toBeCalled();
-      });
-      it('will not show again once it has been seen', async () => {
-        (vscode.window.showInformationMessage as jest.Mocked<any>).mockReturnValue(
-          Promise.resolve('Show Test Explorer')
-        );
-        await extensionManager.activate();
-        expect(vscode.window.showInformationMessage).toBeCalled();
-
-        (vscode.window.showInformationMessage as jest.Mocked<any>).mockClear();
-
-        await extensionManager.activate();
-        expect(vscode.window.showInformationMessage).not.toBeCalled();
-      });
-    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,
+    "allowSyntheticDefaultImports": true,
     "noUnusedParameters": true,
     "target": "es6",
     "outDir": "out",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,10 +1825,10 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-danger@^10.1.1:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-10.1.1.tgz#25400316f27720f14059476c6b9ab40d96564681"
-  integrity sha512-kRJW7TrVYe3nzTILRahXuEvG/+EZwyHrDXTTHA6nkd+4Ga+F4A4AFNkT7d0hEi7OlhhVx8W9BkxNcSO1xEJrAA==
+danger@^10.6.6:
+  version "10.6.6"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-10.6.6.tgz#d9861506dc70eb98c5f00754b520f32e86400dcc"
+  integrity sha512-RBqANs6xbWSCqZMy3+/eIYuC9kd7g5NqJ8PqDJKylPhvBoJEDkDrHQvExYHiP2UquvaZcPWsKohmOQXrosrpdw==
   dependencies:
     "@babel/polyfill" "^7.2.5"
     "@octokit/rest" "^16.43.1"
@@ -1854,7 +1854,7 @@ danger@^10.1.1:
     memfs-or-file-map-to-github-branch "^1.1.0"
     micromatch "^3.1.10"
     node-cleanup "^2.1.2"
-    node-fetch "^2.3.0"
+    node-fetch "2.6.1"
     override-require "^1.1.1"
     p-limit "^2.1.0"
     parse-diff "^0.7.0"
@@ -4489,7 +4489,7 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
-node-fetch@^2.3.0, node-fetch@^2.6.0:
+node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
Removing the release notification since 4.1 has been released over a week so most users should be pretty familiar with the new changes. It seems hard to find the right balance of informative and not-to-be-annoying... 

fix #761