### PR TITLE
add vue language support

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
       ],
       "editor/context": [
         {
-          "when": "jest:run.interactive && editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact)/ ",
+          "when": "jest:run.interactive && editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact|vue)/ ",
           "command": "io.orta.jest.editor.run-all-tests",
           "group": "Jest"
         }
@@ -319,7 +319,7 @@
         "command": "io.orta.jest.editor.run-all-tests",
         "key": "ctrl+alt+t",
         "mac": "ctrl+alt+t",
-        "when": "jest:run.interactive && editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact)/ "
+        "when": "jest:run.interactive && editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact|vue)/ "
       }
     ],
     "debuggers": [

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -488,6 +488,7 @@ export class JestExt {
         this.processSession.scheduleProcess({
           type: 'by-file',
           testFileName: name,
+          notTestFile: this.testResultProvider.isTestFile(name) !== 'yes',
         })
       ) {
         this.dirtyFiles.delete(name);
@@ -524,14 +525,15 @@ export class JestExt {
     if (!this.isSupportedDocument(document) || this.extContext.autoRun.isWatch) {
       return;
     }
+    const isTestFile = this.testResultProvider.isTestFile(document.fileName);
     if (
       this.extContext.autoRun.onSave &&
-      (this.extContext.autoRun.onSave === 'test-src-file' ||
-        this.testResultProvider.isTestFile(document.fileName) !== 'no')
+      (this.extContext.autoRun.onSave === 'test-src-file' || isTestFile !== 'no')
     ) {
       this.processSession.scheduleProcess({
         type: 'by-file',
         testFileName: document.fileName,
+        notTestFile: isTestFile !== 'yes',
       });
     } else {
       this.dirtyFiles.add(document.fileName);

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -119,7 +119,10 @@ export class JestProcess implements JestProcessInfo {
         break;
       case 'by-file': {
         options.testFileNamePattern = this.quoteFileName(this.request.testFileName);
-        args.push('--findRelatedTests', '--watchAll=false');
+        args.push('--watchAll=false');
+        if (this.request.notTestFile) {
+          args.push('--findRelatedTests');
+        }
         if (this.request.updateSnapshot) {
           args.push('--updateSnapshot');
         }

--- a/src/JestProcessManagement/types.ts
+++ b/src/JestProcessManagement/types.ts
@@ -55,6 +55,7 @@ export type JestProcessRequestBase =
       type: Extract<JestTestProcessType, 'by-file'>;
       testFileName: string;
       updateSnapshot?: boolean;
+      notTestFile?: boolean;
     }
   | {
       type: Extract<JestTestProcessType, 'by-file-test'>;

--- a/src/appGlobals.ts
+++ b/src/appGlobals.ts
@@ -5,4 +5,5 @@ export const SupportedLanguageIds = [
   'javascriptreact',
   'typescript',
   'typescriptreact',
+  'vue',
 ];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ const addSubscriptions = (context: vscode.ExtensionContext): void => {
     { language: 'javascriptreact' },
     { language: 'typescript' },
     { language: 'typescriptreact' },
+    { language: 'vue' },
   ];
 
   // command function

--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -253,7 +253,8 @@ export class WorkspaceRoot extends TestItemDataBase {
     }
   };
 
-  private getItemFromProcess = (process: JestProcessInfo): vscode.TestItem => {
+  /** get test item from jest process. If running tests from source file, will return undefined */
+  private getItemFromProcess = (process: JestProcessInfo): vscode.TestItem | undefined => {
     let fileName;
     switch (process.request.type) {
       case 'watch-tests':
@@ -270,15 +271,11 @@ export class WorkspaceRoot extends TestItemDataBase {
         throw new Error(`unsupported external process type ${process.request.type}`);
     }
 
-    const item = this.testDocuments.get(fileName)?.item;
-    if (item) {
-      return item;
-    }
-    throw new Error(`No test file found for ${fileName}`);
+    return this.testDocuments.get(fileName)?.item;
   };
 
   private createTestItemRun = (event: JestRunEvent): TestItemRun => {
-    const item = this.getItemFromProcess(event.process);
+    const item = this.getItemFromProcess(event.process) ?? this.item;
     const run = this.createRun(`${event.type}:${event.process.id}`, item);
     const end = () => {
       this.cachedRun.delete(event.process.id);

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -651,6 +651,7 @@ describe('JestExt', () => {
         ${'javascriptreact'} | ${false}
         ${'typescript'}      | ${false}
         ${'typescriptreact'} | ${false}
+        ${'vue'}             | ${false}
       `('if languageId=languageId => skip? $shouldSkip', ({ languageId, shouldSkip }) => {
         const editor = mockEditor('file', languageId);
         sut.triggerUpdateActiveEditor(editor);

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -140,7 +140,8 @@ describe('JestProcess', () => {
       ${'all-tests'}            | ${undefined}                                                     | ${[false, false]} | ${true}         | ${undefined}
       ${'watch-tests'}          | ${undefined}                                                     | ${[true, false]}  | ${true}         | ${undefined}
       ${'watch-all-tests'}      | ${undefined}                                                     | ${[true, true]}   | ${true}         | ${undefined}
-      ${'by-file'}              | ${{ testFileName: '"c:\\a\\b.ts"' }}                             | ${[false, false]} | ${true}         | ${{ args: { args: ['--findRelatedTests'] }, testFileNamePattern: '"C:\\a\\b.ts"' }}
+      ${'by-file'}              | ${{ testFileName: '"c:\\a\\b.ts"' }}                             | ${[false, false]} | ${true}         | ${{ args: { args: [] }, testFileNamePattern: '"C:\\a\\b.ts"' }}
+      ${'by-file'}              | ${{ testFileName: '"c:\\a\\b.ts"', notTestFile: true }}          | ${[false, false]} | ${true}         | ${{ args: { args: ['--findRelatedTests'] }, testFileNamePattern: '"C:\\a\\b.ts"' }}
       ${'by-file-test'}         | ${{ testFileName: '"/a/b.js"', testNamePattern: 'a test' }}      | ${[false, false]} | ${true}         | ${{ args: { args: ['--runTestsByPath'] }, testFileNamePattern: '"/a/b.js"', testNamePattern: '"a test"' }}
       ${'by-file-pattern'}      | ${{ testFileNamePattern: '"c:\\a\\b.ts"' }}                      | ${[false, false]} | ${true}         | ${{ args: { args: ['--testPathPattern', '"c:\\\\a\\\\b\\.ts"'] } }}
       ${'by-file-test-pattern'} | ${{ testFileNamePattern: '/a/b.js', testNamePattern: 'a test' }} | ${[false, false]} | ${true}         | ${{ args: { args: ['--testPathPattern', '"/a/b\\.js"'] }, testNamePattern: '"a test"' }}

--- a/tests/test-provider/test-item-data.test.ts
+++ b/tests/test-provider/test-item-data.test.ts
@@ -1092,12 +1092,13 @@ describe('test-item-data', () => {
           controllerMock.createTestRun.mockClear();
         });
         describe.each`
-          request                                                   | withFile
-          ${{ type: 'watch-tests' }}                                | ${false}
-          ${{ type: 'watch-all-tests' }}                            | ${false}
-          ${{ type: 'all-tests' }}                                  | ${false}
-          ${{ type: 'by-file', testFileName: file }}                | ${true}
-          ${{ type: 'by-file-pattern', testFileNamePattern: file }} | ${true}
+          request                                                              | withFile
+          ${{ type: 'watch-tests' }}                                           | ${false}
+          ${{ type: 'watch-all-tests' }}                                       | ${false}
+          ${{ type: 'all-tests' }}                                             | ${false}
+          ${{ type: 'by-file', testFileName: file }}                           | ${true}
+          ${{ type: 'by-file', testFileName: 'source.ts', notTestFile: true }} | ${false}
+          ${{ type: 'by-file-pattern', testFileNamePattern: file }}            | ${true}
         `('will create a new run and use it throughout: $request', ({ request, withFile }) => {
           it('if run starts before schedule returns: no enqueue', () => {
             const process = { id: 'whatever', request };


### PR DESCRIPTION
adding `vue` language id for code coverage and validation of source/test file types.

also discovered and fixed the following (not `vue `specific):

1. running `--findRelatedTests` and `--coverage` together for a test file could end up no coverage report generated. => now only apply `--findRelatedTests` for source file run.
2. source-file run output not visible in test explorer terminal => fixed.

fixes #790

updated 11/22:

[vscode-jest-4.3.0-rc.1.vsix.zip](https://github.com/jest-community/vscode-jest/files/7585826/vscode-jest-4.3.0-rc.1.vsix.2.zip)

