### PR TITLE
Fix "Commands" table formatting in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,9 @@ Currently supported variables:
   }
   ``` 
 </details>
+
 ## Commands
+
 This extension contributes the following commands and can be accessed via [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette):
 |command|description|availability|
 |---|---|---|


### PR DESCRIPTION
I think the `<details>` rendering is breaking it: https://github.com/jest-community/vscode-jest/blob/master/README.md