### PR TITLE
Enable interactive run for watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "4.3.0-rc.1",
+  "version": "4.3.0",
   "publisher": "Orta",
   "engines": {
-    "vscode": "^1.59.0"
+    "vscode": "^1.63.0"
   },
   "author": {
     "name": "Orta Therox, ConnectDotz & Sean Poulter",
@@ -443,7 +443,8 @@
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"*.json\"  \"*.js\" ",
     "test": "jest",
     "watch-test": "yarn test -- --watch",
-    "tsc": "tsc --noEmit"
+    "tsc": "tsc --noEmit",
+    "update-vscode-type": "npx vscode-dts main; mv ./vscode.d.ts ./typings"
   },
   "dependencies": {
     "istanbul-lib-coverage": "^3.0.0",

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -14,7 +14,7 @@ import {
 import { AutoRunMode } from '../StatusBar';
 import { pathToJest, pathToConfig, toFilePath } from '../helpers';
 import { workspaceLogging } from '../logging';
-import { AutoRunAccessor, JestExtContext } from './types';
+import { AutoRunAccessor, JestExtContext, RunnerWorkspaceOptions } from './types';
 import { CoverageColors } from '../Coverage';
 
 export const isWatchRequest = (request: JestProcessRequest): boolean =>
@@ -83,23 +83,26 @@ export const createJestExtContext = (
   workspaceFolder: vscode.WorkspaceFolder,
   settings: PluginResourceSettings
 ): JestExtContext => {
-  const currentJestVersion = 20;
-  const [jestCommandLine, pathToConfig] = getJestCommandSettings(settings);
-  const runnerWorkspace = new ProjectWorkspace(
-    toFilePath(settings.rootPath),
-    jestCommandLine,
-    pathToConfig,
-    currentJestVersion,
-    workspaceFolder.name,
-    settings.showCoverageOnLoad,
-    settings.debugMode,
-    settings.nodeEnv,
-    settings.shell
-  );
+  const createRunnerWorkspace = (options?: RunnerWorkspaceOptions) => {
+    const ws = workspaceFolder.name;
+    const currentJestVersion = 20;
+    const [jestCommandLine, pathToConfig] = getJestCommandSettings(settings);
+    return new ProjectWorkspace(
+      toFilePath(settings.rootPath),
+      jestCommandLine,
+      pathToConfig,
+      currentJestVersion,
+      options?.outputFileSuffix ? `${ws}_${options.outputFileSuffix}` : ws,
+      options?.collectCoverage ?? settings.showCoverageOnLoad,
+      settings.debugMode,
+      settings.nodeEnv,
+      settings.shell
+    );
+  };
   return {
     workspace: workspaceFolder,
     settings,
-    runnerWorkspace,
+    createRunnerWorkspace,
     loggingFactory: workspaceLogging(workspaceFolder.name, settings.debugMode ?? false),
     autoRun: AutoRun(settings),
   };

--- a/src/JestExt/types.ts
+++ b/src/JestExt/types.ts
@@ -26,12 +26,16 @@ export interface AutoRunAccessor {
   onStartup: OnStartupType | undefined;
   mode: AutoRunMode;
 }
+export interface RunnerWorkspaceOptions {
+  outputFileSuffix?: string;
+  collectCoverage?: boolean;
+}
 export interface JestExtContext {
   settings: PluginResourceSettings;
   workspace: vscode.WorkspaceFolder;
-  runnerWorkspace: ProjectWorkspace;
   loggingFactory: LoggingFactory;
   autoRun: AutoRunAccessor;
+  createRunnerWorkspace: (options?: RunnerWorkspaceOptions) => ProjectWorkspace;
 }
 
 export interface JestExtSessionContext extends JestExtContext {

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -118,10 +118,13 @@ export class JestProcess implements JestProcessInfo {
         }
         break;
       case 'by-file': {
-        options.testFileNamePattern = this.quoteFileName(this.request.testFileName);
+        const fileName = this.quoteFileName(this.request.testFileName);
         args.push('--watchAll=false');
         if (this.request.notTestFile) {
-          args.push('--findRelatedTests');
+          args.push('--findRelatedTests', fileName);
+        } else {
+          options.testFileNamePattern = fileName;
+          args.push('--runTestsByPath');
         }
         if (this.request.updateSnapshot) {
           args.push('--updateSnapshot');
@@ -167,7 +170,11 @@ export class JestProcess implements JestProcessInfo {
         break;
     }
 
-    const runner = new Runner(this.extContext.runnerWorkspace, options);
+    const runnerWorkspace = this.extContext.createRunnerWorkspace(
+      this.request.schedule.queue === 'blocking-2' ? { outputFileSuffix: '2' } : undefined
+    );
+
+    const runner = new Runner(runnerWorkspace, options);
     this.registerListener(runner);
 
     let taskInfo: Omit<RunnerTask, 'promise'>;

--- a/src/JestProcessManagement/types.ts
+++ b/src/JestProcessManagement/types.ts
@@ -18,7 +18,7 @@ export interface Task<T> {
   status: TaskStatus;
 }
 
-export type QueueType = 'blocking' | 'non-blocking';
+export type QueueType = 'blocking' | 'blocking-2' | 'non-blocking';
 
 /**
  * predicate to match task
@@ -43,7 +43,8 @@ interface JestProcessRequestCommon {
   schedule: ScheduleStrategy;
   listener: JestProcessListener;
 }
-export type JestProcessRequestBase =
+
+export type JestProcessRequestSimple =
   | {
       type: Extract<JestTestProcessType, 'watch-tests' | 'watch-all-tests'>;
     }
@@ -79,6 +80,11 @@ export type JestProcessRequestBase =
       args: string[];
     };
 
+export type JestProcessRequestTransform = (request: JestProcessRequest) => JestProcessRequest;
+
+export type JestProcessRequestBase = JestProcessRequestSimple & {
+  transform?: JestProcessRequestTransform;
+};
 export type JestProcessRequest = JestProcessRequestBase & JestProcessRequestCommon;
 
 export interface TaskArrayFunctions<T> {

--- a/src/test-provider/types.ts
+++ b/src/test-provider/types.ts
@@ -25,10 +25,9 @@ export interface TestItemData {
   readonly uri: vscode.Uri;
   context: JestTestProviderContext;
   discoverTest?: (run: vscode.TestRun) => void;
-  scheduleTest: (run: vscode.TestRun, end: () => void, profile: vscode.TestRunProfile) => void;
-  canRun: (profile: vscode.TestRunProfile) => boolean;
+  scheduleTest: (run: vscode.TestRun, end: () => void) => void;
 }
 
 export interface Debuggable {
-  getDebugInfo: () => { fileName: string; testNamePattern: string };
+  getDebugInfo: () => { fileName: string; testNamePattern?: string };
 }

--- a/tests/JestExt/process-session.test.ts
+++ b/tests/JestExt/process-session.test.ts
@@ -28,6 +28,10 @@ describe('ProcessSession', () => {
     context = mockJestProcessContext();
   });
   describe('scheduleProcess', () => {
+    const transform = (rRequest) => {
+      rRequest.schedule.queue = 'blocking-2';
+      return rRequest;
+    };
     it('will fire event for successful schedule', () => {
       const sm = createProcessSession(context);
 
@@ -43,15 +47,16 @@ describe('ProcessSession', () => {
       expect(context.onRunEvent.fire).toBeCalledWith({ type: 'scheduled', process });
     });
     it.each`
-      type                      | inputProperty                                                | expectedSchedule                                                                        | expectedExtraProperty
-      ${'all-tests'}            | ${undefined}                                                 | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
-      ${'watch-tests'}          | ${undefined}                                                 | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
-      ${'watch-all-tests'}      | ${undefined}                                                 | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
-      ${'by-file'}              | ${{ testFileName: 'abc' }}                                   | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
-      ${'by-file-test'}         | ${{ testFileName: 'abc', testNamePattern: 'a test' }}        | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'], filterByContent: true } }} | ${undefined}
-      ${'by-file-pattern'}      | ${{ testFileNamePattern: 'abc' }}                            | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
-      ${'by-file-test-pattern'} | ${{ testFileNamePattern: 'abc', testNamePattern: 'a test' }} | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'], filterByContent: true } }} | ${undefined}
-      ${'list-test-files'}      | ${undefined}                                                 | ${{ queue: 'non-blocking', dedup: { filterByStatus: ['pending'] } }}                    | ${{ type: 'not-test', args: ['--listTests', '--json', '--watchAll=false'] }}
+      type                      | inputProperty                                                | expectedSchedule                                                                          | expectedExtraProperty
+      ${'all-tests'}            | ${undefined}                                                 | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                          | ${undefined}
+      ${'all-tests'}            | ${{ transform }}                                             | ${{ queue: 'blocking-2', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
+      ${'watch-tests'}          | ${undefined}                                                 | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                          | ${undefined}
+      ${'watch-all-tests'}      | ${undefined}                                                 | ${{ queue: 'blocking', dedup: { filterByStatus: ['pending'] } }}                          | ${undefined}
+      ${'by-file'}              | ${{ testFileName: 'abc' }}                                   | ${{ queue: 'blocking-2', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
+      ${'by-file-test'}         | ${{ testFileName: 'abc', testNamePattern: 'a test' }}        | ${{ queue: 'blocking-2', dedup: { filterByStatus: ['pending'], filterByContent: true } }} | ${undefined}
+      ${'by-file-pattern'}      | ${{ testFileNamePattern: 'abc' }}                            | ${{ queue: 'blocking-2', dedup: { filterByStatus: ['pending'] } }}                        | ${undefined}
+      ${'by-file-test-pattern'} | ${{ testFileNamePattern: 'abc', testNamePattern: 'a test' }} | ${{ queue: 'blocking-2', dedup: { filterByStatus: ['pending'], filterByContent: true } }} | ${undefined}
+      ${'list-test-files'}      | ${undefined}                                                 | ${{ queue: 'non-blocking', dedup: { filterByStatus: ['pending'] } }}                      | ${{ type: 'not-test', args: ['--listTests', '--json', '--watchAll=false'] }}
     `(
       "can schedule '$type' request with ProcessManager",
       ({ type, inputProperty, expectedSchedule, expectedExtraProperty }) => {

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -150,7 +150,7 @@ export const mockJestExtEvents: any = () => ({
 export const mockJestExtContext = (autoRun?: AutoRunAccessor): any => {
   return {
     workspace: jest.fn(),
-    runnerWorkspace: jest.fn(),
+    createRunnerWorkspace: jest.fn(),
     settings: jest.fn(),
     loggingFactory: { create: jest.fn(() => jest.fn()) },
     autoRun: autoRun ?? jest.fn(),

--- a/tests/test-provider/test-helper.ts
+++ b/tests/test-provider/test-helper.ts
@@ -70,13 +70,20 @@ export const mockController = (): any => {
       return run;
     }),
     dispose: jest.fn(),
-    createRunProfile: jest.fn(),
+    createRunProfile: jest.fn().mockImplementation((label, kind, runHandler, isDefault, tags) => ({
+      label,
+      kind,
+      runHandler,
+      isDefault,
+      tags: tags ?? [],
+    })),
     createTestItem: jest.fn().mockImplementation((id, label, uri) => {
       const item: any = {
         id,
         label,
         uri,
         errored: jest.fn(),
+        tags: [],
       };
       item.children = new TestItemCollectionMock(item);
       return item;

--- a/typings/vscode.d.ts
+++ b/typings/vscode.d.ts
@@ -541,7 +541,7 @@ declare module 'vscode' {
 		 * The {@link TextEditorSelectionChangeKind change kind} which has triggered this
 		 * event. Can be `undefined`.
 		 */
-		readonly kind?: TextEditorSelectionChangeKind;
+		readonly kind: TextEditorSelectionChangeKind | undefined;
 	}
 
 	/**
@@ -766,8 +766,9 @@ declare module 'vscode' {
 		preserveFocus?: boolean;
 
 		/**
-		 * An optional flag that controls if an {@link TextEditor editor}-tab will be replaced
-		 * with the next editor or if it will be kept.
+		 * An optional flag that controls if an {@link TextEditor editor}-tab shows as preview. Preview tabs will
+		 * be replaced and reused until set to stay - either explicitly or through editing. The default behaviour depends
+		 * on the `workbench.editor.enablePreview`-setting.
 		 */
 		preview?: boolean;
 
@@ -817,7 +818,7 @@ declare module 'vscode' {
 		/**
 		 * The optional ThemeColor of the icon. The color is currently only used in {@link TreeItem}.
 		 */
-		readonly color?: ThemeColor;
+		readonly color?: ThemeColor | undefined;
 
 		/**
 		 * Creates a reference to a theme icon.
@@ -1106,13 +1107,13 @@ declare module 'vscode' {
 		/**
 		 * The selections in this text editor. The primary selection is always at index 0.
 		 */
-		selections: Selection[];
+		selections: readonly Selection[];
 
 		/**
 		 * The current visible ranges in the editor (vertically).
 		 * This accounts only for vertical scrolling, and not for horizontal scrolling.
 		 */
-		readonly visibleRanges: Range[];
+		readonly visibleRanges: readonly Range[];
 
 		/**
 		 * Text editor options.
@@ -1124,7 +1125,7 @@ declare module 'vscode' {
 		 * isn't one of the main editors, e.g. an embedded editor, or when the editor
 		 * column is larger than three.
 		 */
-		readonly viewColumn?: ViewColumn;
+		readonly viewColumn: ViewColumn | undefined;
 
 		/**
 		 * Perform an edit on the document associated with this text editor.
@@ -1276,16 +1277,16 @@ declare module 'vscode' {
 		 * `Uri.parse('file://' + path)` because the path might contain characters that are
 		 * interpreted (# and ?). See the following sample:
 		 * ```ts
-		const good = URI.file('/coding/c#/project1');
-		good.scheme === 'file';
-		good.path === '/coding/c#/project1';
-		good.fragment === '';
-
-		const bad = URI.parse('file://' + '/coding/c#/project1');
-		bad.scheme === 'file';
-		bad.path === '/coding/c'; // path is now broken
-		bad.fragment === '/project1';
-		```
+		 * const good = URI.file('/coding/c#/project1');
+		 * good.scheme === 'file';
+		 * good.path === '/coding/c#/project1';
+		 * good.fragment === '';
+		 *
+		 * const bad = URI.parse('file://' + '/coding/c#/project1');
+		 * bad.scheme === 'file';
+		 * bad.path === '/coding/c'; // path is now broken
+		 * bad.fragment === '/project1';
+		 * ```
 		 *
 		 * @param path A file system or UNC path.
 		 * @return A new Uri instance.
@@ -1369,11 +1370,11 @@ declare module 'vscode' {
 		 * The *difference* to the {@linkcode Uri.path path}-property is the use of the platform specific
 		 * path separator and the handling of UNC paths. The sample below outlines the difference:
 		 * ```ts
-		const u = URI.parse('file://server/c$/folder/file.txt')
-		u.authority === 'server'
-		u.path === '/shares/c$/file.txt'
-		u.fsPath === '\\server\c$\folder\file.txt'
-		```
+		 * const u = URI.parse('file://server/c$/folder/file.txt')
+		 * u.authority === 'server'
+		 * u.path === '/shares/c$/file.txt'
+		 * u.fsPath === '\\server\c$\folder\file.txt'
+		 * ```
 		 */
 		readonly fsPath: string;
 
@@ -1660,8 +1661,10 @@ declare module 'vscode' {
 		detail?: string;
 
 		/**
-		 * Optional flag indicating if this item is picked initially.
-		 * (Only honored when the picker allows multiple selections.)
+		 * Optional flag indicating if this item is picked initially. This is only honored when using
+		 * the {@link window.showQuickPick()} API. To do the same thing with the {@link window.createQuickPick()} API,
+		 * simply set the {@link QuickPick.selectedItems} to the items you want picked initially.
+		 * (*Note:* This is only honored when the picker allows multiple selections.)
 		 *
 		 * @see {@link QuickPickOptions.canPickMany}
 		 */
@@ -1671,6 +1674,14 @@ declare module 'vscode' {
 		 * Always show this item.
 		 */
 		alwaysShow?: boolean;
+
+		/**
+		 * Optional buttons that will be rendered on this particular item. These buttons will trigger
+		 * an {@link QuickPickItemButtonEvent} when clicked. Buttons are only rendered when using a quickpick
+		 * created by the {@link window.createQuickPick()} API. Buttons are not rendered when using
+		 * the {@link window.showQuickPick()} API.
+		 */
+		buttons?: readonly QuickInputButton[];
 	}
 
 	/**
@@ -2227,7 +2238,7 @@ declare module 'vscode' {
 		 *
 		 * Actions not of this kind are filtered out before being shown by the [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action).
 		 */
-		readonly only?: CodeActionKind;
+		readonly only: CodeActionKind | undefined;
 	}
 
 	/**
@@ -2566,11 +2577,12 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * The MarkdownString represents human-readable text that supports formatting via the
-	 * markdown syntax. Standard markdown is supported, also tables, but no embedded html.
+	 * Human-readable text that supports formatting via the [markdown syntax](https://commonmark.org).
 	 *
 	 * Rendering of {@link ThemeIcon theme icons} via the `$(<name>)`-syntax is supported
-	 * when the {@linkcode MarkdownString.supportThemeIcons supportThemeIcons} is set to `true`.
+	 * when the {@linkcode supportThemeIcons} is set to `true`.
+	 *
+	 * Rendering of embedded html is supported when {@linkcode supportHtml} is set to `true`.
 	 */
 	export class MarkdownString {
 
@@ -2589,6 +2601,18 @@ declare module 'vscode' {
 		 * Indicates that this markdown string can contain {@link ThemeIcon ThemeIcons}, e.g. `$(zap)`.
 		 */
 		supportThemeIcons?: boolean;
+
+		/**
+		 * Indicates that this markdown string can contain raw html tags. Defaults to `false`.
+		 *
+		 * When `supportHtml` is false, the markdown renderer will strip out any raw html tags
+		 * that appear in the markdown text. This means you can only use markdown syntax for rendering.
+		 *
+		 * When `supportHtml` is true, the markdown render will also allow a safe subset of html tags
+		 * and attributes to be rendered. See https://github.com/microsoft/vscode/blob/6d2920473c6f13759c978dd89104c4270a83422d/src/vs/base/browser/markdownRenderer.ts#L296
+		 * for a list of all supported tags and attributes.
+		 */
+		supportHtml?: boolean;
 
 		/**
 		 * Creates a new markdown string with the given value.
@@ -2691,7 +2715,7 @@ declare module 'vscode' {
 		/*
 		 * If specified the expression overrides the extracted expression.
 		 */
-		readonly expression?: string;
+		readonly expression?: string | undefined;
 
 		/**
 		 * Creates a new evaluatable expression object.
@@ -2758,7 +2782,7 @@ declare module 'vscode' {
 		/**
 		 * If specified the name of the variable to look up.
 		 */
-		readonly variableName?: string;
+		readonly variableName?: string | undefined;
 		/**
 		 * How to perform the lookup.
 		 */
@@ -2787,7 +2811,7 @@ declare module 'vscode' {
 		/**
 		 * If specified the expression overrides the extracted expression.
 		 */
-		readonly expression?: string;
+		readonly expression?: string | undefined;
 		/**
 		 * Creates a new InlineValueEvaluatableExpression object.
 		 *
@@ -3538,7 +3562,7 @@ declare module 'vscode' {
 		 *
 		 * This is the id that will be passed to `DocumentSemanticTokensProvider.provideDocumentSemanticTokensEdits` (if implemented).
 		 */
-		readonly resultId?: string;
+		readonly resultId: string | undefined;
 		/**
 		 * The actual tokens data.
 		 * @see {@link DocumentSemanticTokensProvider.provideDocumentSemanticTokens provideDocumentSemanticTokens} for an explanation of the format.
@@ -3558,7 +3582,7 @@ declare module 'vscode' {
 		 *
 		 * This is the id that will be passed to `DocumentSemanticTokensProvider.provideDocumentSemanticTokensEdits` (if implemented).
 		 */
-		readonly resultId?: string;
+		readonly resultId: string | undefined;
 		/**
 		 * The edits to the tokens data.
 		 * All edits refer to the initial data state.
@@ -3584,7 +3608,7 @@ declare module 'vscode' {
 		/**
 		 * The elements to insert.
 		 */
-		readonly data?: Uint32Array;
+		readonly data: Uint32Array | undefined;
 
 		constructor(start: number, deleteCount: number, data?: Uint32Array);
 	}
@@ -3918,7 +3942,7 @@ declare module 'vscode' {
 		 * This is `undefined` when signature help is not triggered by typing, such as when manually invoking
 		 * signature help or when moving the cursor.
 		 */
-		readonly triggerCharacter?: string;
+		readonly triggerCharacter: string | undefined;
 
 		/**
 		 * `true` if signature help was already showing when it was triggered.
@@ -3934,7 +3958,7 @@ declare module 'vscode' {
 		 * The `activeSignatureHelp` has its [`SignatureHelp.activeSignature`] field updated based on
 		 * the user arrowing through available signatures.
 		 */
-		readonly activeSignatureHelp?: SignatureHelp;
+		readonly activeSignatureHelp: SignatureHelp | undefined;
 	}
 
 	/**
@@ -4250,11 +4274,11 @@ declare module 'vscode' {
 		/**
 		 * Character that triggered the completion item provider.
 		 *
-		 * `undefined` if provider was not triggered by a character.
+		 * `undefined` if the provider was not triggered by a character.
 		 *
 		 * The trigger character is already in the document when the completion provider is triggered.
 		 */
-		readonly triggerCharacter?: string;
+		readonly triggerCharacter: string | undefined;
 	}
 
 	/**
@@ -4768,6 +4792,104 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Represents an item of a type hierarchy, like a class or an interface.
+	 */
+	export class TypeHierarchyItem {
+		/**
+		 * The name of this item.
+		 */
+		name: string;
+
+		/**
+		 * The kind of this item.
+		 */
+		kind: SymbolKind;
+
+		/**
+		 * Tags for this item.
+		 */
+		tags?: ReadonlyArray<SymbolTag>;
+
+		/**
+		 * More detail for this item, e.g. the signature of a function.
+		 */
+		detail?: string;
+
+		/**
+		 * The resource identifier of this item.
+		 */
+		uri: Uri;
+
+		/**
+		 * The range enclosing this symbol not including leading/trailing whitespace
+		 * but everything else, e.g. comments and code.
+		 */
+		range: Range;
+
+		/**
+		 * The range that should be selected and revealed when this symbol is being
+		 * picked, e.g. the name of a class. Must be contained by the {@link TypeHierarchyItem.range range}-property.
+		 */
+		selectionRange: Range;
+
+		/**
+		 * Creates a new type hierarchy item.
+		 *
+		 * @param kind The kind of the item.
+		 * @param name The name of the item.
+		 * @param detail The details of the item.
+		 * @param uri The Uri of the item.
+		 * @param range The whole range of the item.
+		 * @param selectionRange The selection range of the item.
+		 */
+		constructor(kind: SymbolKind, name: string, detail: string, uri: Uri, range: Range, selectionRange: Range);
+	}
+
+	/**
+	 * The type hierarchy provider interface describes the contract between extensions
+	 * and the type hierarchy feature.
+	 */
+	export interface TypeHierarchyProvider {
+
+		/**
+		 * Bootstraps type hierarchy by returning the item that is denoted by the given document
+		 * and position. This item will be used as entry into the type graph. Providers should
+		 * return `undefined` or `null` when there is no item at the given location.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @returns One or multiple type hierarchy items or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined`, `null`, or an empty array.
+		 */
+		prepareTypeHierarchy(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<TypeHierarchyItem | TypeHierarchyItem[]>;
+
+		/**
+		 * Provide all supertypes for an item, e.g all types from which a type is derived/inherited. In graph terms this describes directed
+		 * and annotated edges inside the type graph, e.g the given item is the starting node and the result is the nodes
+		 * that can be reached.
+		 *
+		 * @param item The hierarchy item for which super types should be computed.
+		 * @param token A cancellation token.
+		 * @returns A set of direct supertypes or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+		provideTypeHierarchySupertypes(item: TypeHierarchyItem, token: CancellationToken): ProviderResult<TypeHierarchyItem[]>;
+
+		/**
+		 * Provide all subtypes for an item, e.g all types which are derived/inherited from the given item. In
+		 * graph terms this describes directed and annotated edges inside the type graph, e.g the given item is the starting
+		 * node and the result is the nodes that can be reached.
+		 *
+		 * @param item The hierarchy item for which subtypes should be computed.
+		 * @param token A cancellation token.
+		 * @returns A set of direct subtypes or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+		provideTypeHierarchySubtypes(item: TypeHierarchyItem, token: CancellationToken): ProviderResult<TypeHierarchyItem[]>;
+	}
+
+	/**
 	 * Represents a list of ranges that can be edited together along with a word pattern to describe valid range contents.
 	 */
 	export class LinkedEditingRanges {
@@ -4789,7 +4911,7 @@ declare module 'vscode' {
 		 * An optional word pattern that describes valid contents for the given ranges.
 		 * If no pattern is provided, the language configuration's word pattern will be used.
 		 */
-		readonly wordPattern?: RegExp;
+		readonly wordPattern: RegExp | undefined;
 	}
 
 	/**
@@ -5019,18 +5141,17 @@ declare module 'vscode' {
 	 * - *Workspace Folder settings* - From one of the {@link workspace.workspaceFolders Workspace Folders} under which requested resource belongs to.
 	 * - *Language settings* - Settings defined under requested language.
 	 *
-	 * The *effective* value (returned by {@linkcode WorkspaceConfiguration.get get}) is computed by overriding or merging the values in the following order.
+	 * The *effective* value (returned by {@linkcode WorkspaceConfiguration.get get}) is computed by overriding or merging the values in the following order:
 	 *
-	 * ```
-	 * `defaultValue` (if defined in `package.json` otherwise derived from the value's type)
-	 * `globalValue` (if defined)
-	 * `workspaceValue` (if defined)
-	 * `workspaceFolderValue` (if defined)
-	 * `defaultLanguageValue` (if defined)
-	 * `globalLanguageValue` (if defined)
-	 * `workspaceLanguageValue` (if defined)
-	 * `workspaceFolderLanguageValue` (if defined)
-	 * ```
+	 * 1. `defaultValue` (if defined in `package.json` otherwise derived from the value's type)
+	 * 1. `globalValue` (if defined)
+	 * 1. `workspaceValue` (if defined)
+	 * 1. `workspaceFolderValue` (if defined)
+	 * 1. `defaultLanguageValue` (if defined)
+	 * 1. `globalLanguageValue` (if defined)
+	 * 1. `workspaceLanguageValue` (if defined)
+	 * 1. `workspaceFolderLanguageValue` (if defined)
+	 *
 	 * **Note:** Only `object` value types are merged and all other value types are overridden.
 	 *
 	 * Example 1: Overriding
@@ -5546,6 +5667,13 @@ declare module 'vscode' {
 		appendLine(value: string): void;
 
 		/**
+		 * Replaces all output from the channel with the given value.
+		 *
+		 * @param value A string, falsy values will not be printed.
+		 */
+		replace(value: string): void;
+
+		/**
 		 * Removes all output from the channel.
 		 */
 		clear(): void;
@@ -5635,7 +5763,7 @@ declare module 'vscode' {
 		 * The priority of this item. Higher value means the item should
 		 * be shown more to the left.
 		 */
-		readonly priority?: number;
+		readonly priority: number | undefined;
 
 		/**
 		 * The name of the entry, like 'Python Language Indicator', 'Git Status' etc.
@@ -5691,7 +5819,7 @@ declare module 'vscode' {
 		/**
 		 * Accessibility information used when a screen reader interacts with this StatusBar item
 		 */
-		accessibilityInformation?: AccessibilityInformation;
+		accessibilityInformation: AccessibilityInformation | undefined;
 
 		/**
 		 * Shows the entry in the status bar.
@@ -5761,6 +5889,11 @@ declare module 'vscode' {
 		readonly exitStatus: TerminalExitStatus | undefined;
 
 		/**
+		 * The current state of the {@link Terminal}.
+		 */
+		readonly state: TerminalState;
+
+		/**
 		 * Send text to the terminal. The text is written to the stdin of the underlying pty process
 		 * (shell) of the terminal.
 		 *
@@ -5787,6 +5920,71 @@ declare module 'vscode' {
 		 * Dispose and free associated resources.
 		 */
 		dispose(): void;
+	}
+
+	/**
+	 * The location of the terminal.
+	 */
+	export enum TerminalLocation {
+		/**
+		 * In the terminal view
+		 */
+		Panel = 1,
+		/**
+		 * In the editor area
+		 */
+		Editor = 2,
+	}
+
+	/**
+	 * Assumes a {@link TerminalLocation} of editor and allows specifying a {@link ViewColumn} and
+	 * {@link preserveFocus} property
+	 */
+	export interface TerminalEditorLocationOptions {
+		/**
+		 * A view column in which the {@link Terminal terminal} should be shown in the editor area.
+		 * Use {@link ViewColumn.Active active} to open in the active editor group, other values are
+		 * adjusted to be `Min(column, columnCount + 1)`, the
+		 * {@link ViewColumn.Active active}-column is not adjusted. Use
+		 * {@linkcode ViewColumn.Beside} to open the editor to the side of the currently active one.
+		 */
+		viewColumn: ViewColumn;
+		/**
+		 * An optional flag that when `true` will stop the {@link Terminal} from taking focus.
+		 */
+		preserveFocus?: boolean;
+	}
+
+	/**
+	 * Uses the parent {@link Terminal}'s location for the terminal
+	 */
+	export interface TerminalSplitLocationOptions {
+		/**
+		 * The parent terminal to split this terminal beside. This works whether the parent terminal
+		 * is in the panel or the editor area.
+		 */
+		parentTerminal: Terminal;
+	}
+
+	/**
+	 * Represents the state of a {@link Terminal}.
+	 */
+	export interface TerminalState {
+		/**
+		 * Whether the {@link Terminal} has been interacted with. Interaction means that the
+		 * terminal has sent data to the process which depending on the terminal's _mode_. By
+		 * default input is sent when a key is pressed or when a command or extension sends text,
+		 * but based on the terminal's mode it can also happen on:
+		 *
+		 * - a pointer click event
+		 * - a pointer scroll event
+		 * - a pointer move event
+		 * - terminal focus in/out
+		 *
+		 * For more information on events that can send data see "DEC Private Mode Set (DECSET)" on
+		 * https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+		 */
+		readonly isInteractedWith: boolean;
 	}
 
 	/**
@@ -6244,6 +6442,9 @@ declare module 'vscode' {
 		/**
 		 * Store a value. The value must be JSON-stringifyable.
 		 *
+		 * *Note* that using `undefined` as value removes the key from the underlying
+		 * storage.
+		 *
 		 * @param key A string.
 		 * @param value A value. MUST not contain cyclic references.
 		 */
@@ -6424,7 +6625,7 @@ declare module 'vscode' {
 		 * Whether the task that is part of this group is the default for the group.
 		 * This property cannot be set through API, and is controlled by a user's task configurations.
 		 */
-		readonly isDefault?: boolean;
+		readonly isDefault: boolean | undefined;
 
 		/**
 		 * The ID of the task group. Is one of TaskGroup.Clean.id, TaskGroup.Build.id, TaskGroup.Rebuild.id, or TaskGroup.Test.id.
@@ -6760,7 +6961,7 @@ declare module 'vscode' {
 		/**
 		 * The task's scope.
 		 */
-		readonly scope?: TaskScope.Global | TaskScope.Workspace | WorkspaceFolder;
+		readonly scope: TaskScope.Global | TaskScope.Workspace | WorkspaceFolder | undefined;
 
 		/**
 		 * The task's name
@@ -7549,8 +7750,8 @@ declare module 'vscode' {
 		 *
 		 * This is the origin that should be used in a content security policy rule:
 		 *
-		 * ```
-		 * img-src https: ${webview.cspSource} ...;
+		 * ```ts
+		 * `img-src https: ${webview.cspSource} ...;`
 		 * ```
 		 */
 		readonly cspSource: string;
@@ -7563,7 +7764,7 @@ declare module 'vscode' {
 		/**
 		 * Controls if the find widget is enabled in the panel.
 		 *
-		 * Defaults to false.
+		 * Defaults to `false`.
 		 */
 		readonly enableFindWidget?: boolean;
 
@@ -7603,7 +7804,7 @@ declare module 'vscode' {
 		/**
 		 * Icon for the panel shown in UI.
 		 */
-		iconPath?: Uri | { light: Uri; dark: Uri };
+		iconPath?: Uri | { readonly light: Uri; readonly dark: Uri };
 
 		/**
 		 * {@linkcode Webview} belonging to the panel.
@@ -7619,7 +7820,7 @@ declare module 'vscode' {
 		 * Editor position of the panel. This property is only set if the webview is in
 		 * one of the editor view columns.
 		 */
-		readonly viewColumn?: ViewColumn;
+		readonly viewColumn: ViewColumn | undefined;
 
 		/**
 		 * Whether the panel is active (focused by the user).
@@ -7997,14 +8198,14 @@ declare module 'vscode' {
 		 * If this is provided, your extension should restore the editor from the backup instead of reading the file
 		 * from the user's workspace.
 		 */
-		readonly backupId?: string;
+		readonly backupId: string | undefined;
 
 		/**
 		 * If the URI is an untitled file, this will be populated with the byte data of that file
 		 *
 		 * If this is provided, your extension should utilize this byte data rather than executing fs APIs on the URI passed in
 		 */
-		readonly untitledDocumentData?: Uint8Array;
+		readonly untitledDocumentData: Uint8Array | undefined;
 	}
 
 	/**
@@ -8218,7 +8419,10 @@ declare module 'vscode' {
 		export const appRoot: string;
 
 		/**
-		 * The environment in which the app is hosted in. i.e. 'desktop', 'codespaces', 'web'.
+		 * The hosted location of the application
+		 * On desktop this is 'desktop'
+		 * In the web this is the specified embedder i.e. 'github.dev', 'codespaces', or 'web' if the embedder
+		 * does not provide that information
 		 */
 		export const appHost: string;
 
@@ -8279,7 +8483,7 @@ declare module 'vscode' {
 
 		/**
 		 * The detected default shell for the extension host, this is overridden by the
-		 * `terminal.integrated.shell` setting for the extension host's platform. Note that in
+		 * `terminal.integrated.defaultProfile` setting for the extension host's platform. Note that in
 		 * environments that do not support a shell the value is the empty string.
 		 */
 		export const shell: string;
@@ -8349,7 +8553,7 @@ declare module 'vscode' {
 		 * ```
 		 *
 		 * *Note* that extensions should not cache the result of `asExternalUri` as the resolved uri may become invalid due to
-		 * a system or user action — for example, in remote cases, a user may close a port forwarding tunnel that was opened by
+		 * a system or user action — for example, in remote cases, a user may close a port forwarding tunnel that was opened by
 		 * `asExternalUri`.
 		 *
 		 * #### Any other scheme
@@ -8442,10 +8646,10 @@ declare module 'vscode' {
 		 *
 		 * @param command Identifier of the command to execute.
 		 * @param rest Parameters passed to the command function.
-		 * @return A thenable that resolves to the returned value of the given command. `undefined` when
+		 * @return A thenable that resolves to the returned value of the given command. Returns `undefined` when
 		 * the command handler function doesn't return anything.
 		 */
-		export function executeCommand<T>(command: string, ...rest: any[]): Thenable<T | undefined>;
+		export function executeCommand<T = unknown>(command: string, ...rest: any[]): Thenable<T>;
 
 		/**
 		 * Retrieve the list of all available commands. Commands starting with an underscore are
@@ -8500,7 +8704,7 @@ declare module 'vscode' {
 		/**
 		 * The currently visible editors or an empty array.
 		 */
-		export let visibleTextEditors: TextEditor[];
+		export let visibleTextEditors: readonly TextEditor[];
 
 		/**
 		 * An {@link Event} which fires when the {@link window.activeTextEditor active editor}
@@ -8513,7 +8717,7 @@ declare module 'vscode' {
 		 * An {@link Event} which fires when the array of {@link window.visibleTextEditors visible editors}
 		 * has changed.
 		 */
-		export const onDidChangeVisibleTextEditors: Event<TextEditor[]>;
+		export const onDidChangeVisibleTextEditors: Event<readonly TextEditor[]>;
 
 		/**
 		 * An {@link Event} which fires when the selection in an editor has changed.
@@ -8563,6 +8767,11 @@ declare module 'vscode' {
 		 * An {@link Event} which fires when a terminal is disposed.
 		 */
 		export const onDidCloseTerminal: Event<Terminal>;
+
+		/**
+		 * An {@link Event} which fires when a {@link Terminal.state terminal's state} has changed.
+		 */
+		export const onDidChangeTerminalState: Event<Terminal>;
 
 		/**
 		 * Represents the current window's state.
@@ -9193,7 +9402,7 @@ declare module 'vscode' {
 		/**
 		 * Selected elements.
 		 */
-		readonly selection: T[];
+		readonly selection: readonly T[];
 
 	}
 
@@ -9227,7 +9436,7 @@ declare module 'vscode' {
 		/**
 		 * Currently selected elements.
 		 */
-		readonly selection: T[];
+		readonly selection: readonly T[];
 
 		/**
 		 * Event that is fired when the {@link TreeView.selection selection} has changed
@@ -9396,17 +9605,17 @@ declare module 'vscode' {
 		 * Context value of the tree item. This can be used to contribute item specific actions in the tree.
 		 * For example, a tree item is given a context value as `folder`. When contributing actions to `view/item/context`
 		 * using `menus` extension point, you can specify context value for key `viewItem` in `when` expression like `viewItem == folder`.
-		 * ```
-		 *	"contributes": {
-		 *		"menus": {
-		 *			"view/item/context": [
-		 *				{
-		 *					"command": "extension.deleteFolder",
-		 *					"when": "viewItem == folder"
-		 *				}
-		 *			]
-		 *		}
-		 *	}
+		 * ```json
+		 * "contributes": {
+		 *   "menus": {
+		 *     "view/item/context": [
+		 *       {
+		 *         "command": "extension.deleteFolder",
+		 *         "when": "viewItem == folder"
+		 *       }
+		 *     ]
+		 *   }
+		 * }
 		 * ```
 		 * This will show action `extension.deleteFolder` only for items with `contextValue` is `folder`.
 		 */
@@ -9533,6 +9742,11 @@ declare module 'vscode' {
 		 * recommended for the best contrast and consistency across themes.
 		 */
 		color?: ThemeColor;
+
+		/**
+		* The {@link TerminalLocation} or {@link TerminalEditorLocationOptions} or {@link TerminalSplitLocationOptions} for the terminal.
+		*/
+		location?: TerminalLocation | TerminalEditorLocationOptions | TerminalSplitLocationOptions;
 	}
 
 	/**
@@ -9561,6 +9775,11 @@ declare module 'vscode' {
 		 * recommended for the best contrast and consistency across themes.
 		 */
 		color?: ThemeColor;
+
+		/**
+		 * The {@link TerminalLocation} or {@link TerminalEditorLocationOptions} or {@link TerminalSplitLocationOptions} for the terminal.
+		 */
+		location?: TerminalLocation | TerminalEditorLocationOptions | TerminalSplitLocationOptions;
 	}
 
 	/**
@@ -9575,6 +9794,8 @@ declare module 'vscode' {
 		 *
 		 * Note writing `\n` will just move the cursor down 1 row, you need to write `\r` as well
 		 * to move the cursor to the left-most cell.
+		 *
+		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
 		 *
 		 * **Example:** Write red text to the terminal
 		 * ```typescript
@@ -9601,6 +9822,8 @@ declare module 'vscode' {
 		 * bar). Set to `undefined` for the terminal to go back to the regular dimensions (fit to
 		 * the size of the panel).
 		 *
+		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
+		 *
 		 * **Example:** Override the dimensions of a terminal to 20 columns and 10 rows
 		 * ```typescript
 		 * const dimensionsEmitter = new vscode.EventEmitter<vscode.TerminalDimensions>();
@@ -9622,6 +9845,8 @@ declare module 'vscode' {
 
 		/**
 		 * An event that when fired will signal that the pty is closed and dispose of the terminal.
+		 *
+		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
 		 *
 		 * A number can be used to provide an exit code for the terminal. Exit codes must be
 		 * positive and a non-zero exit codes signals failure which shows a notification for a
@@ -9651,6 +9876,8 @@ declare module 'vscode' {
 
 		/**
 		 * An event that when fired allows changing the name of the terminal.
+		 *
+		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
 		 *
 		 * **Example:** Change the terminal name to "My new terminal".
 		 * ```typescript
@@ -10037,6 +10264,12 @@ declare module 'vscode' {
 		readonly onDidTriggerButton: Event<QuickInputButton>;
 
 		/**
+		 * An event signaling when a button in a particular {@link QuickPickItem} was triggered.
+		 * This event does not fire for buttons in the title bar.
+		 */
+		readonly onDidTriggerItemButton: Event<QuickPickItemButtonEvent<T>>;
+
+		/**
 		 * Items to pick from. This can be read and updated by the extension.
 		 */
 		items: readonly T[];
@@ -10055,6 +10288,11 @@ declare module 'vscode' {
 		 * If the filter text should also be matched against the detail of the items. Defaults to false.
 		 */
 		matchOnDetail: boolean;
+
+		/*
+		 * An optional flag to maintain the scroll position of the quick pick when the quick pick items are updated. Defaults to false.
+		 */
+		keepScrollPosition?: boolean;
 
 		/**
 		 * Active items. This can be read and updated by the extension.
@@ -10168,6 +10406,21 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * An event signaling when a button in a particular {@link QuickPickItem} was triggered.
+	 * This event does not fire for buttons in the title bar.
+	 */
+	export interface QuickPickItemButtonEvent<T extends QuickPickItem> {
+		/**
+		 * The button that was clicked.
+		 */
+		readonly button: QuickInputButton;
+		/**
+		 * The item that the button belongs to.
+		 */
+		readonly item: T;
+	}
+
+	/**
 	 * An event describing an individual change in the text of a {@link TextDocument document}.
 	 */
 	export interface TextDocumentContentChangeEvent {
@@ -10214,9 +10467,9 @@ declare module 'vscode' {
 
 		/**
 		 * The reason why the document was changed.
-		 * Is undefined if the reason is not known.
+		 * Is `undefined` if the reason is not known.
 		*/
-		readonly reason?: TextDocumentChangeReason;
+		readonly reason: TextDocumentChangeReason | undefined;
 	}
 
 	/**
@@ -10302,6 +10555,11 @@ declare module 'vscode' {
 	export interface FileWillCreateEvent {
 
 		/**
+		 * A cancellation token.
+		 */
+		readonly token: CancellationToken;
+
+		/**
 		 * The files that are going to be created.
 		 */
 		readonly files: readonly Uri[];
@@ -10357,6 +10615,11 @@ declare module 'vscode' {
 	export interface FileWillDeleteEvent {
 
 		/**
+		 * A cancellation token.
+		 */
+		readonly token: CancellationToken;
+
+		/**
 		 * The files that are going to be deleted.
 		 */
 		readonly files: readonly Uri[];
@@ -10410,6 +10673,11 @@ declare module 'vscode' {
 	 * thenable that resolves to a {@link WorkspaceEdit workspace edit}.
 	 */
 	export interface FileWillRenameEvent {
+
+		/**
+		 * A cancellation token.
+		 */
+		readonly token: CancellationToken;
 
 		/**
 		 * The files that are going to be renamed.
@@ -10589,6 +10857,11 @@ declare module 'vscode' {
 
 		/**
 		 * An event that is emitted when a workspace folder is added or removed.
+		 *
+		 * **Note:** this event will not fire if the first workspace folder is added, removed or changed,
+		 * because in that case the currently executing extensions (including the one that listens to this
+		 * event) will be terminated and restarted so that the (deprecated) `rootPath` property is updated
+		 * to point to the first workspace folder.
 		 */
 		export const onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent>;
 
@@ -10688,8 +10961,8 @@ declare module 'vscode' {
 		 * will be matched against the file paths of resulting matches relative to their workspace. Use a {@link RelativePattern relative pattern}
 		 * to restrict the search results to a {@link WorkspaceFolder workspace folder}.
 		 * @param exclude  A {@link GlobPattern glob pattern} that defines files and folders to exclude. The glob pattern
-		 * will be matched against the file paths of resulting matches relative to their workspace. When `undefined`, default excludes and the user's
-		 * configured excludes will apply. When `null`, no excludes will apply.
+		 * will be matched against the file paths of resulting matches relative to their workspace. When `undefined`, default file-excludes (e.g. the `files.exclude`-setting
+		 * but not `search.exclude`) will apply. When `null`, no excludes will apply.
 		 * @param maxResults An upper-bound for the result.
 		 * @param token A token that can be used to signal cancellation to the underlying search engine.
 		 * @return A thenable that resolves to an array of resource identifiers. Will return no results if no
@@ -11098,7 +11371,7 @@ declare module 'vscode' {
 		 * 2. A string will be desugared to become the `language`-part of a {@linkcode DocumentFilter}, so `"fooLang"` is like `{ language: "fooLang" }`.
 		 * 3. A {@linkcode DocumentFilter} will be matched against the document by comparing its parts with the document. The following rules apply:
 		 *  1. When the `DocumentFilter` is empty (`{}`) the result is `0`
-		 *  2. When `scheme`, `language`, or `pattern` are defined but one doesn’t match, the result is `0`
+		 *  2. When `scheme`, `language`, or `pattern` are defined but one doesn't match, the result is `0`
 		 *  3. Matching against `*` gives a score of `5`, matching via equality or via a glob-pattern gives a score of `10`
 		 *  4. The result is the maximum value of each match
 		 *
@@ -11521,6 +11794,15 @@ declare module 'vscode' {
 		export function registerCallHierarchyProvider(selector: DocumentSelector, provider: CallHierarchyProvider): Disposable;
 
 		/**
+		 * Register a type hierarchy provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A type hierarchy provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerTypeHierarchyProvider(selector: DocumentSelector, provider: TypeHierarchyProvider): Disposable;
+
+		/**
 		 * Register a linked editing range provider.
 		 *
 		 * Multiple providers can be registered for a language. In that case providers are sorted
@@ -11604,7 +11886,7 @@ declare module 'vscode' {
 		/**
 		 * The most recent {@link NotebookCellExecutionSummary execution summary} for this cell.
 		 */
-		readonly executionSummary?: NotebookCellExecutionSummary;
+		readonly executionSummary: NotebookCellExecutionSummary | undefined;
 	}
 
 	/**
@@ -12496,17 +12778,17 @@ declare module 'vscode' {
 		 * Context value of the resource state. This can be used to contribute resource specific actions.
 		 * For example, if a resource is given a context value as `diffable`. When contributing actions to `scm/resourceState/context`
 		 * using `menus` extension point, you can specify context value for key `scmResourceState` in `when` expressions, like `scmResourceState == diffable`.
-		 * ```
-		 *	"contributes": {
-		 *		"menus": {
-		 *			"scm/resourceState/context": [
-		 *				{
-		 *					"command": "extension.diff",
-		 *					"when": "scmResourceState == diffable"
-		 *				}
-		 *			]
-		 *		}
-		 *	}
+		 * ```json
+		 * "contributes": {
+		 *   "menus": {
+		 *     "scm/resourceState/context": [
+		 *       {
+		 *         "command": "extension.diff",
+		 *         "when": "scmResourceState == diffable"
+		 *       }
+		 *     ]
+		 *   }
+		 * }
 		 * ```
 		 * This will show action `extension.diff` only for resources with `contextValue` is `diffable`.
 		 */
@@ -12577,8 +12859,9 @@ declare module 'vscode' {
 		 * The UI-visible count of {@link SourceControlResourceState resource states} of
 		 * this source control.
 		 *
-		 * Equals to the total number of {@link SourceControlResourceState resource state}
-		 * of this source control, if undefined.
+		 * If undefined, this source control will
+		 * - display its UI-visible count as zero, and
+		 * - contribute the count of its {@link SourceControlResourceState resource states} to the UI-visible aggregated count for all source controls
 		 */
 		count?: number;
 
@@ -12760,7 +13043,7 @@ declare module 'vscode' {
 		/**
 		 * Event specific information.
 		 */
-		readonly body?: any;
+		readonly body: any;
 	}
 
 	/**
@@ -12873,7 +13156,7 @@ declare module 'vscode' {
 		/**
 		 * The host.
 		 */
-		readonly host?: string;
+		readonly host?: string | undefined;
 
 		/**
 		 * Create a description for a debug adapter running as a socket based server.
@@ -13046,15 +13329,15 @@ declare module 'vscode' {
 		/**
 		 * An optional expression for conditional breakpoints.
 		 */
-		readonly condition?: string;
+		readonly condition?: string | undefined;
 		/**
 		 * An optional expression that controls how many hits of the breakpoint are ignored.
 		 */
-		readonly hitCondition?: string;
+		readonly hitCondition?: string | undefined;
 		/**
 		 * An optional message that gets logged when this breakpoint is hit. Embedded expressions within {} are interpolated by the debug adapter.
 		 */
-		readonly logMessage?: string;
+		readonly logMessage?: string | undefined;
 
 		protected constructor(enabled?: boolean, condition?: string, hitCondition?: string, logMessage?: string);
 	}
@@ -13182,7 +13465,7 @@ declare module 'vscode' {
 		/**
 		 * List of breakpoints.
 		 */
-		export let breakpoints: Breakpoint[];
+		export let breakpoints: readonly Breakpoint[];
 
 		/**
 		 * An {@link Event} which fires when the {@link debug.activeDebugSession active debug session}
@@ -13332,15 +13615,7 @@ declare module 'vscode' {
 		 * @param extensionId An extension identifier.
 		 * @return An extension or `undefined`.
 		 */
-		export function getExtension(extensionId: string): Extension<any> | undefined;
-
-		/**
-		 * Get an extension by its full identifier in the form of: `publisher.name`.
-		 *
-		 * @param extensionId An extension identifier.
-		 * @return An extension or `undefined`.
-		 */
-		export function getExtension<T>(extensionId: string): Extension<T> | undefined;
+		export function getExtension<T = any>(extensionId: string): Extension<T> | undefined;
 
 		/**
 		 * All extensions currently known to the system.
@@ -13420,17 +13695,17 @@ declare module 'vscode' {
 		 * Context value of the comment thread. This can be used to contribute thread specific actions.
 		 * For example, a comment thread is given a context value as `editable`. When contributing actions to `comments/commentThread/title`
 		 * using `menus` extension point, you can specify context value for key `commentThread` in `when` expression like `commentThread == editable`.
-		 * ```
-		 *	"contributes": {
-		 *		"menus": {
-		 *			"comments/commentThread/title": [
-		 *				{
-		 *					"command": "extension.deleteCommentThread",
-		 *					"when": "commentThread == editable"
-		 *				}
-		 *			]
-		 *		}
-		 *	}
+		 * ```json
+		 * "contributes": {
+		 *   "menus": {
+		 *     "comments/commentThread/title": [
+		 *       {
+		 *         "command": "extension.deleteCommentThread",
+		 *         "when": "commentThread == editable"
+		 *       }
+		 *     ]
+		 *   }
+		 * }
 		 * ```
 		 * This will show action `extension.deleteCommentThread` only for comment threads with `contextValue` is `editable`.
 		 */
@@ -13484,7 +13759,7 @@ declare module 'vscode' {
 		readonly count: number;
 
 		/**
-		 * Whether the [author](CommentAuthorInformation) of the comment has reacted to this reaction
+		 * Whether the {@link CommentAuthorInformation author} of the comment has reacted to this reaction
 		 */
 		readonly authorHasReacted: boolean;
 	}
@@ -13691,6 +13966,17 @@ declare module 'vscode' {
 	 */
 	export interface AuthenticationGetSessionOptions {
 		/**
+		 * Whether the existing user session preference should be cleared.
+		 *
+		 * For authentication providers that support being signed into multiple accounts at once, the user will be
+		 * prompted to select an account to use when {@link authentication.getSession getSession} is called. This preference
+		 * is remembered until {@link authentication.getSession getSession} is called with this flag.
+		 *
+		 * Defaults to false.
+		 */
+		clearSessionPreference?: boolean;
+
+		/**
 		 * Whether login should be performed if there is no matching session.
 		 *
 		 * If true, a modal dialog will be shown asking the user to sign in. If false, a numbered badge will be shown
@@ -13701,19 +13987,32 @@ declare module 'vscode' {
 		 * will also result in an immediate modal dialog, and false will add a numbered badge to the accounts icon.
 		 *
 		 * Defaults to false.
+		 *
+		 * Note: you cannot use this option with {@link silent}.
 		 */
 		createIfNone?: boolean;
 
 		/**
-		 * Whether the existing user session preference should be cleared.
+		 * Whether we should attempt to reauthenticate even if there is already a session available.
 		 *
-		 * For authentication providers that support being signed into multiple accounts at once, the user will be
-		 * prompted to select an account to use when {@link authentication.getSession getSession} is called. This preference
-		 * is remembered until {@link authentication.getSession getSession} is called with this flag.
+		 * If true, a modal dialog will be shown asking the user to sign in again. This is mostly used for scenarios
+		 * where the token needs to be re minted because it has lost some authorization.
 		 *
 		 * Defaults to false.
 		 */
-		clearSessionPreference?: boolean;
+		forceNewSession?: boolean | { detail: string };
+
+		/**
+		 * Whether we should show the indication to sign in in the Accounts menu.
+		 *
+		 * If false, the user will be shown a badge on the Accounts menu with an option to sign in for the extension.
+		 * If true, no indication will be shown.
+		 *
+		 * Defaults to false.
+		 *
+		 * Note: you cannot use this option with any other options that prompt the user like {@link createIfNone}.
+		 */
+		silent?: boolean;
 	}
 
 	/**
@@ -13757,21 +14056,21 @@ declare module 'vscode' {
 	*/
 	export interface AuthenticationProviderAuthenticationSessionsChangeEvent {
 		/**
-		 * The {@link AuthenticationSession}s of the {@link AuthenticationProvider} that have been added.
+		 * The {@link AuthenticationSession AuthenticationSessions} of the {@link AuthenticationProvider} that have been added.
 		*/
-		readonly added?: readonly AuthenticationSession[];
+		readonly added: readonly AuthenticationSession[] | undefined;
 
 		/**
-		 * The {@link AuthenticationSession}s of the {@link AuthenticationProvider} that have been removed.
+		 * The {@link AuthenticationSession AuthenticationSessions} of the {@link AuthenticationProvider} that have been removed.
 		 */
-		readonly removed?: readonly AuthenticationSession[];
+		readonly removed: readonly AuthenticationSession[] | undefined;
 
 		/**
-		 * The {@link AuthenticationSession}s of the {@link AuthenticationProvider} that have been changed.
+		 * The {@link AuthenticationSession AuthenticationSessions} of the {@link AuthenticationProvider} that have been changed.
 		 * A session changes when its data excluding the id are updated. An example of this is a session refresh that results in a new
 		 * access token being set for the session.
 		 */
-		readonly changed?: readonly AuthenticationSession[];
+		readonly changed: readonly AuthenticationSession[] | undefined;
 	}
 
 	/**
@@ -13854,6 +14153,21 @@ declare module 'vscode' {
 		export function getSession(providerId: string, scopes: readonly string[], options?: AuthenticationGetSessionOptions): Thenable<AuthenticationSession | undefined>;
 
 		/**
+		 * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
+		 * registered, or if the user does not consent to sharing authentication information with
+		 * the extension. If there are multiple sessions with the same scopes, the user will be shown a
+		 * quickpick to select which account they would like to use.
+		 *
+		 * Currently, there are only two authentication providers that are contributed from built in extensions
+		 * to the editor that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+		 * @param providerId The id of the provider to use
+		 * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+		 * @param options The {@link AuthenticationGetSessionOptions} to use
+		 * @returns A thenable that resolves to an authentication session
+		 */
+		export function getSession(providerId: string, scopes: readonly string[], options: AuthenticationGetSessionOptions & { forceNewSession: true | { detail: string } }): Thenable<AuthenticationSession>;
+
+		/**
 		 * An {@link Event} which fires when the authentication sessions of an authentication provider have
 		 * been added, removed, or changed.
 		 */
@@ -13901,6 +14215,25 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Tags can be associated with {@link TestItem TestItems} and
+	 * {@link TestRunProfile TestRunProfiles}. A profile with a tag can only
+	 * execute tests that include that tag in their {@link TestItem.tags} array.
+	 */
+	export class TestTag {
+		/**
+		 * ID of the test tag. `TestTag` instances with the same ID are considered
+		 * to be identical.
+		 */
+		readonly id: string;
+
+		/**
+		 * Creates a new TestTag instance.
+		 * @param id ID of the test tag.
+		 */
+		constructor(id: string);
+	}
+
+	/**
 	 * A TestRunProfile describes one way to execute tests in a {@link TestController}.
 	 */
 	export interface TestRunProfile {
@@ -13931,12 +14264,18 @@ declare module 'vscode' {
 		isDefault: boolean;
 
 		/**
+		 * Associated tag for the profile. If this is set, only {@link TestItem}
+		 * instances with the same tag will be eligible to execute in this profile.
+		 */
+		tag: TestTag | undefined;
+
+		/**
 		 * If this method is present, a configuration gear will be present in the
 		 * UI, and this method will be invoked when it's clicked. When called,
 		 * you can take other editor actions, such as showing a quick pick or
 		 * opening a configuration file.
 		 */
-		configureHandler?: () => void;
+		configureHandler: (() => void) | undefined;
 
 		/**
 		 * Handler called to start a test run. When invoked, the function should call
@@ -13997,10 +14336,11 @@ declare module 'vscode' {
 		 * @param kind Configures what kind of execution this profile manages.
 		 * @param runHandler Function called to start a test run.
 		 * @param isDefault Whether this is the default action for its kind.
+		 * @param tag Profile test tag.
 		 * @returns An instance of a {@link TestRunProfile}, which is automatically
 		 * associated with this controller.
 		 */
-		createRunProfile(label: string, kind: TestRunProfileKind, runHandler: (request: TestRunRequest, token: CancellationToken) => Thenable<void> | void, isDefault?: boolean): TestRunProfile;
+		createRunProfile(label: string, kind: TestRunProfileKind, runHandler: (request: TestRunRequest, token: CancellationToken) => Thenable<void> | void, isDefault?: boolean, tag?: TestTag): TestRunProfile;
 
 		/**
 		 * A function provided by the extension that the editor may call to request
@@ -14084,7 +14424,7 @@ declare module 'vscode' {
 		 * The process of running tests should resolve the children of any test
 		 * items who have not yet been resolved.
 		 */
-		readonly include?: TestItem[];
+		readonly include: readonly TestItem[] | undefined;
 
 		/**
 		 * An array of tests the user has marked as excluded from the test included
@@ -14093,14 +14433,14 @@ declare module 'vscode' {
 		 * May be omitted if no exclusions were requested. Test controllers should
 		 * not run excluded tests or any children of excluded tests.
 		 */
-		readonly exclude?: TestItem[];
+		readonly exclude: readonly TestItem[] | undefined;
 
 		/**
 		 * The profile used for this request. This will always be defined
 		 * for requests issued from the editor UI, though extensions may
 		 * programmatically create requests not associated with any profile.
 		 */
-		readonly profile?: TestRunProfile;
+		readonly profile: TestRunProfile | undefined;
 
 		/**
 		 * @param tests Array of specific tests to run, or undefined to run all tests
@@ -14119,7 +14459,7 @@ declare module 'vscode' {
 		 * disambiguate multiple sets of results in a test run. It is useful if
 		 * tests are run across multiple platforms, for example.
 		 */
-		readonly name?: string;
+		readonly name: string | undefined;
 
 		/**
 		 * A cancellation token which will be triggered when the test run is
@@ -14183,8 +14523,11 @@ declare module 'vscode' {
 		 * such as colors and text styles, are supported.
 		 *
 		 * @param output Output text to append.
+		 * @param location Indicate that the output was logged at the given
+		 * location.
+		 * @param test Test item to associate the output with.
 		 */
-		appendOutput(output: string): void;
+		appendOutput(output: string, location?: Location, test?: TestItem): void;
 
 		/**
 		 * Signals that the end of the test run. Any tests included in the run whose
@@ -14256,7 +14599,7 @@ declare module 'vscode' {
 		/**
 		 * URI this `TestItem` is associated with. May be a file or directory.
 		 */
-		readonly uri?: Uri;
+		readonly uri: Uri | undefined;
 
 		/**
 		 * The children of this test item. For a test suite, this may contain the
@@ -14269,7 +14612,13 @@ declare module 'vscode' {
 		 * top-level items in the {@link TestController.items} and for items that
 		 * aren't yet included in another item's {@link children}.
 		 */
-		readonly parent?: TestItem;
+		readonly parent: TestItem | undefined;
+
+		/**
+		 * Tags associated with this test item. May be used in combination with
+		 * {@link TestRunProfile.tags}, or simply as an organizational feature.
+		 */
+		tags: readonly TestTag[];
 
 		/**
 		 * Indicates whether this test item may have children discovered by resolving.
@@ -14305,7 +14654,7 @@ declare module 'vscode' {
 		 *
 		 * This is only meaningful if the `uri` points to a file.
 		 */
-		range?: Range;
+		range: Range | undefined;
 
 		/**
 		 * Optional error encountered while loading the test.
@@ -14313,7 +14662,7 @@ declare module 'vscode' {
 		 * Note that this is not a test result and should only be used to represent errors in
 		 * test discovery, such as syntax errors.
 		 */
-		error?: string | MarkdownString;
+		error: string | MarkdownString | undefined;
 	}
 
 	/**


### PR DESCRIPTION
This PR mainly implements TestItem profile support using `vscode.TestRunTag` and enable TestExplorer to run tests on demand for all workspaces including watch-mode:

1. each test item can enable/disable run/debug profile independently via `vscode.TestRunTag`
2. enable run profile for all configs, even "watch" mode. Why? There seems to be a common confusion for watch mode users when the watcher does not function as they anticipated. This will give users the ability to run any tests regardless how jest-watcher behave (#757). However, to prevent the output got overridden by each other, we created a separate run queue with different output file names.
3. allow debugging test on the test file level, i.e. no explicit test name. This could be useful if the test block can not be identified. Will use the wildcard for 'testNamePattern' in this case.
4. remove the warning popup when no debug config is found.
5. in order to increase compatibility with known platforms (such as angular), move run test by-path to by-pattern when running test by explicit test file.

---
fixes #757