### PR TITLE
add showTerminalOnLaunch setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 ---
 ## Release Notes<!-- omit in toc -->
-### Latest: [v4.4.0](https://github.com/jest-community/vscode-jest/releases/tag/v4.4.0) <!-- omit in toc -->
+### Pre-Release: [v4.5.0](https://github.com/jest-community/vscode-jest/releases/tag/v4.5.0) <!-- omit in toc -->
+
+<details>
+
+<summary>features</summary>
+
+- adding a new setting `jest.showTerminalOnLaunch` to control if test explorer terminal should be automatically opened upon launch. Default is true. 
+  
+</details>
+
+### Stable: [v4.4.0](https://github.com/jest-community/vscode-jest/releases/tag/v4.4.0) <!-- omit in toc -->
 
 Interactive run has been extended to watch mode in v4.4.0. Users in watch mode can now run any test/folder/workspace interactively just like with non-watch mode. 
 
@@ -357,6 +367,7 @@ Users can use the following settings to tailor the extension for their environme
 |**Misc**|
 |debugMode|Enable debug mode to diagnose plugin issues. (see developer console)|false|`"jest.debugMode": true`|
 |disabledWorkspaceFolders 💼|Disabled workspace folders names in multiroot environment|[]|`"jest.disabledWorkspaceFolders": ["package-a", "package-b"]`|
+|showTerminalOnLaunch 💼|automatically open test explorer terminal on launch (>= v4.5)|true|`"jest.showTerminalOnLaunch": false`|
 
 #### Details
 ##### jestCommandLine

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
       "type": "object",
       "title": "Jest",
       "properties": {
+        "jest.showTerminalOnLaunch": {
+          "description": "Automatically open test explorer's terminal upon launch",
+          "type": "boolean",
+          "default": true,
+          "scope": "window"
+        },
         "jest.autoEnable": {
           "description": "Automatically start Jest for this project",
           "type": "boolean",

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -111,6 +111,7 @@ export const createJestExtContext = (
 export const getExtensionResourceSettings = (uri: vscode.Uri): PluginResourceSettings => {
   const config = vscode.workspace.getConfiguration('jest', uri);
   return {
+    showTerminalOnLaunch: config.get<boolean>('showTerminalOnLaunch') ?? true,
     autoEnable: config.get<boolean>('autoEnable'),
     enableSnapshotUpdateMessages: config.get<boolean>('enableSnapshotUpdateMessages'),
     pathToConfig: config.get<string>('pathToConfig'),

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -28,6 +28,7 @@ export type TestExplorerConfig =
   | { enabled: true; showClassicStatus?: boolean; showInlineError?: boolean };
 export type NodeEnv = ProjectWorkspace['nodeEnv'];
 export interface PluginResourceSettings {
+  showTerminalOnLaunch?: boolean;
   autoEnable?: boolean;
   enableSnapshotUpdateMessages?: boolean;
   jestCommandLine?: string;

--- a/src/test-provider/test-provider-context.ts
+++ b/src/test-provider/test-provider-context.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 import { JestExtExplorerContext, TestItemData } from './types';
 
+let showTerminal = true;
+export const _resetShowTerminal = (): void => {
+  showTerminal = true;
+};
+
 /**
  * provide context information from JestExt and test provider state:
  * 1. TestData <-> TestItem
@@ -17,6 +22,7 @@ const COLORS = {
   ['end']: '\x1b[0m',
 };
 export type TagIdType = 'run' | 'debug';
+
 export class JestTestProviderContext {
   private testItemData: WeakMap<vscode.TestItem, TestItemData>;
 
@@ -88,19 +94,18 @@ export class JestTestProviderContext {
       text = `${COLORS[color]}${text}${COLORS['end']}`;
     }
     run.appendOutput(`${text}${newLine ? '\r\n' : ''}`);
-    showTestExplorerTerminal();
+    this.showTestExplorerTerminal();
+  };
+
+  /** show TestExplorer Terminal on first invocation only */
+  showTestExplorerTerminal = (): void => {
+    if (showTerminal && this.ext.settings.showTerminalOnLaunch !== false) {
+      showTerminal = false;
+      vscode.commands.executeCommand('testing.showMostRecentOutput');
+    }
   };
 
   // tags
   getTag = (tagId: TagIdType): vscode.TestTag | undefined =>
     this.profiles.find((p) => p.tag?.id === tagId)?.tag;
 }
-
-/** show TestExplorer Terminal on first invocation only */
-let showTerminal = true;
-const showTestExplorerTerminal = () => {
-  if (showTerminal) {
-    showTerminal = false;
-    vscode.commands.executeCommand('testing.showMostRecentOutput');
-  }
-};

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -188,6 +188,7 @@ describe('getExtensionResourceSettings()', () => {
       coverageColors: null,
       autoRun: null,
       testExplorer: { enabled: true },
+      showTerminalOnLaunch: true,
     });
   });
   it('can read user settings', () => {


### PR DESCRIPTION
add a new setting  `jest.showTerminalOnLaunch` to control the test explorer terminal on launch.

fixes #854