### PR TITLE
Fix double error reporting

### DIFF
--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -213,9 +213,6 @@ export class JestExt {
             actions.push(this.setupIgnoreAction());
           }
           break;
-        default:
-          console.error(`invalid message action type: ${t}`);
-          break;
       }
     }
     return actions;
@@ -640,11 +637,11 @@ export class JestExt {
             'Failed to obtain test file list, something might not be setup right?'
           );
           this.logging('error', msg, error);
-          messaging.systemWarningMessage(
-            msg,
-            messaging.showTroubleshootingAction,
-            this.setupWizardAction('cmdLine')
-          );
+          //fire this warning message could risk reporting error multiple times for the given workspace folder
+          //therefore garding the warning message with the debugMode
+          if (this.extContext.settings.debugMode) {
+            messaging.systemWarningMessage(msg, ...this.buildMessageActions(['help', 'wizard']));
+          }
         }
       },
     });

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -39,6 +39,8 @@ interface RunTestPickItem extends vscode.QuickPickItem {
   id: DebugTestIdentifier;
 }
 
+type MessageActionType = 'help' | 'wizard' | 'disable-folder';
+
 /** extract lines starts and end with [] */
 export class JestExt {
   coverageMapProvider: CoverageMapProvider;
@@ -184,14 +186,10 @@ export class JestExt {
             this.channel.appendLine(msg);
             this.channel.show();
 
-            const messageActions: Array<MessageAction> = [
-              messaging.showTroubleshootingAction,
-              this.setupWizardAction('cmdLine'),
-            ];
-            if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 1) {
-              messageActions.push(this.setupIgnoreAction());
-            }
-            messaging.systemErrorMessage(event.error, ...messageActions);
+            messaging.systemErrorMessage(
+              prefixWorkspace(this.extContext, event.error),
+              ...this.buildMessageActions(['help', 'wizard', 'disable-folder'])
+            );
           } else {
             this.updateStatusBar({ state: 'done' });
           }
@@ -200,6 +198,28 @@ export class JestExt {
     });
   }
 
+  private buildMessageActions = (types: MessageActionType[]): MessageAction[] => {
+    const actions: MessageAction[] = [];
+    for (const t of types) {
+      switch (t) {
+        case 'help':
+          actions.push(messaging.showTroubleshootingAction);
+          break;
+        case 'wizard':
+          actions.push(this.setupWizardAction('cmdLine'));
+          break;
+        case 'disable-folder':
+          if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 1) {
+            actions.push(this.setupIgnoreAction());
+          }
+          break;
+        default:
+          console.error(`invalid message action type: ${t}`);
+          break;
+      }
+    }
+    return actions;
+  };
   private createProcessSession(): ProcessSession {
     return createProcessSession({
       ...this.extContext,
@@ -248,8 +268,7 @@ export class JestExt {
       this.channel.appendLine('Failed to start jest session');
       messaging.systemErrorMessage(
         `${msg}...`,
-        messaging.showTroubleshootingAction,
-        this.setupWizardAction('cmdLine')
+        ...this.buildMessageActions(['help', 'wizard', 'disable-folder'])
       );
     }
   }
@@ -270,7 +289,7 @@ export class JestExt {
       const msg = prefixWorkspace(this.extContext, 'Failed to stop jest session');
       this.logging('error', `${msg}:`, e);
       this.channel.appendLine('Failed to stop jest session');
-      messaging.systemErrorMessage('${msg}...', messaging.showTroubleshootingAction);
+      messaging.systemErrorMessage('${msg}...', ...this.buildMessageActions(['help']));
     }
   }
 

--- a/src/JestExt/process-listeners.ts
+++ b/src/JestExt/process-listeners.ts
@@ -85,16 +85,17 @@ export class AbstractProcessListener {
     // no default behavior...
   }
   protected onProcessExit(process: JestProcess, code?: number, signal?: string): void {
+    // default behavior: logging error
+    if (this.isProcessError(code)) {
+      const error = `${process.request.type} onProcessExit: process exit with code=${code}, signal=${signal}`;
+      this.logging('warn', `${error} :`, process.toString());
+    }
+  }
+  protected isProcessError(code?: number): boolean {
     // code = 1 is general error, usually mean the command emit error, which should already handled by other event processing, for example when jest has failed tests.
     // However, error beyond 1, usually means some error outside of the command it is trying to execute, so reporting here for debugging purpose
     // see shell error code: https://www.linuxjournal.com/article/10844
-    if (code && code > 1) {
-      const error = `${process.request.type} onProcessExit: process exit with code=${code}, signal=${signal}`;
-      this.session.context.onRunEvent.fire({ type: 'exit', process, error });
-      this.logging('debug', `${error} :`, process.toString());
-    } else {
-      this.session.context.onRunEvent.fire({ type: 'exit', process });
-    }
+    return code != null && code > 1;
   }
 }
 
@@ -104,6 +105,7 @@ export class ListTestFileListener extends AbstractProcessListener {
     return 'ListTestFileListener';
   }
   private buffer = '';
+  private error: string | undefined;
   private onResult: ListTestFilesCallback;
 
   constructor(session: ListenerSession, onResult: ListTestFilesCallback) {
@@ -114,8 +116,20 @@ export class ListTestFileListener extends AbstractProcessListener {
   protected onExecutableOutput(_process: JestProcess, data: string): void {
     this.buffer += data;
   }
+  protected onProcessExit(process: JestProcess, code?: number, signal?: string): void {
+    // Note: will not fire 'exit' event, as the output is reported via the onResult() callback
+    super.onProcessExit(process, code, signal);
+    if (super.isProcessError(code)) {
+      this.error = `${process.request.type} onProcessExit: process exit with code=${code}, signal=${signal}`;
+    }
+  }
+
   protected onProcessClose(process: JestProcess): void {
     super.onProcessClose(process);
+    if (this.error) {
+      return this.onResult(undefined, this.error);
+    }
+
     try {
       const json = this.buffer.match(JsonArrayRegexp);
       if (!json || json.length === 0) {
@@ -133,7 +147,7 @@ export class ListTestFileListener extends AbstractProcessListener {
       return this.onResult(uriFiles);
     } catch (e) {
       this.logging('warn', 'failed to parse result:', this.buffer, 'error=', e);
-      return this.onResult(undefined, e);
+      this.onResult(undefined, e);
     }
   }
 }

--- a/src/JestExt/process-listeners.ts
+++ b/src/JestExt/process-listeners.ts
@@ -3,7 +3,7 @@ import { JestTotalResults } from 'jest-editor-support';
 import { cleanAnsi } from '../helpers';
 import { JestProcess, JestProcessEvent } from '../JestProcessManagement';
 import { ListenerSession, ListTestFilesCallback } from './process-session';
-import { isWatchRequest, prefixWorkspace } from './helper';
+import { isWatchRequest } from './helper';
 import { Logging } from '../logging';
 import { JestRunEvent } from './types';
 
@@ -219,10 +219,7 @@ export class RunTestListener extends AbstractProcessListener {
       (process.request.type === 'watch-tests' || process.request.type === 'watch-all-tests') &&
       process.stopReason !== 'on-demand'
     ) {
-      const msg = prefixWorkspace(
-        this.session.context,
-        `Jest process "${process.request.type}" ended unexpectedly`
-      );
+      const msg = `Jest process "${process.request.type}" ended unexpectedly`;
       this.logging('warn', msg);
 
       return msg;

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -1170,12 +1170,12 @@ describe('JestExt', () => {
           );
         });
         it('if error: status bar stopped and show error with ignore folder button', () => {
-          (vscode.workspace.workspaceFolders as any) = ['testfolder1', 'testfolder2'];
+          (vscode.workspace.workspaceFolders as any) = ['testfolder1', 'testfolder'];
 
           onRunEvent({ type: 'exit', error: 'something is wrong', process });
           expect(sbUpdateMock).toBeCalledWith({ state: 'stopped' });
           expect(messaging.systemErrorMessage).toHaveBeenCalledWith(
-            'something is wrong',
+            '(test-folder) something is wrong',
             { action: expect.any(Function), title: 'Help' },
             { action: expect.any(Function), title: 'Run Setup Wizard' },
             { action: expect.any(Function), title: 'Ignore Folder' }

--- a/tests/JestExt/process-listeners.test.ts
+++ b/tests/JestExt/process-listeners.test.ts
@@ -335,32 +335,6 @@ describe('jest process listeners', () => {
             })
           );
         });
-        it('in single-root env, folder name will not be shown in the message', () => {
-          expect.hasAssertions();
-
-          (vscode.workspace.workspaceFolders as any) = ['workspace-xyz'];
-
-          const listener = new RunTestListener(mockSession);
-
-          listener.onEvent(mockProcess, 'processClose', 1);
-          expect(mockSession.context.onRunEvent.fire).toBeCalled();
-
-          const event = mockSession.context.onRunEvent.fire.mock.calls[0][0];
-          expect(event.error).not.toContain('workspace-xyz');
-        });
-        it('in multi-root env, folder name will be shown in the message', () => {
-          expect.hasAssertions();
-
-          (vscode.workspace.workspaceFolders as any) = ['workspace-xyz', 'workspace-abc'];
-
-          const listener = new RunTestListener(mockSession);
-
-          listener.onEvent(mockProcess, 'processClose', 1);
-          expect(mockSession.context.onRunEvent.fire).toBeCalled();
-
-          const event = mockSession.context.onRunEvent.fire.mock.calls[0][0];
-          expect(event.error).toContain('workspace-xyz');
-        });
       });
     });
   });


### PR DESCRIPTION
When jest process failed to start, users often see 2 different error/warning popups, with inconsistent formats. This PR addresses this issue:
1. consolidate where the final message was composed to apply consistent format
2. suppress `exitProcess` event in the `ListTestFileListener` and report process error via `onResult` instead.
3. furthermore, the `onResult` error will only be reported in the pop-up if `debugMode=true`, since most system errors shall be reported (again) when running the actual tests. 