### PR TITLE
Long run monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,13 @@ Content
         - [shell](#shell)
     - [Debug Config](#debug-config)
     - [Debug Config v2](#debug-config-v2)
+    - [monitorLongRun](#monitorlongrun)
   - [Commands](#commands)
   - [Menu](#menu)
   - [Troubleshooting](#troubleshooting)
     - [Jest failed to run](#jest-failed-to-run)
     - [I don't see "Jest" in the bottom status bar](#i-dont-see-jest-in-the-bottom-status-bar)
+    - [What to do with "Long Running Tests Warning"](#what-to-do-with-long-running-tests-warning)
     - [The extension seems to consume high CPU](#the-extension-seems-to-consume-high-cpu)
     - [The tests and status do not match or some tests showing question marks unexpectedly?](#the-tests-and-status-do-not-match-or-some-tests-showing-question-marks-unexpectedly)
   - [Want to Contribute?](#want-to-contribute)
@@ -368,9 +370,10 @@ Users can use the following settings to tailor the extension for their environme
 |nodeEnv|Add additional env variables to spawned jest process|null|`"jest.nodeEnv": {"PORT": "9800", "BAR":"true"}` |
 |shell|Custom shell (path or LoginShell) for executing jest|null|`"jest.shell": "/bin/bash"` or `"jest.shell": "powershell"` or `"jest.shell": {"path": "/bin/bash"; args: ["--login"]}`  |
 |[autoRun](#autorun)|Controls when and what tests should be run|undefined|`"jest.autoRun": "off"` or `"jest.autoRun": {"watch": true, "onStartup": ["all-tests"]}` or `"jest.autoRun": false, onSave:"test-only"}`|
+|[rootPath](#rootPath)|The path to your frontend src folder|""|`"jest.rootPath":"packages/app"` or `"jest.rootPath":"/apps/my-app"`|
+|[monitorLongRun](#monitorlongrun)| monitor long running tests based on given threshold in ms|60000|`"jest.monitorLongRun": 120000`|
 |pathToJest :x:|The path to the Jest binary, or an npm/yarn command to run tests|undefined|Please use `jestCommandLine` instead|
 |pathToConfig :x:|The path to your Jest configuration file"|""|Please use `jestCommandLine` instead|
-|[rootPath](#rootPath)|The path to your frontend src folder|""|`"jest.rootPath":"packages/app"` or `"jest.rootPath":"/apps/my-app"`|
 |runAllTestsFirst :x:| Run all tests before starting Jest in watch mode|true|Please use `autoRun` instead|
 |**Editor**|
 |<strike>enableInlineErrorMessages</strike> :x:| Whether errors should be reported inline on a file|--|This is now deprecated in favor of `jest.testExplorer` |
@@ -601,7 +604,15 @@ Currently supported variables:
   ``` 
   
 </details>
+### monitorLongRun
+```ts
+monitorLongRun = number | 'off'
+```
 
+- specify a number (milliseconds) means any run exceeds this threshold will trigger a warning. The number has to be > 0. 
+- specify "off" to disable long-run process monitoring
+
+Default is `"jest.monitorLongRun":60000` (1 minute)
 ## Commands
 
 This extension contributes the following commands and can be accessed via [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette):
@@ -673,6 +684,16 @@ There could be other causes, such as jest test root path is different from the p
   - your source and tests are not in the project root directory: try [jest.rootPath](#rootPath) to point to that directory instead.
 
   Users can also try to manually activate the extension via command palette: `"Jest: Start All Runners"`
+### What to do with "Long Running Tests Warning"
+The extension monitor excessive test run with ["jest.monitorLongRun"](#monitorlongrun) setting. By default if any runs exceed 60 seconds, a warning message will be shown. 
+- If running the tests with the extension seems to be longer than running it from a terminal, chances are you can use ["jest.autoRun"](#autorun) to optimize it, for example:
+  - for process type "all-tests", you can turn off the all-tests from autoRun.
+  - for process type "watch-tests" or "watch-all-tests", you can maybe turn off watch mode and use "onSave" instead. 
+  
+- If the tests are slow even from the terminal, i.e. without the extension, you will need to optimize your tests, feel free to check out [jest troubleshooting](https://jestjs.io/docs/troubleshooting) or other online articles.
+- If the run appeared to hang, i.e. the TestExplorer or statusBar showed test running when it is not. It might be related to this [jest issue](https://github.com/facebook/jest/issues/13187), which should be fixed after release `29.0.2`. If you believe your issue is different, please [file a new issue](https://github.com/jest-community/vscode-jest/issues) so we can take a look.
+
+You can also turn off the monitor or change the threshold with ["jest.monitorLongRun"](#monitorlongrun) to meet your needs. 
 ### The extension seems to consume high CPU 
   By default the extension will run all tests when it is launched followed by a jest watch process. If you have many resource intensive tests or source files that can trigger many tests when changed, this could be the reason. Check out [jest.autoRun](#autorun) to see how you can change and control when and what tests should be run.
 

--- a/package.json
+++ b/package.json
@@ -229,12 +229,15 @@
           },
           "scope": "resource"
         },
-        "jest.monitorLongRun" : {
+        "jest.monitorLongRun": {
           "markdownDescription": "Enable monitoring for long running test process. See valid [monitorLongRun](https://github.com/jest-community/vscode-jest/blob/master/README.md#monitorLongRun) for details",
-          "type": ["string", "integer"],
+          "type": [
+            "string",
+            "integer"
+          ],
           "default": 60000,
           "scope": "resource"
-        } 
+        }
       }
     },
     "commands": [

--- a/package.json
+++ b/package.json
@@ -228,7 +228,13 @@
             "enabled": true
           },
           "scope": "resource"
-        }
+        },
+        "jest.monitorLongRun" : {
+          "markdownDescription": "Enable monitoring for long running test process. See valid [monitorLongRun](https://github.com/jest-community/vscode-jest/blob/master/README.md#monitorLongRun) for details",
+          "type": ["string", "integer"],
+          "default": 60000,
+          "scope": "resource"
+        } 
       }
     },
     "commands": [

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -10,6 +10,7 @@ import {
   JestExtAutoRunConfig,
   TestExplorerConfig,
   NodeEnv,
+  MonitorLongRun,
 } from '../Settings';
 import { AutoRunMode } from '../StatusBar';
 import { pathToJest, pathToConfig, toFilePath } from '../helpers';
@@ -114,16 +115,12 @@ const isLoginShell = (arg: any): arg is LoginShell =>
   arg && typeof arg.path === 'string' && Array.isArray(arg.args);
 
 const getShell = (config: vscode.WorkspaceConfiguration): string | LoginShell | undefined => {
-  console.log('inside getShell');
-
   const shell = config.get<string | LoginShell>('shell');
 
-  console.log('shell=', shell);
   if (!shell || typeof shell === 'string') {
     return shell;
   }
 
-  console.log('before calling isLoginShell shell=', shell);
   if (isLoginShell(shell)) {
     if (platform() === 'win32') {
       console.error(`LoginShell is not supported for windows currently.`);
@@ -164,6 +161,7 @@ export const getExtensionResourceSettings = (uri: vscode.Uri): PluginResourceSet
     testExplorer: config.get<TestExplorerConfig>('testExplorer') ?? { enabled: true },
     nodeEnv: config.get<NodeEnv | null>('nodeEnv') ?? undefined,
     shell: getShell(config) ?? undefined,
+    monitorLongRun: config.get<MonitorLongRun>('monitorLongRun') ?? undefined,
   };
 };
 

--- a/src/JestExt/types.ts
+++ b/src/JestExt/types.ts
@@ -51,6 +51,7 @@ export type JestRunEvent = RunEventBase &
     | { type: 'start' }
     | { type: 'end' }
     | { type: 'exit'; error?: string }
+    | { type: 'long-run'; threshold: number; numTotalTestSuites?: number }
   );
 export interface JestSessionEvents {
   onRunEvent: vscode.EventEmitter<JestRunEvent>;

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -27,6 +27,7 @@ export type TestExplorerConfig =
   | { enabled: false }
   | { enabled: true; showClassicStatus?: boolean; showInlineError?: boolean };
 export type NodeEnv = ProjectWorkspace['nodeEnv'];
+export type MonitorLongRun = 'off' | number;
 export interface PluginResourceSettings {
   showTerminalOnLaunch?: boolean;
   autoEnable?: boolean;
@@ -45,6 +46,7 @@ export interface PluginResourceSettings {
   testExplorer: TestExplorerConfig;
   nodeEnv?: NodeEnv;
   shell?: string | LoginShell;
+  monitorLongRun?: MonitorLongRun;
 }
 
 export interface PluginWindowSettings {

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -6,6 +6,8 @@ import * as vscode from 'vscode';
 
 export const TROUBLESHOOTING_URL =
   'https://github.com/jest-community/vscode-jest/blob/master/README.md#troubleshooting';
+export const LONG_RUN_TROUBLESHOOTING_URL =
+  'https://github.com/jest-community/vscode-jest/blob/master/README.md#what-to-do-with-long-running-tests-warning';
 
 //
 // internal methods
@@ -57,4 +59,9 @@ export const showTroubleshootingAction: MessageAction = {
   title: 'Help',
   action: () =>
     vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(TROUBLESHOOTING_URL)),
+};
+export const showLongRunTroubleshootingAction: MessageAction = {
+  title: 'Help',
+  action: () =>
+    vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(LONG_RUN_TROUBLESHOOTING_URL)),
 };

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -3,39 +3,16 @@
 import type { AggregatedResult } from '@jest/test-result';
 import { Reporter, Context } from '@jest/reporters';
 
-export interface VSCodeJestReporterOptions {
-  reportingInterval: number;
-}
 export default class VSCodeJestReporter implements Reporter {
-  private reportTime = 0;
-  private startTime = 0;
-  private options: VSCodeJestReporterOptions;
-
-  constructor(
-    _globalConfig: unknown,
-    options: VSCodeJestReporterOptions = { reportingInterval: 30000 } // 30 second default interval
-  ) {
-    this.options = options;
+  onRunStart(aggregatedResults: AggregatedResult): void {
+    console.log(`onRunStart: numTotalTestSuites: ${aggregatedResults.numTotalTestSuites}`);
   }
 
-  onRunStart(): void {
-    this.startTime = Date.now();
-    this.reportTime = this.startTime;
-
-    console.log('onRunStart');
-  }
-  onTestFileStart(): void {
-    const t0 = Date.now();
-    if (t0 - this.reportTime > this.options.reportingInterval) {
-      this.reportTime = t0;
-      console.log(`ElapsedTime: ${(t0 - this.startTime) / 1000}s`);
-    }
-  }
   onRunComplete(_contexts: Set<Context>, results: AggregatedResult): void {
-    // report exec errors
+    // report exec errors that could have prevented Result file being generated
+    // TODO: replace with checking results.runExecError after Jest release https://github.com/facebook/jest/pull/13203
     if (results.numTotalTests === 0 && results.numTotalTestSuites > 0) {
-      // TODO: check results.runExecError after Jest release https://github.com/facebook/jest/pull/13203
-      console.log('onRunComplete: with execError');
+      console.log('onRunComplete: execError: no test is run');
     } else {
       console.log('onRunComplete');
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,13 +1,46 @@
 // Custom Jest reporter used by jest-vscode extension
-class VSCodeJestReporter {
-  onRunStart() {
-    // tslint:disable-next-line: no-console
+
+import type { AggregatedResult } from '@jest/test-result';
+import { Reporter, Context } from '@jest/reporters';
+
+export interface VSCodeJestReporterOptions {
+  reportingInterval: number;
+}
+export default class VSCodeJestReporter implements Reporter {
+  private reportTime = 0;
+  private startTime = 0;
+  private options: VSCodeJestReporterOptions;
+
+  constructor(
+    _globalConfig: unknown,
+    options: VSCodeJestReporterOptions = { reportingInterval: 30000 } // 30 second default interval
+  ) {
+    this.options = options;
+  }
+
+  onRunStart(): void {
+    this.startTime = Date.now();
+    this.reportTime = this.startTime;
+
     console.log('onRunStart');
   }
-  onRunComplete() {
-    // tslint:disable-next-line: no-console
-    console.log('onRunComplete');
+  onTestFileStart(): void {
+    const t0 = Date.now();
+    if (t0 - this.reportTime > this.options.reportingInterval) {
+      this.reportTime = t0;
+      console.log(`ElapsedTime: ${(t0 - this.startTime) / 1000}s`);
+    }
+  }
+  onRunComplete(_contexts: Set<Context>, results: AggregatedResult): void {
+    // report exec errors
+    if (results.numTotalTests === 0 && results.numTotalTestSuites > 0) {
+      // TODO: check results.runExecError after Jest release https://github.com/facebook/jest/pull/13203
+      console.log('onRunComplete: with execError');
+    } else {
+      console.log('onRunComplete');
+    }
+  }
+  getLastError(): Error | undefined {
+    return;
   }
 }
-
-module.exports = VSCodeJestReporter;

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -1189,6 +1189,25 @@ describe('JestExt', () => {
           expect(addFolderToDisabledWorkspaceFolders).toHaveBeenCalledWith('test-folder');
         });
       });
+      it.each`
+        numTotalTestSuites
+        ${undefined}
+        ${17}
+      `(
+        'long-run event with $numTotalTestSuites numTotalTestSuites triggers system warning',
+        ({ numTotalTestSuites }) => {
+          process = { ...process, request: { type: 'all-tests' } };
+          onRunEvent({ type: 'long-run', numTotalTestSuites, threshold: 60000, process });
+          expect(messaging.systemWarningMessage).toBeCalledTimes(1);
+          const msg = (messaging.systemWarningMessage as jest.Mocked<any>).mock.calls[0][0];
+          expect(msg).toContain('all-tests');
+          if (numTotalTestSuites) {
+            expect(msg).toContain(`${numTotalTestSuites} suites`);
+          } else {
+            expect(msg).not.toContain(`${numTotalTestSuites} suites`);
+          }
+        }
+      );
     });
     it('events are disposed when extensioin deactivated', () => {
       sut.deactivate();

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -169,7 +169,6 @@ describe('getExtensionResourceSettings()', () => {
           defaults[key] = config[key].default;
         }
       }
-
       return {
         get: jest
           .fn()
@@ -195,6 +194,7 @@ describe('getExtensionResourceSettings()', () => {
       autoRun: null,
       testExplorer: { enabled: true },
       showTerminalOnLaunch: true,
+      monitorLongRun: 60000,
     });
   });
   describe('can read user settings', () => {

--- a/tests/messaging.test.ts
+++ b/tests/messaging.test.ts
@@ -58,6 +58,11 @@ describe('test system messaging', () => {
     expect(mockExecCommands.mock.calls.length).toBe(1);
     expect(mockUriParse.mock.calls[0][0]).toBe(messaging.TROUBLESHOOTING_URL);
   });
+  it('can open longRunTroubleshooting url via action', () => {
+    messaging.showLongRunTroubleshootingAction.action();
+    expect(mockExecCommands.mock.calls.length).toBe(1);
+    expect(mockUriParse.mock.calls[0][0]).toBe(messaging.LONG_RUN_TROUBLESHOOTING_URL);
+  });
   it('can handle user actions', () => {
     let a = messaging._handleMessageActions();
     expect(a).not.toBeNull();

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -1,0 +1,57 @@
+jest.unmock('../src/reporter');
+import VSCodeJestReporter from '../src/reporter';
+
+describe('VSCodeJest Reporter', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    console.log = jest.fn();
+  });
+  it('reports on RunStart and RunComplete via console.log', () => {
+    const reporter = new VSCodeJestReporter({});
+    reporter.onRunStart();
+    expect(console.log).toBeCalledWith('onRunStart');
+    reporter.onRunComplete(new Set(), {} as any);
+    expect(console.log).toBeCalledWith('onRunComplete');
+  });
+  it('reports ElapsedTime with minimal reporting interval', () => {
+    const reporter = new VSCodeJestReporter({}, { reportingInterval: 20000 });
+    const mockNow = jest.fn();
+    Date.now = mockNow;
+
+    mockNow.mockReturnValueOnce(1000);
+    reporter.onRunStart();
+    expect(console.log).toBeCalledWith('onRunStart');
+
+    // nothing should be logged
+    mockNow.mockReturnValueOnce(15000);
+    reporter.onTestFileStart();
+    expect(console.log).toBeCalledTimes(1);
+    expect(console.log).not.toBeCalledWith('ElapsedTime: 14s');
+
+    // when exceed reporting interval, it should output elapsed time
+    mockNow.mockReturnValueOnce(23000);
+    reporter.onTestFileStart();
+    expect(console.log).toBeCalledTimes(2);
+    expect(console.log).toBeCalledWith('ElapsedTime: 22s');
+  });
+  it.each`
+    numTotalTests | numTotalTestSuites | hasError
+    ${1}          | ${1}               | ${false}
+    ${0}          | ${0}               | ${false}
+    ${0}          | ${2}               | ${true}
+  `(
+    'report runtime exec error in RunComplete',
+    ({ numTotalTests, numTotalTestSuites, hasError }) => {
+      const reporter = new VSCodeJestReporter({});
+      reporter.onRunStart();
+      expect(console.log).toBeCalledWith('onRunStart');
+      const result: any = { numTotalTests, numTotalTestSuites };
+      reporter.onRunComplete(new Set(), result);
+      if (hasError) {
+        expect(console.log).toBeCalledWith('onRunComplete: with execError');
+      } else {
+        expect(console.log).toBeCalledWith('onRunComplete');
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Motivation: 
One of the most common complaints is the extension seems to consume lots of resources. Given the extension is just a thin wrapper over jest, many of those issues most likely could be addressed by changing the settings, such as `jest.autoRun`.  This PR is to add proactive monitoring to inform users when the seemingly long run (defined by the new setting `jest.monitorLongRun`) is detected, and provide info to help users address it.

## Change outline
- add a new setting `jest.monitorLongRun` to control the threshold of the long-run detection.
- update reporters to report more info for more helpful messaging.
- create a new event for long-run detection
- add a `LongRunMonitor` in `RunTestListener` to monitor runs that exceed the configured threshold (`jest.monitorLongRun`)
- display a warning message when long-run is detected
- updated README 

## Follow-up
Right now the default setting of the monitor is 60000ms, i.e. 1 minute. Not sure if this is sufficient or becoming too annoying for some users... Let's observe the pre-release response.