### PR TITLE
change autoRun default

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,11 +360,11 @@ Users can use the following settings to tailor the extension for their environme
 |setting|description|default|example/notes|
 |---|---|---|---|
 |**Process**|
-|autoEnable :x:|Automatically start Jest for this project|true|Please use `autoRun` instead|
+|<strike>autoEnable</strike> :x:|Automatically start Jest for this project|true|Please use [autoRun](#autorun) instead|
 |[jestCommandLine](#jestCommandLine)|The command line to start jest tests|undefined|`"jest.jestCommandLine": "npm test -"` or `"jest.jestCommandLine": "yarn test"` or `"jest.jestCommandLine": "node_modules/.bin/jest --config custom-config.js"`|
 |nodeEnv|Add additional env variables to spawned jest process|null|`"jest.nodeEnv": {"PORT": "9800", "BAR":"true"}` |
 |shell|Custom shell (path or LoginShell) for executing jest|null|`"jest.shell": "/bin/bash"` or `"jest.shell": "powershell"` or `"jest.shell": {"path": "/bin/bash"; args: ["--login"]}`  |
-|[autoRun](#autorun)|Controls when and what tests should be run|undefined|`"jest.autoRun": "off"` or `"jest.autoRun": "watch"` or `"jest.autoRun": {watch: false, onSave:"test-only"}`|
+|[autoRun](#autorun)|Controls when and what tests should be run|undefined|`"jest.autoRun": "off"` or `"jest.autoRun": "watch"` or `"jest.autoRun": {"watch": false, "onSave":"test-only"}`|
 |[rootPath](#rootPath)|The path to your frontend src folder|""|`"jest.rootPath":"packages/app"` or `"jest.rootPath":"/apps/my-app"`|
 |[monitorLongRun](#monitorlongrun)| monitor long running tests based on given threshold in ms|60000|`"jest.monitorLongRun": 120000`|
 |pathToJest :x:|The path to the Jest binary, or an npm/yarn command to run tests|undefined|Please use `jestCommandLine` instead|
@@ -457,12 +457,16 @@ for example:
       }
   ```
 
-  The string type are short-hand of the most common configurations. User can also pass the actual config in the .settings file for custom config. Following are the mapping of short-hand type to the actual config:
+  The string type are short-hand for the most common configurations:
 
-  - "watch" => {watch: true}
-  - "off" => {watch: false}
-  - "legacy" => {watch: true, onStartup: ["all-tests"]}
-  - "on-save" => {watch: false, onSave: "test-src-file"}
+  | Short Hand | description | actual config | note |
+  |:-:|---|---|---|---|
+  |**"watch"** |run jest in watch mode| {"watch": true} | the default mode|
+  |**"off"**|turn off jest autoRun| {"watch": false} | this is the manual mode | 
+  |**"legacy"**|starting a full test-run followed by jest watch| {"watch": true, "onStartup": ["all-tests"]} | he default mode prior to v4.7 | 
+  |**"on-save"**|run jest upon source or test file changes| {"watch": false, "onSave": "test-src-file"} | | 
+
+  User can also pass the actual config in the `.vscode/settings.json`, see more example below.
 
   <details>
   <summary>example</summary>
@@ -502,19 +506,11 @@ for example:
 
 </details>
 
-Note: migration rule from settings prior to v4:
+Note: migration rule for default autoRun:
 
   - if `"jest.autoEnabled" = false` => manual mode: `"jest.autoRun": "off"`
-  - if `"jest.runAllTestsFirst" = false` => `"jest.autoRun": {"watch": true }`
-  - if no customization of the 2 settings and no `"jest.autoRun"` found =>
-    after v4.7:
-       ``` json
-       "jest.autoRun": "watch"
-       ```
-    prior to v4.7
-       ``` json
-       "jest.autoRun": "legacy"
-       ```
+  - if `"jest.runAllTestsFirst" = true` => `"jest.autoRun": {"watch": true, "onStartup": ["all-tests"] }`
+  - if no customization of the 2 settings and no `"jest.autoRun"` found => `"jest.autoRun": "watch"`
 
 ##### testExplorer
   ```ts

--- a/package.json
+++ b/package.json
@@ -110,10 +110,7 @@
         },
         "jest.nodeEnv": {
           "markdownDescription": "The env passed to runner process in addtion to `process.env`",
-          "type": [
-            "object",
-            "null"
-          ],
+          "type": "object",
           "default": null,
           "scope": "resource"
         },
@@ -121,8 +118,7 @@
           "markdownDescription": "The shell path or a login-shell to override jest runner process default shell (see Node [child_process.spawn()](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)) for more detail)",
           "type": [
             "string",
-            "object",
-            "null"
+            "object"
           ],
           "default": null,
           "scope": "resource"
@@ -215,8 +211,7 @@
           "markdownDescription": "Control when jest should run (changed) tests. It supports multiple models, such as fully automated, fully manual and onSave... See [AutoRun](https://github.com/jest-community/vscode-jest/blob/master/README.md#how-to-trigger-the-test-run) for details and examples",
           "type": [
             "object",
-            "string",
-            "null"
+            "string"
           ],
           "default": null,
           "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "jest.runAllTestsFirst": {
           "description": "Run all tests before starting Jest in watch mode",
           "type": "boolean",
-          "default": true,
+          "default": null,
           "scope": "resource",
           "markdownDeprecationMessage": "**Deprecated**: in favor of `#jest.autoRun#`"
         },

--- a/src/JestExt/types.ts
+++ b/src/JestExt/types.ts
@@ -3,7 +3,7 @@ import { JestTotalResults, ProjectWorkspace } from 'jest-editor-support';
 import * as vscode from 'vscode';
 import { LoggingFactory } from '../logging';
 import {
-  JestExtAutoRunConfig,
+  JestExtAutoRunSetting,
   OnSaveFileType,
   OnStartupType,
   PluginResourceSettings,
@@ -19,7 +19,7 @@ export enum WatchMode {
   WatchAll = 'watchAll',
 }
 export interface AutoRunAccessor {
-  config: JestExtAutoRunConfig;
+  config: JestExtAutoRunSetting;
   isOff: boolean;
   isWatch: boolean;
   onSave: OnSaveFileType | undefined;

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -14,14 +14,16 @@ export type JestTestProcessType =
 
 export type OnStartupType = Extract<JestTestProcessType, 'all-tests'>[];
 export type OnSaveFileType = 'test-file' | 'test-src-file';
+export type JestExtAutoRunShortHand = 'default' | 'watch' | 'on-save' | 'legacy' | 'off';
+
 export type JestExtAutoRunConfig =
-  | 'off'
   | { watch: true; onStartup?: OnStartupType }
   | {
       watch: false;
       onStartup?: OnStartupType;
       onSave?: OnSaveFileType;
     };
+export type JestExtAutoRunSetting = JestExtAutoRunShortHand | JestExtAutoRunConfig;
 
 export type TestExplorerConfig =
   | { enabled: false }
@@ -42,7 +44,7 @@ export interface PluginResourceSettings {
   coverageFormatter: string;
   debugMode?: boolean;
   coverageColors?: CoverageColors;
-  autoRun?: JestExtAutoRunConfig;
+  autoRun: JestExtAutoRunConfig;
   testExplorer: TestExplorerConfig;
   nodeEnv?: NodeEnv;
   shell?: string | LoginShell;

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -84,7 +84,11 @@ describe('JestExt', () => {
     settings?: Partial<PluginResourceSettings>;
     coverageCodeLensProvider?: any;
   }) => {
-    const extensionSettings = { debugCodeLens: {}, testExplorer: { enabled: true } } as any;
+    const extensionSettings = {
+      debugCodeLens: {},
+      testExplorer: { enabled: true },
+      autoRun: { watch: true },
+    } as any;
     mockGetExtensionResourceSettings.mockReturnValue(
       override?.settings ? { ...extensionSettings, ...override.settings } : extensionSettings
     );
@@ -1018,12 +1022,11 @@ describe('JestExt', () => {
       expect(createProcessSession).toBeCalledTimes(1);
       const settings: any = {
         debugMode: true,
+        autoRun: { watch: true },
       };
       await jestExt.triggerUpdateSettings(settings);
       expect(createProcessSession).toBeCalledTimes(2);
-      expect(createProcessSession).toHaveBeenLastCalledWith(
-        expect.objectContaining({ settings: { debugMode: true } })
-      );
+      expect(createProcessSession).toHaveBeenLastCalledWith(expect.objectContaining({ settings }));
     });
   });
   describe('can handle test run results', () => {


### PR DESCRIPTION
This is a breaking change, mainly to disable "full test run at start-up" as the default behavior. This should improve most projects' start-up time, especially for big projects. 

Summary of the change:
- introduce some short-hand to make configuring `jest.autoRun` easier.
- change default `jest.autoRun` to be  `{watch: true}` instead of `{watch: true, onStartup: ["all-tests"]}`.
- updated README

Note, This only impacts users without the existing `jest.autoRun` setting. People with  `"jest.runAllTestsFirst": true` will continue to use the "legacy" autoRun.


