### PR TITLE
Fix  quoting test names with special characters

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -225,8 +225,10 @@ const getShellPath = (shell?: string | LoginShell): string | undefined => {
  * quoting a given string for it to be used as shell command arguments.
  *
  * Note: the logic is based on vscode's debug argument handling:
- * https://github.com/microsoft/vscode/blob/c0001d7becf437944f5898a7c9485922d60dd8d3/src/vs/workbench/contrib/debug/node/terminals.ts#L82 .
+ * https://github.com/microsoft/vscode/blob/c0001d7becf437944f5898a7c9485922d60dd8d3/src/vs/workbench/contrib/debug/node/terminals.ts#L82
  * However, had to modify a few places for windows platform.
+ *
+ * updated 10/22/2022 based on https://github.com/microsoft/vscode/blob/d1f38520db76f0e80e3cdcbb35b95651afe802ae/src/vs/workbench/contrib/debug/node/terminals.ts#L60
  *
  **/
 
@@ -256,6 +258,7 @@ export const shellQuote = (str: string, shell?: string | LoginShell): string => 
 
     case 'cmd': {
       let s = str.replace(/"/g, '""');
+      s = s.replace(/([><!^&|])/g, '^$1');
       if (s.length > 2 && s.slice(-2) === '\\\\') {
         s = `${s}\\\\`;
       }
@@ -264,11 +267,13 @@ export const shellQuote = (str: string, shell?: string | LoginShell): string => 
 
     default: {
       //'sh'
-      const s = str.replace(/(["'\\$])/g, '\\$1');
-      return s.indexOf(' ') >= 0 || s.indexOf(';') >= 0 || s.length === 0 ? `"${s}"` : s;
+      const s = str.replace(/(["'\\$!><#()[\]*&^| ;{}`])/g, '\\$1');
+      return s.length === 0 ? `""` : s;
     }
   }
 };
+// [.+?]
+// ["'!><#&;`]
 
 export const toErrorString = (e: unknown): string => {
   if (e == null) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -272,8 +272,6 @@ export const shellQuote = (str: string, shell?: string | LoginShell): string => 
     }
   }
 };
-// [.+?]
-// ["'!><#&;`]
 
 export const toErrorString = (e: unknown): string => {
   if (e == null) {

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -259,6 +259,7 @@ describe('JestProcess', () => {
         ${'win32'}  | ${undefined}    | ${"with '$single quote'"}         | ${'"with \'\\$single quote\'"'}
         ${'win32'}  | ${'powershell'} | ${"with '$single quote'"}         | ${"'with ''\\$single quote'''"}
         ${'darwin'} | ${'bash'}       | ${"with '$single quote'"}         | ${"with\\ \\'\\\\\\$single\\ quote\\'"}
+        ${'darwin'} | ${'bash'}       | ${'with single `backtick'}        | ${'with\\ single\\ \\`backtick'}
       `(
         'convert "$testNamePattern" on $platform, $shell',
         ({ platform, shell, testNamePattern, expected }) => {

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -144,9 +144,9 @@ describe('JestProcess', () => {
       ${'watch-all-tests'}      | ${undefined}                                                     | ${[true, true]}   | ${true}         | ${undefined}
       ${'by-file'}              | ${{ testFileName: '"c:\\a\\b.ts"' }}                             | ${[false, false]} | ${true}         | ${{ args: { args: ['--runTestsByPath'] }, testFileNamePattern: '"C:\\a\\b.ts"' }}
       ${'by-file'}              | ${{ testFileName: '"c:\\a\\b.ts"', notTestFile: true }}          | ${[false, false]} | ${true}         | ${{ args: { args: ['--findRelatedTests', '"C:\\a\\b.ts"'] } }}
-      ${'by-file-test'}         | ${{ testFileName: '"/a/b.js"', testNamePattern: 'a test' }}      | ${[false, false]} | ${true}         | ${{ args: { args: ['--runTestsByPath'] }, testFileNamePattern: '"/a/b.js"', testNamePattern: '"a test"' }}
+      ${'by-file-test'}         | ${{ testFileName: '"/a/b.js"', testNamePattern: 'a test' }}      | ${[false, false]} | ${true}         | ${{ args: { args: ['--runTestsByPath'] }, testFileNamePattern: '"/a/b.js"', testNamePattern: 'a\\ test' }}
       ${'by-file-pattern'}      | ${{ testFileNamePattern: '"c:\\a\\b.ts"' }}                      | ${[false, false]} | ${true}         | ${{ args: { args: ['--testPathPattern', '"c:\\\\a\\\\b\\.ts"'] } }}
-      ${'by-file-test-pattern'} | ${{ testFileNamePattern: '/a/b.js', testNamePattern: 'a test' }} | ${[false, false]} | ${true}         | ${{ args: { args: ['--testPathPattern', '"/a/b\\.js"'] }, testNamePattern: '"a test"' }}
+      ${'by-file-test-pattern'} | ${{ testFileNamePattern: '/a/b.js', testNamePattern: 'a test' }} | ${[false, false]} | ${true}         | ${{ args: { args: ['--testPathPattern', '"/a/b\\.js"'] }, testNamePattern: 'a\\ test' }}
       ${'not-test'}             | ${{ args: ['--listTests', '--watchAll=false'] }}                 | ${[false, false]} | ${false}        | ${{ args: { args: ['--listTests'], replace: true } }}
     `(
       'supports jest process request: $type',
@@ -251,14 +251,14 @@ describe('JestProcess', () => {
         ${'win32'}  | ${undefined}    | ${'with special $character.abc*'} | ${'"with special \\$character\\.abc\\*"'}
         ${'win32'}  | ${'CMD.EXE'}    | ${'with special $character.abc*'} | ${'"with special \\$character\\.abc\\*"'}
         ${'win32'}  | ${'powershell'} | ${'with special $character.abc*'} | ${"'with special \\$character\\.abc\\*'"}
-        ${'darwin'} | ${undefined}    | ${'with special $character.abc*'} | ${'"with special \\\\\\$character\\\\.abc\\\\*"'}
-        ${'darwin'} | ${'zsh'}        | ${'with special $character.abc*'} | ${'"with special \\\\\\$character\\\\.abc\\\\*"'}
+        ${'darwin'} | ${undefined}    | ${'with special $character.abc*'} | ${'with\\ special\\ \\\\\\$character\\\\.abc\\\\\\*'}
+        ${'darwin'} | ${'zsh'}        | ${'with special $character.abc*'} | ${'with\\ special\\ \\\\\\$character\\\\.abc\\\\\\*'}
         ${'win32'}  | ${undefined}    | ${'with "$double quote"'}         | ${'"with ""\\$double quote"""'}
         ${'win32'}  | ${'powershell'} | ${'with "$double quote"'}         | ${'\'with ""\\$double quote""\''}
-        ${'linux'}  | ${'bash'}       | ${'with "$double quote"'}         | ${'"with \\"\\\\\\$double quote\\""'}
+        ${'linux'}  | ${'bash'}       | ${'with "$double quote"'}         | ${'with\\ \\"\\\\\\$double\\ quote\\"'}
         ${'win32'}  | ${undefined}    | ${"with '$single quote'"}         | ${'"with \'\\$single quote\'"'}
         ${'win32'}  | ${'powershell'} | ${"with '$single quote'"}         | ${"'with ''\\$single quote'''"}
-        ${'darwin'} | ${'bash'}       | ${"with '$single quote'"}         | ${'"with \\\'\\\\\\$single quote\\\'"'}
+        ${'darwin'} | ${'bash'}       | ${"with '$single quote'"}         | ${"with\\ \\'\\\\\\$single\\ quote\\'"}
       `(
         'convert "$testNamePattern" on $platform, $shell',
         ({ platform, shell, testNamePattern, expected }) => {

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -328,6 +328,9 @@ describe('shellQuote', () => {
     ${'win32'}  | ${'powershell'}                           | ${'something\\'}         | ${"'something\\'"}
     ${'win32'}  | ${undefined}                              | ${'something\\'}         | ${'something\\'}
     ${'darwin'} | ${undefined}                              | ${'something\\'}         | ${'something\\\\'}
+    ${'win32'}  | ${'powershell'}                           | ${'with `backtick'}      | ${"'with `backtick'"}
+    ${'win32'}  | ${undefined}                              | ${'with `backtick'}      | ${'"with `backtick"'}
+    ${'darwin'} | ${undefined}                              | ${'with `backtick'}      | ${'with\\ \\`backtick'}
   `('can quote "$str" for $shell on $platform', ({ platform, shell, str, expected }) => {
     jest.resetAllMocks();
     mockPlatform.mockReturnValueOnce(platform);

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -301,27 +301,30 @@ describe('shellQuote', () => {
   it.each`
     platform    | shell                                     | str                      | expected
     ${'win32'}  | ${undefined}                              | ${'plain text'}          | ${'"plain text"'}
-    ${'linux'}  | ${undefined}                              | ${'plain text'}          | ${'"plain text"'}
+    ${'linux'}  | ${undefined}                              | ${'plain text'}          | ${'plain\\ text'}
     ${'win32'}  | ${'powershell'}                           | ${"with 'single quote'"} | ${"'with ''single quote'''"}
     ${'win32'}  | ${'cmd.exe'}                              | ${"with 'single quote'"} | ${'"with \'single quote\'"'}
-    ${'linux'}  | ${'/bin/bash'}                            | ${"with 'single quote'"} | ${'"with \\\'single quote\\\'"'}
-    ${'darwin'} | ${'/bin/zsh'}                             | ${"with 'single quote'"} | ${'"with \\\'single quote\\\'"'}
-    ${'darwin'} | ${{ path: '/bin/zsh', args: ['-l'] }}     | ${"with 'single quote'"} | ${'"with \\\'single quote\\\'"'}
+    ${'linux'}  | ${'/bin/bash'}                            | ${"with 'single quote'"} | ${"with\\ \\'single\\ quote\\'"}
+    ${'darwin'} | ${'/bin/zsh'}                             | ${"with 'single quote'"} | ${"with\\ \\'single\\ quote\\'"}
+    ${'darwin'} | ${{ path: '/bin/zsh', args: ['-l'] }}     | ${"with 'single quote'"} | ${"with\\ \\'single\\ quote\\'"}
     ${'win32'}  | ${undefined}                              | ${"with 'single quote'"} | ${'"with \'single quote\'"'}
-    ${'linux'}  | ${undefined}                              | ${"with 'single quote'"} | ${'"with \\\'single quote\\\'"'}
+    ${'linux'}  | ${undefined}                              | ${"with 'single quote'"} | ${"with\\ \\'single\\ quote\\'"}
     ${'win32'}  | ${'powershell'}                           | ${'with "double quote"'} | ${'\'with ""double quote""\''}
     ${'win32'}  | ${'cmd.exe'}                              | ${'with "double quote"'} | ${'"with ""double quote"""'}
-    ${'linux'}  | ${'bash'}                                 | ${'with "double quote"'} | ${'"with \\"double quote\\""'}
+    ${'linux'}  | ${'bash'}                                 | ${'with "double quote"'} | ${'with\\ \\"double\\ quote\\"'}
+    ${'win32'}  | ${'powershell'}                           | ${'with $name.txt'}      | ${"'with $name.txt'"}
+    ${'win32'}  | ${'cmd.exe'}                              | ${'with $name.txt'}      | ${'"with $name.txt"'}
+    ${'linux'}  | ${'bash'}                                 | ${'with $name.txt'}      | ${'with\\ \\$name.txt'}
     ${'win32'}  | ${'powershell'}                           | ${'with \\$name\\.txt'}  | ${"'with \\$name\\.txt'"}
     ${'win32'}  | ${'cmd.exe'}                              | ${'with \\$name\\.txt'}  | ${'"with \\$name\\.txt"'}
-    ${'linux'}  | ${'bash'}                                 | ${'with \\$name\\.txt'}  | ${'"with \\\\\\$name\\\\.txt"'}
-    ${'linux'}  | ${{ path: '/bin/sh', args: ['--login'] }} | ${'with \\$name\\.txt'}  | ${'"with \\\\\\$name\\\\.txt"'}
+    ${'linux'}  | ${'bash'}                                 | ${'with \\$name\\.txt'}  | ${'with\\ \\\\\\$name\\\\.txt'}
+    ${'linux'}  | ${{ path: '/bin/sh', args: ['--login'] }} | ${'with \\$name\\.txt'}  | ${'with\\ \\\\\\$name\\\\.txt'}
     ${'win32'}  | ${'powershell'}                           | ${''}                    | ${"''"}
     ${'win32'}  | ${undefined}                              | ${''}                    | ${'""'}
     ${'darwin'} | ${undefined}                              | ${''}                    | ${'""'}
     ${'win32'}  | ${'powershell'}                           | ${'with \\ and \\\\'}    | ${"'with \\ and \\\\\\\\'"}
     ${'win32'}  | ${undefined}                              | ${'with \\ and \\\\'}    | ${'"with \\ and \\\\\\\\"'}
-    ${'linux'}  | ${undefined}                              | ${'with \\ and \\\\'}    | ${'"with \\\\ and \\\\\\\\"'}
+    ${'linux'}  | ${undefined}                              | ${'with \\ and \\\\'}    | ${'with\\ \\\\\\ and\\ \\\\\\\\'}
     ${'win32'}  | ${'powershell'}                           | ${'something\\'}         | ${"'something\\'"}
     ${'win32'}  | ${undefined}                              | ${'something\\'}         | ${'something\\'}
     ${'darwin'} | ${undefined}                              | ${'something\\'}         | ${'something\\\\'}


### PR DESCRIPTION
fix shellQuote to accommodate more special characters, such as backtick.

fixes #847 