### PR TITLE
auto recovery with login-shell when encountered command not found issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Content
   - [Troubleshooting](#troubleshooting)
     - [Jest failed to run](#jest-failed-to-run)
     - [Performance issue?](#performance-issue)
+    - [Intermittent errors for (npm/yar/node) command not found during test run or debugging](#intermittent-errors-for-npmyarnode-command-not-found-during-test-run-or-debugging)
     - [I don't see "Jest" in the bottom status bar](#i-dont-see-jest-in-the-bottom-status-bar)
     - [What to do with "Long Running Tests Warning"](#what-to-do-with-long-running-tests-warning)
     - [The tests and status do not match or some tests showing question marks unexpectedly?](#the-tests-and-status-do-not-match-or-some-tests-showing-question-marks-unexpectedly)
@@ -169,12 +170,12 @@ You can customize coverage start up behavior, style and colors, see [customizati
 
 ### How to use the extension with monorepo projects?
 
+The easiest way to setup the monorepo projects is to use the [Setup Tool](setup-wizard.md#setup-monorepo-project) and choose **Setup monorepo project**
+
 The extension supports monorepo projects in the following configurations:
 
 1. Single-root workspace: If all tests from monorepo packages can be run from a centralized location, such as project root, then a single-root workspace with proper ["jest.jestCommandLine"](#jestcommandline) and ["jest.rootPath"](#rootpath) setting should work. 
 2. Multi-root workspace: If each monorepo package has its own local jest root and configuration, a [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) is required. Users can use `"jest.disabledWorkspaceFolders"` to exclude the packages from jest run. 
-
-Users might find it easier to setup monorepo project via a [Setup Tool](setup-wizard.md).
 
 Please note, a working jest environment is a prerequisite for this extension. If you are having problem running the tests from a terminal, please follow [jest](https://jestjs.io/docs/configuration) instruction to set it up first.
    
@@ -555,20 +556,13 @@ Sorry you are having trouble with the extension. If your issue did not get resol
 
   If you can run jest manually in the terminal but the extension showed error like "xxx ended unexpectedly", following are the most common causes (see [self-diagnosis](#how-to-see-more-debug-info-self-diagnosis) if you need more debug info):
 
-  - <a id="trouble-shell-env"></a>**runtime environment issue**: such as the shell env is not fully initialized upon vscode start up. A good indicator is messages prefixed with **"env:"**, or node/yarn/npm command not found, such as `env: node: No such file or directory` 
-    - This should only happened in Linux or MacOS and is caused by vscode not able to fully initialize the shell env when it starts up (more details [here](https://code.visualstudio.com/docs/supporting/faq#_resolving-shell-environment-fails)).
-    - The extension usually spawns the jest process with a non-login/not-interactive shell, which inherits the vscode env. If vscode env is not complete, the jest process could fail for example the `PATH` env variable is not correct. (more details [here](https://github.com/jest-community/vscode-jest/issues/741#issuecomment-921222851))
-    - There are many ways to workaround such issues:
-      - simply restart vscode sometimes can fix it
-      - start vscode from a terminal 
-      - add `PATH` directly to `jest.nodeEnv` settings, if that is the only problem.
-      - force the jest command to be executed in a login shell by setting ["jest.shell"](#shell) to a LoginShell. Note this might have some slight performance overhead. 
+  
   - <a id="trouble-jest-cmdline"></a>**jest command line issue**: such as you usually run `yarn test` but the extension uses the default `jest` instead.
     - Try configuring the [jest.jestCommandLine](#jestcommandline) to mimic how you run jest from the terminal, such as `yarn test` or `npm run test --`. The extension can auto-config common configurations like create react apps but not custom scripts like [CRACO](https://github.com/gsoft-inc/craco).
     - or you can use the **"Run Setup Tool"** button in the error panel to resolve the configuration issue, see [Setup Tool](setup-wizard.md).  
   - **monorepo project issue**: you have a monorepo project but might not have been set up properly. 
-    - see more in [monorepo projects](#how-to-use-the-extension-with-monorepo-projects) on how to set it up.
-
+    - short answer is try [Setup monorepo project](setup-wizard.md#setup-monorepo-project) tool. Or read more detail in [how to use the extension with monorepo projects](#how-to-use-the-extension-with-monorepo-projects).
+  
 There could be other causes, such as jest test root path is different from the project's, which can be fixed by setting [jest.rootPath](#rootPath). Feel free to check out the [customization](#customization) section to manually adjust the extension if needed.
 
 ### Performance issue? 
@@ -592,6 +586,26 @@ https://user-images.githubusercontent.com/891093/199872543-4f37de90-1e56-4e0d-83
 Every project and developer are different. Experiment and pick the autoRun setting that fits your style and preference!
 
 </details>
+
+### Intermittent errors for (npm/yar/node) command not found during test run or debugging
+
+This should only happen in Linux or MacOS, and is due to vscode not able to fully initialize the shell env when it starts up (more details [here](https://code.visualstudio.com/docs/supporting/faq#_resolving-shell-environment-fails)).
+
+- for test run:
+  A solution is introduced in [v5.0.2](release-notes/release-note-v5.md#v50-pre-release-roll-up), which will automatically fallback to a login-shell during such situation. It should not be an issue any more 🤞.
+- for test debugging:
+  - you can instruct vscode debugger to use a login shell via [task/debug profile](https://code.visualstudio.com/docs/terminal/profiles#_configuring-the-taskdebug-profile), for example, adding the following in your user's settings then restart:
+
+    ```json
+    "terminal.integrated.automationProfile.osx": {
+      "args": ["-l"],
+      "path": "/bin/bash"
+    },
+    ```
+
+Alternatively, you can try the following methods if you prefer a non-login-shell solution:
+  - simply restart vscode sometimes can fix it
+  - start vscode from a terminal: type `code` from your external terminal
 
 ### I don't see "Jest" in the bottom status bar
 This means the extension is not activated. 

--- a/README.md
+++ b/README.md
@@ -429,6 +429,9 @@ interface LoginShell
 By default, jest command is executed in default shell ('cmd' for windows, '/bin/sh' for non-windows). Users can use the `"jest.shell"` setting to either pass the path of another shell (e.g. "/bin/zsh") or a LoginShell config, basically a shell path and login arguments (e.g. `{"path": "/bin/bash", "args": ["--login"]}`)
 
 Note the LoginShell is only applicable for non-windows platform and could cause a bit more overhead.
+
+<a id="auto-fallback-login-shell"></a>
+_Note_: If detected shell env issue, such as `node: command not found` or `npm: no such file or directory`, the extension will fallback to a login shell to ensure tests can run correctly. If will try to auto generate a login shell configuration based on the `jest.shell` setting, otherwise, it will use the default `bash` login-shell. Currently supported auto-fallback shells are `bash`, `zsh`, `fish`.
 ### Debug Config
 
 This extension looks for jest specific debug config (`"vscode-jest-tests"` or `"vscode-jest-tests.v2"`) in the following order:
@@ -592,7 +595,7 @@ Every project and developer are different. Experiment and pick the autoRun setti
 This should only happen in Linux or MacOS, and is due to vscode not able to fully initialize the shell env when it starts up (more details [here](https://code.visualstudio.com/docs/supporting/faq#_resolving-shell-environment-fails)).
 
 - for test run:
-  A solution is introduced in [v5.0.2](release-notes/release-note-v5.md#v50-pre-release-roll-up), which will automatically fallback to a login-shell during such situation. It should not be an issue any more 🤞.
+  A solution is introduced in [v5.0.2](release-notes/release-note-v5.md#v50-pre-release-roll-up), which will [automatically fallback to a login-shell](#auto-fallback-login-shell) during such situation. Hopefully, this should not be an issue any more 🤞.
 - for test debugging:
   - you can instruct vscode debugger to use a login shell via [task/debug profile](https://code.visualstudio.com/docs/terminal/profiles#_configuring-the-taskdebug-profile), for example, adding the following in your user's settings then restart:
 

--- a/package.json
+++ b/package.json
@@ -501,7 +501,7 @@
   "dependencies": {
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",
-    "jest-editor-support": "^30.2.0"
+    "jest-editor-support": "^30.2.1"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.2",

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -219,11 +219,12 @@ export class JestExt {
     return actions;
   };
   private createProcessSession(): ProcessSession {
-    return createProcessSession({
+    const sessionContext = {
       ...this.extContext,
       updateWithData: this.updateWithData.bind(this),
       onRunEvent: this.events.onRunEvent,
-    });
+    };
+    return createProcessSession(sessionContext);
   }
   private toSBStats(stats: TestStats): SBTestStats {
     return { ...stats, isDirty: this.dirtyFiles.size > 0 };
@@ -629,6 +630,17 @@ export class JestExt {
 
     // restart jest since coverage condition has changed
     this.triggerUpdateSettings(this.extContext.settings);
+  }
+  enableLoginShell(): void {
+    if (this.extContext.settings.shell.useLoginShell) {
+      return;
+    }
+    this.extContext.settings.shell.enableLoginShell();
+    this.triggerUpdateSettings(this.extContext.settings);
+    this.extContext.output.write(
+      `possible process env issue detected, restarting with a login-shell...\r\n`,
+      'warn'
+    );
   }
 
   private setupStatusBar(): void {

--- a/src/JestExt/process-listeners.ts
+++ b/src/JestExt/process-listeners.ts
@@ -182,7 +182,7 @@ const WATCH_IS_NOT_SUPPORTED_REGEXP =
   /^s*--watch is not supported without git\/hg, please use --watchAlls*/im;
 const RUN_EXEC_ERROR = /onRunComplete: execError: (.*)/im;
 const RUN_START_TEST_SUITES_REGEX = /onRunStart: numTotalTestSuites: ((\d)+)/im;
-const CONTROL_MESSAGES = /^(onRunStart|onRunComplete|Test results written to)[^\n]+\n/im;
+const CONTROL_MESSAGES = /^(onRunStart|onRunComplete|Test results written to)[^\n]+\n/gim;
 
 /**
  * monitor for long test run, default is 1 minute

--- a/src/JestExt/process-listeners.ts
+++ b/src/JestExt/process-listeners.ts
@@ -6,16 +6,28 @@ import { ListenerSession, ListTestFilesCallback } from './process-session';
 import { Logging } from '../logging';
 import { JestRunEvent } from './types';
 import { MonitorLongRun } from '../Settings';
+import { extensionName } from '../appGlobals';
+import { RunShell } from './run-shell';
 
+// command not found error for anything but "jest", as it most likely not be caused by env issue
+const POSSIBLE_ENV_ERROR_REGEX =
+  /^(((?!(jest|react-scripts)).)*)(command not found|no such file or directory)/im;
 export class AbstractProcessListener {
   protected session: ListenerSession;
   protected readonly logging: Logging;
   public onRunEvent: vscode.EventEmitter<JestRunEvent>;
 
+  // flag indicating command not found due to process env issue
+  protected CmdNotFoundEnv: boolean;
+  private useLoginShell: RunShell['useLoginShell'];
+
   constructor(session: ListenerSession) {
     this.session = session;
     this.logging = session.context.loggingFactory.create(this.name);
     this.onRunEvent = session.context.onRunEvent;
+
+    this.CmdNotFoundEnv = false;
+    this.useLoginShell = session.context.settings.shell.useLoginShell;
   }
   protected get name(): string {
     return 'AbstractProcessListener';
@@ -67,16 +79,17 @@ export class AbstractProcessListener {
 
   protected onProcessStarting(process: JestProcess): void {
     this.session.context.onRunEvent.fire({ type: 'process-start', process });
-    this.logging('debug', `${process.request.type} onProcessStarting`);
   }
-  protected onExecutableStdErr(process: JestProcess, data: string, _raw: string): void {
-    this.logging('debug', `${process.request.type} onExecutableStdErr:`, data);
+  protected onExecutableStdErr(_process: JestProcess, data: string, _raw: string): void {
+    if (POSSIBLE_ENV_ERROR_REGEX.test(data)) {
+      this.CmdNotFoundEnv = true;
+    }
   }
-  protected onExecutableJSON(process: JestProcess, data: JestTotalResults): void {
-    this.logging('debug', `${process.request.type} onExecutableJSON:`, data);
+  protected onExecutableJSON(_process: JestProcess, _data: JestTotalResults): void {
+    // no default behavior...
   }
-  protected onExecutableOutput(process: JestProcess, data: string, _raw: string): void {
-    this.logging('debug', `${process.request.type} onExecutableOutput:`, data);
+  protected onExecutableOutput(_process: JestProcess, _data: string, _raw: string): void {
+    // no default behavior...
   }
   protected onTerminalError(process: JestProcess, data: string, _raw: string): void {
     this.logging('error', `${process.request.type} onTerminalError:`, data);
@@ -84,18 +97,29 @@ export class AbstractProcessListener {
   protected onProcessClose(_process: JestProcess, _code?: number, _signal?: string): void {
     // no default behavior...
   }
-  protected onProcessExit(process: JestProcess, code?: number, signal?: string): void {
-    // default behavior: logging error
-    if (this.isProcessError(code)) {
-      const error = `${process.request.type} onProcessExit: process exit with code=${code}, signal=${signal}`;
-      this.logging('warn', `${error} :`, process.toString());
-    }
+  protected onProcessExit(_process: JestProcess, _code?: number, _signal?: string): void {
+    // no default behavior
   }
-  protected isProcessError(code?: number): boolean {
-    // code = 1 is general error, usually mean the command emit error, which should already handled by other event processing, for example when jest has failed tests.
-    // However, error beyond 1, usually means some error outside of the command it is trying to execute, so reporting here for debugging purpose
-    // see shell error code: https://www.linuxjournal.com/article/10844
-    return code != null && code > 1;
+
+  /**
+   * retry the process with login shell if possible. return true if will retry, otherwise false.
+   * @param process
+   * @param code
+   * @param signal
+   */
+  protected retryWithLoginShell(process: JestProcess, code?: number, signal?: string): boolean {
+    const msg = `${process.id} exit with code=${code}, signal=${signal}`;
+
+    if (code && code >= 127 && this.CmdNotFoundEnv && !this.useLoginShell) {
+      // enable login-shell
+      this.logging('debug', `${msg}; will retry with login-shell`);
+      vscode.commands.executeCommand(
+        `${extensionName}.with-workspace.enable-login-shell`,
+        this.session.context.workspace
+      );
+      return true;
+    }
+    return false;
   }
 }
 
@@ -106,7 +130,6 @@ export class ListTestFileListener extends AbstractProcessListener {
   }
   private buffer = '';
   private stderrOutput = '';
-  private exitCode?: number;
   private onResult: ListTestFilesCallback;
 
   constructor(session: ListenerSession, onResult: ListTestFilesCallback) {
@@ -122,16 +145,12 @@ export class ListTestFileListener extends AbstractProcessListener {
     this.stderrOutput += raw;
   }
 
-  protected onProcessExit(process: JestProcess, code?: number, signal?: string): void {
-    // Note: will not fire 'exit' event, as the output is reported via the onResult() callback
-    super.onProcessExit(process, code, signal);
-    this.exitCode = code;
-  }
-
-  protected onProcessClose(process: JestProcess): void {
-    super.onProcessClose(process);
-    if (this.exitCode !== 0) {
-      return this.onResult(undefined, this.stderrOutput, this.exitCode);
+  protected onProcessClose(process: JestProcess, code?: number, signal?: string): void {
+    if (code !== 0) {
+      if (super.retryWithLoginShell(process, code, signal)) {
+        return;
+      }
+      return this.onResult(undefined, this.stderrOutput, code);
     }
 
     try {
@@ -151,7 +170,7 @@ export class ListTestFileListener extends AbstractProcessListener {
       return this.onResult(uriFiles);
     } catch (e) {
       this.logging('warn', 'failed to parse result:', this.buffer, 'error=', e);
-      this.onResult(undefined, toErrorString(e), this.exitCode);
+      this.onResult(undefined, toErrorString(e), code);
     }
   }
 }
@@ -163,7 +182,7 @@ const WATCH_IS_NOT_SUPPORTED_REGEXP =
   /^s*--watch is not supported without git\/hg, please use --watchAlls*/im;
 const RUN_EXEC_ERROR = /onRunComplete: execError: (.*)/im;
 const RUN_START_TEST_SUITES_REGEX = /onRunStart: numTotalTestSuites: ((\d)+)/im;
-const CONTROL_MESSAGES = /^(onRunStart|onRunComplete|Test results written to)[^\n]+\n/gim;
+const CONTROL_MESSAGES = /^(onRunStart|onRunComplete|Test results written to)[^\n]+\n/im;
 
 /**
  * monitor for long test run, default is 1 minute
@@ -211,7 +230,6 @@ export class RunTestListener extends AbstractProcessListener {
   // fire long-run warning once per run
   private longRunMonitor: LongRunMonitor;
   private runInfo: RunInfo | undefined;
-  private exitCode?: number;
 
   constructor(session: ListenerSession) {
     super(session);
@@ -332,6 +350,7 @@ export class RunTestListener extends AbstractProcessListener {
     if (this.shouldIgnoreOutput(message)) {
       return;
     }
+    super.onExecutableStdErr(process, message, raw);
 
     const cleaned = this.cleanupOutput(raw);
     this.handleRunStart(process, message);
@@ -388,15 +407,16 @@ export class RunTestListener extends AbstractProcessListener {
   protected onTerminalError(process: JestProcess, data: string, raw: string): void {
     this.onRunEvent.fire({ type: 'data', process, text: data, raw, newLine: true, isError: true });
   }
-  protected onProcessExit(process: JestProcess, code?: number, signal?: string): void {
-    this.runEnded();
-    super.onProcessExit(process, code, signal);
-    this.exitCode = code;
-  }
 
-  protected onProcessClose(process: JestProcess): void {
-    super.onProcessClose(process);
+  protected onProcessClose(process: JestProcess, code?: number, signal?: string): void {
+    this.runEnded();
     const error = this.handleWatchProcessCrash(process);
-    this.onRunEvent.fire({ type: 'exit', process, error, code: this.exitCode });
+
+    if (code && code > 1) {
+      if (this.retryWithLoginShell(process, code, signal)) {
+        return;
+      }
+    }
+    this.onRunEvent.fire({ type: 'exit', process, error, code });
   }
 }

--- a/src/JestExt/run-shell.ts
+++ b/src/JestExt/run-shell.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+import { LoginShell } from 'jest-editor-support';
+import { platform } from 'os';
+import * as path from 'path';
+
+// based on vscode setting configuration for "terminal.integrated.profiles.osx"
+export const LoginShells: Record<string, LoginShell> = {
+  bash: {
+    path: 'bash',
+    args: ['-l'],
+  },
+  zsh: {
+    path: 'zsh',
+    args: ['-l'],
+  },
+  fish: {
+    path: 'fish',
+    args: ['-l'],
+  },
+  sh: {
+    path: '/bin/bash',
+    args: ['-l'],
+  },
+};
+
+export class RunShell {
+  /** determine toSetting() output; if set to 'never', only the nonLoginShell will ever be returned */
+  private _useLoginShell: boolean | 'never';
+  private nonLoginShell?: string;
+  private loginShell?: LoginShell;
+
+  constructor(setting?: string | LoginShell) {
+    this._useLoginShell = false;
+    this.initFromSetting(setting);
+  }
+
+  private initFromSetting(setting?: string | LoginShell): void {
+    if (setting) {
+      if (typeof setting === 'string') {
+        this._useLoginShell = false;
+        this.nonLoginShell = setting;
+        this.loginShell = this.getLoginShell(setting);
+      } else {
+        if (setting.args.length > 0) {
+          this._useLoginShell = true;
+          this.nonLoginShell = undefined;
+          this.loginShell = setting;
+        } else {
+          this._useLoginShell = false;
+          this.nonLoginShell = setting.path;
+          this.loginShell = this.getLoginShell(setting.path);
+        }
+      }
+    } else {
+      this._useLoginShell = false;
+      this.nonLoginShell = undefined;
+      this.loginShell = this.getLoginShell();
+    }
+    if (!this.loginShell) {
+      this._useLoginShell = 'never';
+    }
+  }
+
+  public get useLoginShell(): boolean | 'never' {
+    return this._useLoginShell;
+  }
+  public enableLoginShell(): void {
+    if (this._useLoginShell === 'never') {
+      console.warn('will not enable loginShell for a "never-login-shell" RunShell', this);
+      return;
+    }
+    this._useLoginShell = true;
+  }
+
+  /**
+   * returns the shell setting based on useLoginShell flag. If there is no loginShell available,
+   * for example on windows, the original setting will be returned
+   */
+  public toSetting(): undefined | string | LoginShell {
+    if (!this._useLoginShell || this._useLoginShell === 'never') {
+      return this.nonLoginShell;
+    }
+    return this.loginShell;
+  }
+
+  private getLoginShell(shellPath?: string): undefined | LoginShell {
+    if (platform() === 'win32') {
+      return;
+    }
+    const name = shellPath ? path.parse(shellPath).base : 'sh';
+    const shell = LoginShells[name];
+    if (!shell) {
+      const msg = `no login-shell definition found for shell=${name} on ${platform()}`;
+      console.warn(msg);
+      vscode.window.showErrorMessage(`${msg}. Please report this issue.`);
+    }
+    return shell;
+  }
+}

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -95,6 +95,7 @@ export class JestProcess implements JestProcessInfo {
   private quoteFilePattern(aString: string): string {
     return `"${removeSurroundingQuote(aString)}"`;
   }
+
   private startRunner(): Promise<void> {
     if (this.task) {
       this.logging('warn', `the runner task has already started!`);
@@ -144,7 +145,7 @@ export class JestProcess implements JestProcessInfo {
         options.testFileNamePattern = this.quoteFileName(this.request.testFileName);
         options.testNamePattern = shellQuote(
           escapeRegExp(this.request.testNamePattern),
-          this.extContext.settings.shell
+          this.extContext.settings.shell.toSetting()
         );
         args.push('--runTestsByPath', '--watchAll=false');
         if (this.request.updateSnapshot) {
@@ -156,7 +157,7 @@ export class JestProcess implements JestProcessInfo {
         const regex = this.quoteFilePattern(escapeRegExp(this.request.testFileNamePattern));
         options.testNamePattern = shellQuote(
           escapeRegExp(this.request.testNamePattern),
-          this.extContext.settings.shell
+          this.extContext.settings.shell.toSetting()
         );
         args.push('--watchAll=false', '--testPathPattern', regex);
         if (this.request.updateSnapshot) {
@@ -170,9 +171,9 @@ export class JestProcess implements JestProcessInfo {
         break;
     }
 
-    const runnerWorkspace = this.extContext.createRunnerWorkspace(
-      this.request.schedule.queue === 'blocking-2' ? { outputFileSuffix: '2' } : undefined
-    );
+    const runnerWorkspace = this.extContext.createRunnerWorkspace({
+      outputFileSuffix: this.request.schedule.queue === 'blocking-2' ? '2' : undefined,
+    });
 
     const runner = new Runner(runnerWorkspace, options);
     this.registerListener(runner);

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -1,7 +1,8 @@
 import { TestState } from '../DebugCodeLens';
 import { CoverageColors } from '../Coverage/CoverageOverlay';
-import { LoginShell, ProjectWorkspace } from 'jest-editor-support';
+import { ProjectWorkspace } from 'jest-editor-support';
 import { AutoRun } from '../JestExt/auto-run';
+import { RunShell } from '../JestExt/run-shell';
 
 export type JestTestProcessType =
   | 'all-tests'
@@ -52,7 +53,7 @@ export interface PluginResourceSettings {
   autoRun: AutoRun;
   testExplorer: TestExplorerConfig;
   nodeEnv?: NodeEnv;
-  shell?: string | LoginShell;
+  shell: RunShell;
   monitorLongRun?: MonitorLongRun;
 }
 

--- a/src/extensionManager.ts
+++ b/src/extensionManager.ts
@@ -400,6 +400,13 @@ export class ExtensionManager {
           extension.toggleCoverageOverlay();
         },
       }),
+      this.registerCommand({
+        type: 'workspace',
+        name: 'enable-login-shell',
+        callback: (extension) => {
+          extension.enableLoginShell();
+        },
+      }),
 
       // setup tool
       vscode.commands.registerCommand(`${extensionName}.setup-extension`, this.startWizard),

--- a/tests/JestExt/run-shell.test.ts
+++ b/tests/JestExt/run-shell.test.ts
@@ -1,0 +1,62 @@
+jest.unmock('../../src/JestExt/run-shell');
+
+const mockPlatform = jest.fn();
+jest.mock('os', () => ({ platform: mockPlatform }));
+jest.mock('path', () => ({
+  parse: (p: string) => {
+    const parts = p.split('/');
+    return { base: parts[parts.length - 1] };
+  },
+}));
+
+// import * as vscode from 'vscode';
+import { RunShell, LoginShells } from '../../src/JestExt/run-shell';
+
+describe('RunnerShell', () => {
+  beforeAll(() => {
+    console.error = jest.fn();
+    console.warn = jest.fn();
+  });
+  beforeEach(() => {});
+
+  describe('can initialize from a shell setting', () => {
+    it.each`
+      case | platform    | setting                                | loginShell                             | useLoginShell | settingOverride
+      ${1} | ${'win32'}  | ${'c:\\whatever\\powershell'}          | ${undefined}                           | ${'never'}    | ${undefined}
+      ${2} | ${'win32'}  | ${undefined}                           | ${undefined}                           | ${'never'}    | ${undefined}
+      ${3} | ${'darwin'} | ${'/bin/bash'}                         | ${LoginShells.bash}                    | ${false}      | ${undefined}
+      ${4} | ${'darwin'} | ${'/usr/local/bin/zsh'}                | ${LoginShells.zsh}                     | ${false}      | ${undefined}
+      ${5} | ${'darwin'} | ${{ path: '/bin/zsh', args: [] }}      | ${LoginShells.zsh}                     | ${false}      | ${'/bin/zsh'}
+      ${6} | ${'darwin'} | ${{ path: 'bash', args: ['--login'] }} | ${{ path: 'bash', args: ['--login'] }} | ${true}       | ${undefined}
+      ${7} | ${'linux'}  | ${undefined}                           | ${LoginShells.sh}                      | ${false}      | ${undefined}
+      ${8} | ${'linux'}  | ${'whatever'}                          | ${undefined}                           | ${'never'}    | ${undefined}
+    `('case $case', ({ platform, setting, loginShell, settingOverride, useLoginShell }) => {
+      jest.clearAllMocks();
+      mockPlatform.mockReturnValue(platform);
+      const shell = new RunShell(setting);
+      expect(shell.toSetting()).toEqual(settingOverride ?? setting);
+      expect(shell.useLoginShell).toEqual(useLoginShell);
+
+      // test loginShell
+      shell.enableLoginShell();
+      if (loginShell) {
+        expect(shell.toSetting()).toEqual(loginShell);
+        expect(shell.useLoginShell).toEqual(true);
+      } else {
+        expect(shell.useLoginShell).not.toEqual(true);
+        expect(shell.toSetting()).toEqual(settingOverride ?? setting);
+        expect(console.warn).toHaveBeenCalled();
+      }
+    });
+  });
+  it('if setting already a loginShell, will always return the loginShell', () => {
+    mockPlatform.mockReturnValue('darwin');
+    const setting = { path: '/bin/zsh', args: ['-l'] };
+    const shell = new RunShell(setting);
+    expect(shell.useLoginShell).toEqual(true);
+    expect(shell.toSetting()).toEqual(setting);
+
+    shell.enableLoginShell();
+    expect(shell.toSetting()).toEqual(setting);
+  });
+});

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -270,7 +270,7 @@ describe('JestProcess', () => {
             testFileNamePattern: 'abc',
             testNamePattern,
           });
-          extContext.settings = { shell };
+          extContext.settings.shell.toSetting.mockReturnValue(shell);
           jestProcess = new JestProcess(extContext, request);
           jestProcess.start();
           const [, options] = RunnerClassMock.mock.calls[0];
@@ -284,14 +284,16 @@ describe('JestProcess', () => {
 
       const jestProcess1 = new JestProcess(extContext, request);
       jestProcess1.start();
-      expect(extContext.createRunnerWorkspace).toHaveBeenCalledWith(undefined);
+      expect(extContext.createRunnerWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({ outputFileSuffix: undefined })
+      );
 
       const request2 = mockRequest('by-file', { testFileName: 'abc' });
       request2.schedule.queue = 'blocking-2';
       const jestProcess2 = new JestProcess(extContext, request2);
       jestProcess2.start();
       expect(extContext.createRunnerWorkspace).toHaveBeenCalledWith(
-        expect.objectContaining({ outputFileSuffix: expect.anything() })
+        expect.objectContaining({ outputFileSuffix: expect.stringContaining('2') })
       );
     });
   });

--- a/tests/extensionManager.test.ts
+++ b/tests/extensionManager.test.ts
@@ -72,6 +72,7 @@ const makeJestExt = (workspace: vscode.WorkspaceFolder): any => {
     triggerUpdateSettings: jest.fn(),
     toggleAutoRun: jest.fn(),
     toggleCoverageOverlay: jest.fn(),
+    enableLoginShell: jest.fn(),
     workspace,
   };
 };
@@ -687,17 +688,18 @@ describe('ExtensionManager', () => {
         extensionManager = createExtensionManager(['ws-1', 'ws-2']);
       });
       it.each`
-        name                                | extFunc
-        ${'start'}                          | ${'startSession'}
-        ${'workspace.start'}                | ${'startSession'}
-        ${'stop'}                           | ${'stopSession'}
-        ${'workspace.stop'}                 | ${'stopSession'}
-        ${'toggle-coverage'}                | ${'toggleCoverageOverlay'}
-        ${'workspace.toggle-coverage'}      | ${'toggleCoverageOverlay'}
-        ${'run-all-tests'}                  | ${'runAllTests'}
-        ${'workspace.run-all-tests'}        | ${'runAllTests'}
-        ${'with-workspace.toggle-auto-run'} | ${'toggleAutoRun'}
-        ${'with-workspace.toggle-coverage'} | ${'toggleCoverageOverlay'}
+        name                                   | extFunc
+        ${'start'}                             | ${'startSession'}
+        ${'workspace.start'}                   | ${'startSession'}
+        ${'stop'}                              | ${'stopSession'}
+        ${'workspace.stop'}                    | ${'stopSession'}
+        ${'toggle-coverage'}                   | ${'toggleCoverageOverlay'}
+        ${'workspace.toggle-coverage'}         | ${'toggleCoverageOverlay'}
+        ${'run-all-tests'}                     | ${'runAllTests'}
+        ${'workspace.run-all-tests'}           | ${'runAllTests'}
+        ${'with-workspace.toggle-auto-run'}    | ${'toggleAutoRun'}
+        ${'with-workspace.toggle-coverage'}    | ${'toggleCoverageOverlay'}
+        ${'with-workspace.enable-login-shell'} | ${'enableLoginShell'}
       `('extension-based commands "$name"', async ({ name, extFunc }) => {
         extensionManager.register();
         const expectedName = `${extensionName}.${name}`;

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -148,10 +148,11 @@ export const mockJestExtEvents: any = () => ({
 });
 
 export const mockJestExtContext = (autoRun?: AutoRun): any => {
+  const baseSettings = { shell: { toSetting: jest.fn() } };
   return {
     workspace: jest.fn(),
     createRunnerWorkspace: jest.fn(),
-    settings: autoRun ? { autoRun } : jest.fn(),
+    settings: autoRun ? { ...baseSettings, autoRun } : baseSettings,
     loggingFactory: { create: jest.fn(() => jest.fn()) },
     events: mockJestExtEvents(),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2934,10 +2934,10 @@ jest-each@^29.2.1:
     jest-util "^29.2.1"
     pretty-format "^29.2.1"
 
-jest-editor-support@^30.2.0:
-  version "30.2.0"
-  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-30.2.0.tgz#62c61b4d2a1b36d070c665acd0705e3fef37a0fb"
-  integrity sha512-+ylyVaGv9kB1kMkNI8LmOLHl4a4Lr9n7hYkqewTnUY0k5eAENWLpCwbPm7KzOiyHU9FU2K4T4hPCcyQAxz0wFw==
+jest-editor-support@^30.2.1:
+  version "30.2.1"
+  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-30.2.1.tgz#902911427fe46f052ec29320de8b8da41f832d97"
+  integrity sha512-zsWAv6Taoqvci1jSiEVqCEG/IS/+Lwhyu1VJ/skcdlrhjjFrrcV+W3PRPjjI6bgSWMVNi20yPU1CrA88+e56Tg==
   dependencies:
     "@babel/parser" "^7.15.7"
     "@babel/runtime" "^7.15.4"


### PR DESCRIPTION
There are many complaints about intermittent test run failure (exit code 127) with `"command not found"` or `"No such file or directory"` errors for programs like node/npm/yarn. While it is not caused by this extension, it significantly impacted our users' experience nevertheless.

With the recent implementation of the login-shell, I think we can finally address this once and for all. This PR implemented an auto-retry with a login shell when detected the situation mentioned above. 

This is only applicable for non-windows platforms. The currently supported login shell are: `bash`, `zsh`,  `fish`. 

fixes #899 
fixes #845 
fixes #874 
fixes #867