### PR TITLE
supports v8 coverage provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The coverage state is reflected in test tree toggle menu, as well as  StatusBar:
 
 ![status-bar-modes](images/status-bar-watch-coverage.png)
 
+This extension supports both `babel` and `v8` coverageProviders. However, please note the coverage might not be exactly the same, see [facebook/jest#11188](https://github.com/facebook/jest/issues/11188) for more details.
+
 <details>
 
 <summary>How to read coverage scheme and customize it</summary>


### PR DESCRIPTION
This is to support jest coverageProvider `v8`. 

Please note the coverage results might not be exactly the same between `babel` and `v8`. Here is a good list of the difference between the 2 providers: facebook/jest#11188

I didn't compare each scenario though. It is possible there is still something that needs to be adjusted. But this should make the extension useable with v8. 

fixes #842 