### PR TITLE
test-provider: adjust workspace location handling

### DIFF
--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -195,7 +195,15 @@ export class WorkspaceRoot extends TestItemDataBase {
     );
   };
   private addPath = (absoluteFileName: string): FolderData | undefined => {
-    const relativePath = path.relative(this.context.ext.workspace.uri.fsPath, absoluteFileName);
+    const fs = require('fs');
+
+    // On Windows, the workspace URI is not the real resolved path, however, the
+    // paths returned by the jest cli tool are resolved paths. Explicitly
+    // resolve the path to ensure that we get the proper relative path.  Note
+    // that we must use `fs.realpath.native` as `fs.realpath` will only
+    // canonicalise the path, not resolve any path substitutions.
+    const workspace =  fs.realpathSync.native(this.context.ext.workspace.uri.fsPath);
+    const relativePath = path.relative(workspace, absoluteFileName);
     const folders = relativePath.split(path.sep).slice(0, -1);
 
     return folders.reduce(this.addFolder, undefined);


### PR DESCRIPTION
The VSCode reported workspace path is unresolved
(microsoft/vscode#18837).  When the repository is hosted in a path substituted path (e.g. `subst X: C:`), the test path will not be properly translated as the drive is different.  This may potentially also impact paths which are hosted within a NT junction.  Explicitly resolve the workspace path to match the fact that `jest` will report paths which have been resolved to the real path.