### PR TITLE
added autoRevealOutput setting to control when to reveal the output terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This extension supports full [jest](https://jestjs.io/) features in vscode envir
 2. [install](#installation) **"Jest"** extension in vscode.
 3. reload or restart vscode 
 
-If the extension can find the [jest command](#how-to-set-up-the-jest-command), by default it will automatically run and monitor all tests in watch mode upon launch, and you should see tests, status, errors, coverage (if enabled) in TestExplorer and editors like this:
+If the extension can find the jest command, by default it will automatically run and monitor all tests in watch mode upon launch, and you should see tests, status, errors, coverage (if enabled) in TestExplorer and editors like this:
 
 ![image](images/v5-output-terminals.png)
 
@@ -62,6 +62,7 @@ Content
     - [Debug Config](#debug-config)
       - [Debug Config v2](#debug-config-v2)
     - [monitorLongRun](#monitorlongrun)
+        - [autoRevealOutput](#autorevealoutput)
   - [Commands](#commands)
   - [Menu](#menu)
   - [Troubleshooting](#troubleshooting)
@@ -185,7 +186,7 @@ Please note, a working jest environment is a prerequisite for this extension. If
 StatusBar shows 2 kinds of information:
 `Jest` shows the mode and state of the "active" workspace folder.
 `Jest-WS` shows the total test suite stats for the whole workspace.
-Clicking on each of these button will reveal the OUTPUT channel with more details.
+Clicking on each of these button will reveal the corresponding output window with more details.
 
 <details>
 <summary>Illustration</summary>
@@ -202,6 +203,10 @@ shows the active workspace has onSave for test file only, and that the workspace
 <img src='images/status-bar-save-all.png' width="600" />
 
 shows the autoRun will be triggered by either test or source file changes.
+
+<img src='images/status-bar-error.png' width="600" />
+
+shows active workspace has an execution error.
 </details>
 
 ### How to use the Test Explorer?
@@ -219,6 +224,11 @@ Users with `vscode` v1.59 and `vscode-jest` v4.1 and up will start to see tests 
 - In TestExplorer, click on the root of the test tree, i.e. the one with the workspace name and the current autoRun mode. You will see a list of buttons to its right.
 - Click on the coverage button (see image above) to toggle on or off.
   - The next test run (auto or manual) will start reporting test coverage.
+
+<a id='how-to-reveal-output'>**How to reveal test output for the workspace?**</a>
+- In TestExplorer, click on the root of the test tree, i.e. the one with the workspace name and the current autoRun mode. You will see a list of buttons to its right.
+- Click on the terminal button (see image above) to reveal the test output terminal.
+
 
 You can further customize the explorer with [jest.testExplorer](#testexplorer) in [settings](#settings).
 
@@ -255,6 +265,7 @@ Users can use the following settings to tailor the extension for their environme
 |**Misc**|
 |debugMode|Enable debug mode to diagnose plugin issues. (see developer console)|false|`"jest.debugMode": true`|
 |disabledWorkspaceFolders 💼|Disabled workspace folders names in multiroot environment|[]|`"jest.disabledWorkspaceFolders": ["package-a", "package-b"]`|
+|[autoRevealOutput](#autoRevealOutput)|Determine when to show test output|"on-run"|`"jest.autoRevealOutput": "on-exec-error"`|
 
 #### Details
 ##### jestCommandLine
@@ -491,6 +502,15 @@ monitorLongRun = number | 'off'
 - specify "off" to disable long-run process monitoring
 
 Default is `"jest.monitorLongRun":60000` (1 minute)
+
+##### autoRevealOutput
+```ts
+autoRevealOutput = "on-run" | "on-exec-error" | "off"
+```
+- `on-run`: reveal test run output when test run started.
+- `on-exec-error`: reveal test run output only when execution error (note, not test error) occurred.
+- `off`: no auto reveal test output. Note this could mask critical error, check status bar status for detail.
+
 ## Commands
 
 This extension contributes the following commands and can be accessed via [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette):

--- a/package.json
+++ b/package.json
@@ -153,17 +153,19 @@
           "default": 60000,
           "scope": "resource"
         },
-        "jest.revealOutput": {
+        "jest.autoRevealOutput": {
           "description": "Review jest output terminal",
           "type": "string",
           "default": "on-run",
           "enum": [
             "on-run",
-            "silent"
+            "on-exec-error",
+            "off"
           ],
           "enumDescriptions": [
-            "show output when test run starts",
-            "will not show test output unless explicitly requsted or encountered a fatal error"
+            "auto show output when test run starts",
+            "auto show test output when execution error occurred",
+            "disable auto show test output"
           ],
           "scope": "resource"
         }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,18 @@
           ],
           "default": 60000,
           "scope": "resource"
-        }
+        },
+        "jest.revealOutput": {
+          "description": "Review jest output terminal",
+          "type": "string",
+          "default": "on-run",
+          "enum": ["on-run", "silent"],
+          "enumDescriptions": [
+            "show output when test run starts",
+            "will not show test output unless explicitly requsted or encountered a fatal error"
+          ],
+          "scope": "resource"
+        } 
       }
     },
     "commands": [

--- a/package.json
+++ b/package.json
@@ -157,13 +157,16 @@
           "description": "Review jest output terminal",
           "type": "string",
           "default": "on-run",
-          "enum": ["on-run", "silent"],
+          "enum": [
+            "on-run",
+            "silent"
+          ],
           "enumDescriptions": [
             "show output when test run starts",
             "will not show test output unless explicitly requsted or encountered a fatal error"
           ],
           "scope": "resource"
-        } 
+        }
       }
     },
     "commands": [

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -192,9 +192,13 @@ export class JestExt {
         return;
       }
       switch (event.type) {
-        case 'start':
+        case 'start': {
+          if(this.extContext.settings.revealOutput === 'on-run'){
+            this.output.reveal();
+          }
           this.updateStatusBar({ state: 'running' });
           break;
+        }
         case 'end':
           this.updateStatusBar({ state: 'done' });
           break;

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -96,8 +96,9 @@ export class JestExt {
     coverageCodeLensProvider: CoverageCodeLensProvider
   ) {
     this.vscodeContext = vscodeContext;
-    this.output = new JestOutputTerminal(workspaceFolder.name);
     const pluginSettings = getExtensionResourceSettings(workspaceFolder.uri);
+    this.output = new JestOutputTerminal(workspaceFolder.name);
+    this.updateOutputSetting(pluginSettings);
 
     this.extContext = createJestExtContext(workspaceFolder, pluginSettings, this.output);
     this.logging = this.extContext.loggingFactory.create('JestExt');
@@ -193,7 +194,7 @@ export class JestExt {
       }
       switch (event.type) {
         case 'start': {
-          if (this.extContext.settings.revealOutput === 'on-run') {
+          if (this.extContext.settings.autoRevealOutput === 'on-run') {
             this.output.reveal();
           }
           this.updateStatusBar({ state: 'running' });
@@ -366,9 +367,18 @@ export class JestExt {
     this.updateTestFileEditor(editor);
   }
 
+  private updateOutputSetting(settings: PluginResourceSettings): void {
+    this.output.revealOnError = settings.autoRevealOutput !== 'off';
+    this.output.close();
+  }
   public async triggerUpdateSettings(newSettings?: PluginResourceSettings): Promise<void> {
     const updatedSettings =
       newSettings ?? getExtensionResourceSettings(this.extContext.workspace.uri);
+
+    // output
+    if (this.extContext.settings.autoRevealOutput !== updatedSettings.autoRevealOutput) {
+      this.updateOutputSetting(updatedSettings);
+    }
 
     // debug
     this.testResultProvider.verbose = updatedSettings.debugMode ?? false;

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -193,7 +193,7 @@ export class JestExt {
       }
       switch (event.type) {
         case 'start': {
-          if(this.extContext.settings.revealOutput === 'on-run'){
+          if (this.extContext.settings.revealOutput === 'on-run') {
             this.output.reveal();
           }
           this.updateStatusBar({ state: 'running' });

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -12,6 +12,7 @@ import {
   MonitorLongRun,
   TestExplorerConfigLegacy,
   JestExtAutoRunSetting,
+  RevealOutputType,
 } from '../Settings';
 import { workspaceLogging } from '../logging';
 import { JestExtContext, RunnerWorkspaceOptions } from './types';
@@ -118,6 +119,7 @@ export const getExtensionResourceSettings = (uri: vscode.Uri): PluginResourceSet
     shell: new RunShell(config.get<string | LoginShell>('shell')),
     monitorLongRun: config.get<MonitorLongRun>('monitorLongRun') ?? undefined,
     autoRun: new AutoRun(config.get<JestExtAutoRunSetting | null>('autoRun')),
+    revealOutput: config.get<RevealOutputType>('revealOutput') ?? 'on-run',
   };
 };
 

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -12,7 +12,7 @@ import {
   MonitorLongRun,
   TestExplorerConfigLegacy,
   JestExtAutoRunSetting,
-  RevealOutputType,
+  AutoRevealOutputType,
 } from '../Settings';
 import { workspaceLogging } from '../logging';
 import { JestExtContext, RunnerWorkspaceOptions } from './types';
@@ -119,7 +119,7 @@ export const getExtensionResourceSettings = (uri: vscode.Uri): PluginResourceSet
     shell: new RunShell(config.get<string | LoginShell>('shell')),
     monitorLongRun: config.get<MonitorLongRun>('monitorLongRun') ?? undefined,
     autoRun: new AutoRun(config.get<JestExtAutoRunSetting | null>('autoRun')),
-    revealOutput: config.get<RevealOutputType>('revealOutput') ?? 'on-run',
+    autoRevealOutput: config.get<AutoRevealOutputType>('autoRevealOutput') ?? 'on-run',
   };
 };
 

--- a/src/JestExt/output-terminal.ts
+++ b/src/JestExt/output-terminal.ts
@@ -44,6 +44,7 @@ export class ExtOutputTerminal implements JestExtOutput {
   private writeEmitter = new vscode.EventEmitter<string>();
   private _terminal?: vscode.Terminal;
   private canReveal: boolean;
+  public revealOnError: boolean;
 
   private pty: vscode.Pseudoterminal = {
     onDidWrite: this.writeEmitter.event,
@@ -66,6 +67,7 @@ export class ExtOutputTerminal implements JestExtOutput {
     this.ptyIsOpen = false;
     this.pendingMessages = new PendingOutput();
     this.canReveal = visibile ?? false;
+    this.revealOnError = true;
   }
 
   /**
@@ -115,7 +117,7 @@ export class ExtOutputTerminal implements JestExtOutput {
     const text = toAnsi(msg, opt);
     this.appendRaw(text);
 
-    if (isErrorOutputType(opt)) {
+    if (isErrorOutputType(opt) && this.revealOnError) {
       this.show();
     }
     return text;
@@ -123,6 +125,9 @@ export class ExtOutputTerminal implements JestExtOutput {
   show(): void {
     this.reveal();
     this._terminal?.show(true);
+  }
+  close(): void {
+    this._terminal?.dispose();
   }
   dispose(): void {
     this.writeEmitter.dispose();

--- a/src/JestExt/output-terminal.ts
+++ b/src/JestExt/output-terminal.ts
@@ -11,20 +11,20 @@ export interface JestExtOutput {
 
 /**
  * simple class to manage the pending data before the terminal is
- * visible. 
+ * visible.
  * The default is to keep max 100 output batch (each push counts 1), when exceeding
  * it will remove the first 10 batches. We could make this configurable
  * if needed.
  */
 export class PendingOutput {
-  private pendingOutput: string[]
-  constructor(private maxLength = 100){
+  private pendingOutput: string[];
+  constructor(private maxLength = 100) {
     this.pendingOutput = [];
   }
   push(output: string): void {
-    if(this.pendingOutput.length >= this.maxLength){
+    if (this.pendingOutput.length >= this.maxLength) {
       // truncate the first few blocks to make room for the new output
-      const cutoff = Math.max(Math.floor(this.maxLength/10), 1);
+      const cutoff = Math.max(Math.floor(this.maxLength / 10), 1);
       this.pendingOutput = this.pendingOutput.slice(cutoff);
     }
     this.pendingOutput.push(output);
@@ -33,7 +33,7 @@ export class PendingOutput {
     this.pendingOutput = [];
   }
   toString(): string {
-    return this.pendingOutput.join(''); 
+    return this.pendingOutput.join('');
   }
 }
 
@@ -69,19 +69,19 @@ export class ExtOutputTerminal implements JestExtOutput {
   }
 
   /**
-   * indicate the terminal can be revealed if needed. 
+   * indicate the terminal can be revealed if needed.
    * This allows the terminal to be created in a "background" mode, i.e. it will not force the terminal to be shown if the panels are hidden or
    * if there are other active terminal
-   * @returns 
+   * @returns
    */
-  reveal() {
-    if(this.canReveal){
+  reveal(): void {
+    if (this.canReveal) {
       return;
     }
     this.canReveal = true;
-    this.createTerminalIfNeeded(); 
+    this.createTerminalIfNeeded();
   }
-  
+
   /** delay creating terminal until we are actually running the tests */
   private createTerminalIfNeeded() {
     if (!this.canReveal || this._terminal) {
@@ -130,7 +130,7 @@ export class ExtOutputTerminal implements JestExtOutput {
   }
 }
 export class JestOutputTerminal extends ExtOutputTerminal {
-  constructor(workspaceName: string, visible?: boolean ) {
+  constructor(workspaceName: string, visible?: boolean) {
     super(`Jest (${workspaceName})`, visible);
   }
 }

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -36,7 +36,7 @@ export interface TestExplorerConfig {
 
 export type NodeEnv = ProjectWorkspace['nodeEnv'];
 export type MonitorLongRun = 'off' | number;
-export type RevealOutputType = 'on-run' | 'silent';
+export type AutoRevealOutputType = 'on-run' | 'on-exec-error' | 'off';
 export interface PluginResourceSettings {
   jestCommandLine?: string;
   rootPath: string;
@@ -49,7 +49,7 @@ export interface PluginResourceSettings {
   nodeEnv?: NodeEnv;
   shell: RunShell;
   monitorLongRun?: MonitorLongRun;
-  revealOutput: RevealOutputType;
+  autoRevealOutput: AutoRevealOutputType;
 }
 
 export interface PluginWindowSettings {

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -36,6 +36,7 @@ export interface TestExplorerConfig {
 
 export type NodeEnv = ProjectWorkspace['nodeEnv'];
 export type MonitorLongRun = 'off' | number;
+export type RevealOutputType = 'on-run' | 'silent';
 export interface PluginResourceSettings {
   jestCommandLine?: string;
   rootPath: string;
@@ -48,6 +49,7 @@ export interface PluginResourceSettings {
   nodeEnv?: NodeEnv;
   shell: RunShell;
   monitorLongRun?: MonitorLongRun;
+  revealOutput: RevealOutputType;
 }
 
 export interface PluginWindowSettings {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -14,9 +14,6 @@ class VSCodeJestReporter implements Reporter {
     // report exec errors that could have prevented Result file being generated
     if (results.runExecError) {
       process.stderr.write(`onRunComplete: execError: ${results.runExecError.message}\r\n`);
-    } else if (results.numTotalTests === 0 && results.numTotalTestSuites > 0) {
-      // for jest < 29.1.2, we won't see onRunComplete with runExecError, so try this as best effort. see https://github.com/facebook/jest/pull/13203
-      process.stderr.write('onRunComplete: execError: no test is run\r\n');
     } else {
       process.stderr.write('onRunComplete\r\n');
     }

--- a/src/setup-wizard/start-wizard.ts
+++ b/src/setup-wizard/start-wizard.ts
@@ -47,7 +47,7 @@ export const startWizard = (
 ): Promise<WizardStatus> => {
   const { workspace, taskId, verbose } = options;
 
-  const terminal = new ExtOutputTerminal('vscode-jest Setup Tool');
+  const terminal = new ExtOutputTerminal('vscode-jest Setup Tool', true);
 
   const message = (msg: string, opt?: OutputOptions): string => {
     const str = terminal.write(`${msg}${opt ? '' : '\r\n'}`, opt);

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -896,6 +896,19 @@ describe('JestExt', () => {
           }
         });
       });
+      it('will update statusBar', async () => {
+        expect.hasAssertions();
+
+        const sut = newJestExt();
+        sut.coverageOverlay.enabled = true;
+        await sut.startSession();
+        expect(sbUpdateMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            state: 'initial',
+            mode: expect.arrayContaining(['coverage']),
+          })
+        );
+      });
     });
     describe('stopSession', () => {
       it('will fire event', async () => {
@@ -1408,6 +1421,7 @@ describe('JestExt', () => {
       expect(mockOutputTerminal.revealOnError).toEqual(true);
       sut.triggerUpdateSettings({ autoRevealOutput: 'off' } as any);
       expect(mockOutputTerminal.revealOnError).toEqual(false);
+      expect(mockOutputTerminal.close).toHaveBeenCalled();
     });
   });
 });

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -1393,9 +1393,9 @@ describe('JestExt', () => {
         const process = { id: 'a process id', request: { type: 'watch' } };
         onRunEvent({ type: 'start', process });
         if (shouldReveal) {
-          expect(mockOutputTerminal.reveal).toBeCalled();
+          expect(mockOutputTerminal.reveal).toHaveBeenCalled();
         } else {
-          expect(mockOutputTerminal.reveal).not.toBeCalled();
+          expect(mockOutputTerminal.reveal).not.toHaveBeenCalled();
         }
       }
     );

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -53,6 +53,7 @@ const mockHelpers = helper as jest.Mocked<any>;
 const mockOutputTerminal = {
   write: jest.fn(),
   show: jest.fn(),
+  reveal: jest.fn(),
   dispose: jest.fn(),
 };
 
@@ -1378,5 +1379,25 @@ describe('JestExt', () => {
         );
       });
     });
+  });
+  describe('revealOutput', () => {
+    it.each`
+      revealOutput | shouldReveal
+      ${'on-run'}  | ${true}
+      ${'silent'}  | ${false}
+    `(
+      'revealOutput = $revealOutput, shouldReveal = $shouldReveal',
+      ({ revealOutput, shouldReveal }) => {
+        const sut = newJestExt({ settings: { revealOutput } });
+        const onRunEvent = (sut.events.onRunEvent.event as jest.Mocked<any>).mock.calls[0][0];
+        const process = { id: 'a process id', request: { type: 'watch' } };
+        onRunEvent({ type: 'start', process });
+        if (shouldReveal) {
+          expect(mockOutputTerminal.reveal).toBeCalled();
+        } else {
+          expect(mockOutputTerminal.reveal).not.toBeCalled();
+        }
+      }
+    );
   });
 });

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -161,6 +161,7 @@ describe('getExtensionResourceSettings()', () => {
       testExplorer: {},
       monitorLongRun: 60000,
       shell: mockShell,
+      revealOutput: 'on-run'
     });
   });
 

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -161,7 +161,7 @@ describe('getExtensionResourceSettings()', () => {
       testExplorer: {},
       monitorLongRun: 60000,
       shell: mockShell,
-      revealOutput: 'on-run',
+      autoRevealOutput: 'on-run',
     });
   });
 

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -161,7 +161,7 @@ describe('getExtensionResourceSettings()', () => {
       testExplorer: {},
       monitorLongRun: 60000,
       shell: mockShell,
-      revealOutput: 'on-run'
+      revealOutput: 'on-run',
     });
   });
 

--- a/tests/JestExt/outpt-terminal.test.ts
+++ b/tests/JestExt/outpt-terminal.test.ts
@@ -2,7 +2,13 @@ jest.unmock('../../src/JestExt/output-terminal');
 jest.unmock('../../src/errors');
 
 import * as vscode from 'vscode';
-import { ansiEsc, AnsiSeq, JestOutputTerminal, PendingOutput, toAnsi } from '../../src/JestExt/output-terminal';
+import {
+  ansiEsc,
+  AnsiSeq,
+  JestOutputTerminal,
+  PendingOutput,
+  toAnsi,
+} from '../../src/JestExt/output-terminal';
 import * as errors from '../../src/errors';
 
 describe('JestOutputTerminal', () => {
@@ -148,7 +154,7 @@ describe('text format utility function', () => {
 describe('PendingOutput', () => {
   it('can limit output not to exceed max size', () => {
     const pOut = new PendingOutput(3);
-    ['1', '2', '3'].forEach(s => pOut.push(s));
+    ['1', '2', '3'].forEach((s) => pOut.push(s));
     expect(pOut.toString()).toEqual('123');
     pOut.push('4');
     expect(pOut.toString()).toEqual('234');

--- a/tests/JestExt/outpt-terminal.test.ts
+++ b/tests/JestExt/outpt-terminal.test.ts
@@ -98,6 +98,17 @@ describe('JestOutputTerminal', () => {
     output.write('2', errors.GENERIC_ERROR);
     expect(mockTerminal.show).toHaveBeenCalledTimes(2);
   });
+  it('will not show terminal when writing error messages if revalOnError is false', () => {
+    const output = new JestOutputTerminal('a');
+    output.revealOnError = false;
+
+    output.write('an error', 'error');
+    expect(mockTerminal.show).not.toHaveBeenCalled();
+
+    output.revealOnError = true;
+    output.write('an error', 'error');
+    expect(mockTerminal.show).toHaveBeenCalledTimes(1);
+  });
   it('will properly dispose terminal and emitter', () => {
     const output = new JestOutputTerminal('a');
     output.reveal();
@@ -105,6 +116,14 @@ describe('JestOutputTerminal', () => {
     output.dispose();
     expect(mockTerminal.dispose).toHaveBeenCalled();
     expect(mockEmitter.dispose).toHaveBeenCalled();
+  });
+  it('can close the terminal', () => {
+    const output = new JestOutputTerminal('a');
+    output.reveal();
+    output.write('1');
+    output.close();
+    expect(mockTerminal.dispose).toHaveBeenCalled();
+    expect(mockEmitter.dispose).not.toHaveBeenCalled();
   });
   describe('can write output with options', () => {
     it.each`

--- a/tests/JestExt/outpt-terminal.test.ts
+++ b/tests/JestExt/outpt-terminal.test.ts
@@ -2,7 +2,7 @@ jest.unmock('../../src/JestExt/output-terminal');
 jest.unmock('../../src/errors');
 
 import * as vscode from 'vscode';
-import { ansiEsc, AnsiSeq, JestOutputTerminal, toAnsi } from '../../src/JestExt/output-terminal';
+import { ansiEsc, AnsiSeq, JestOutputTerminal, PendingOutput, toAnsi } from '../../src/JestExt/output-terminal';
 import * as errors from '../../src/errors';
 
 describe('JestOutputTerminal', () => {
@@ -22,9 +22,15 @@ describe('JestOutputTerminal', () => {
     mockEmitter = { fire: jest.fn(), event: jest.fn(), dispose: jest.fn() };
     (vscode.EventEmitter as jest.Mocked<any>).mockImplementation(() => mockEmitter);
   });
-  it('delay creating terminal until the actual write occurs', () => {
+  it('will not create terminal until it is revealed', () => {
     const output = new JestOutputTerminal('workspace');
+    output.write('abc');
     expect(vscode.window.createTerminal).not.toHaveBeenCalled();
+    output.reveal();
+    expect(vscode.window.createTerminal).toHaveBeenCalled();
+  });
+  it('can be create with revealed by default', () => {
+    const output = new JestOutputTerminal('workspace', true);
     output.write('abc');
     expect(vscode.window.createTerminal).toHaveBeenCalled();
   });
@@ -36,14 +42,16 @@ describe('JestOutputTerminal', () => {
     expect(vscode.window.createTerminal).not.toHaveBeenCalled();
     expect(a.dispose).not.toHaveBeenCalled();
 
+    t.reveal();
     t.write('something');
     expect(vscode.window.createTerminal).toHaveBeenCalled();
     expect(a.dispose).toHaveBeenCalled();
     expect(b.dispose).not.toHaveBeenCalled();
   });
-  it('can buffer output until open', () => {
+  it('can buffer output until terminal opened', () => {
     const output = new JestOutputTerminal('a');
     output.write('text 1');
+    output.reveal();
     expect(mockEmitter.fire).not.toHaveBeenCalled();
 
     // after open, the buffered text should be sent again
@@ -56,16 +64,17 @@ describe('JestOutputTerminal', () => {
   });
   it('if user close the terminal, it will be reopened on the next write', () => {
     const output = new JestOutputTerminal('a');
+    output.reveal();
     output.write('1');
     expect(vscode.window.createTerminal).toHaveBeenCalledTimes(1);
     const { pty } = (vscode.window.createTerminal as jest.Mocked<any>).mock.calls[0][0];
 
     // simulate users close the terminal
     pty.close();
-    expect(mockTerminal.dispose).toHaveBeenCalled();
 
     // user writes again
     output.write('1');
+    output.reveal();
     // terminal should be opened again with the same pty
     expect(vscode.window.createTerminal).toHaveBeenCalledTimes(2);
     const { pty: pty2 } = (vscode.window.createTerminal as jest.Mocked<any>).mock.calls[1][0];
@@ -85,6 +94,7 @@ describe('JestOutputTerminal', () => {
   });
   it('will properly dispose terminal and emitter', () => {
     const output = new JestOutputTerminal('a');
+    output.reveal();
     output.write('1');
     output.dispose();
     expect(mockTerminal.dispose).toHaveBeenCalled();
@@ -132,5 +142,15 @@ describe('text format utility function', () => {
     ${'lf'}      | ${AnsiSeq.lf}
   `('ansiEsc: format by ANSI escape sequence: $desc', ({ escSeq }) => {
     expect(ansiEsc(escSeq, 'whatever')).toMatchSnapshot();
+  });
+});
+
+describe('PendingOutput', () => {
+  it('can limit output not to exceed max size', () => {
+    const pOut = new PendingOutput(3);
+    ['1', '2', '3'].forEach(s => pOut.push(s));
+    expect(pOut.toString()).toEqual('123');
+    pOut.push('4');
+    expect(pOut.toString()).toEqual('234');
   });
 });

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -15,31 +15,6 @@ describe('VSCodeJest Reporter', () => {
     expect(process.stderr.write).toHaveBeenCalledWith('onRunComplete\r\n');
   });
   describe('report runtime exec error', () => {
-    it.each`
-      numTotalTests | numTotalTestSuites | hasError
-      ${1}          | ${1}               | ${false}
-      ${0}          | ${0}               | ${false}
-      ${0}          | ${2}               | ${true}
-    `(
-      'version < 29.1.2: ($numTotalTests, $numTotalTestSuites)',
-      ({ numTotalTests, numTotalTestSuites, hasError }) => {
-        const reporter = new VSCodeJestReporter();
-        const args: any = { numTotalTestSuites };
-        reporter.onRunStart(args);
-        expect(process.stderr.write).toHaveBeenCalledWith(
-          `onRunStart: numTotalTestSuites: ${numTotalTestSuites}\r\n`
-        );
-        const result: any = { numTotalTests, numTotalTestSuites };
-        reporter.onRunComplete(new Set(), result);
-        if (hasError) {
-          expect(process.stderr.write).toHaveBeenCalledWith(
-            expect.stringContaining('onRunComplete: execError')
-          );
-        } else {
-          expect(process.stderr.write).toHaveBeenCalledWith('onRunComplete\r\n');
-        }
-      }
-    );
     it('version >= 29.1.2', () => {
       const reporter = new VSCodeJestReporter();
       const args: any = { numTotalTestSuites: 10 };


### PR DESCRIPTION
Added a new setting `jest.revealOutput` (see [comments](https://github.com/jest-community/vscode-jest/issues/973#issuecomment-1364162771)) to give users more control over when to reveal the output terminal.

resolve #973