### PR TITLE
fix: support path based auto completion for `jsx` and `tsx`

### DIFF
--- a/src/language-provider.ts
+++ b/src/language-provider.ts
@@ -58,8 +58,10 @@ export class LocalFileCompletionItemProvider
 
 export function register(): vscode.Disposable[] {
   const selector = [
-    { scheme: 'file', language: 'typescript' },
     { scheme: 'file', language: 'javascript' },
+    { scheme: 'file', language: 'javascriptreact' },
+    { scheme: 'file', language: 'typescript' },
+    { scheme: 'file', language: 'typescriptreact' },
   ];
   return [
     vscode.languages.registerCompletionItemProvider(

--- a/tests/language-provider.test.ts
+++ b/tests/language-provider.test.ts
@@ -112,7 +112,9 @@ describe('register', () => {
     expect(vscodeMock.languages.registerCompletionItemProvider).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ language: 'javascript' }),
+        expect.objectContaining({ language: 'javascriptreact' }),
         expect.objectContaining({ language: 'typescript' }),
+        expect.objectContaining({ language: 'typescriptreact' }),
       ]),
       expect.any(LocalFileCompletionItemProvider),
       '/'

--- a/tests/language-provider.test.ts
+++ b/tests/language-provider.test.ts
@@ -71,7 +71,7 @@ describe('LocalFileCompletionItemProvider', () => {
       }
     });
   });
-  describe('will only return the vallid file/directories completion items', () => {
+  describe('will only return the valid file/directories completion items', () => {
     it.each`
       case  | fileInfo                                    | completionItem
       ${1}  | ${['file.ts', vscode.FileType.File]}        | ${{ label: 'file', kind: vscode.CompletionItemKind.File }}


### PR DESCRIPTION
Following up #963

Thanks for path based auto completion for `jest.mock` and similar methods. Very helpful.

It works perfect in `js` and `ts` files. I just noticed that the feature is missing if a test file has `jsx` or `tsx` extension. Adding `javascriptreact` and `typescriptreact` language selectors fixed this issue locally.