### PR TITLE
fix: support path based auto completion for `unstable_mockModule` method

### DIFF
--- a/src/language-provider.ts
+++ b/src/language-provider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 
 const JestMockModuleApi =
-  /jest\.(mock|unmock|domock|dontmock|setmock|requireActual|requireMock|createMockFromModule|)\(['"](.*)/gi;
+  /jest\.(mock|unmock|domock|dontmock|setmock|requireActual|requireMock|createMockFromModule|unstable_mockModule)\(['"](.*)/gi;
 const ImportFileRegex = /^([^\\.].*)\.(json|jsx|tsx|mjs|cjs|js|ts)$/gi;
 
 const toCompletionItem = (

--- a/tests/language-provider.test.ts
+++ b/tests/language-provider.test.ts
@@ -45,6 +45,7 @@ describe('LocalFileCompletionItemProvider', () => {
       ${'jest.requireActual'}        | ${true}
       ${'jest.requireMock'}          | ${true}
       ${'jest.createMockFromModule'} | ${true}
+      ${'jest.unstable_mockModule'}  | ${true}
       ${'jest.spyOn'}                | ${false}
       ${'jest.fn'}                   | ${false}
     `('for $jestMethod', async ({ jestMethod, isValid }) => {


### PR DESCRIPTION
From https://github.com/jest-community/vscode-jest/pull/977#issuecomment-1375059701

Currently path based auto completion is supported for `jest.mock`, but not for `jest.unstable_mockModule` method.

The `jest.mock` works only with CJS modules. The `jest.unstable_mockModule` method was introduced to supporting mocking of ESM modules. If I get it right, it is marked `unstable`, because it is not yet feature complete and can change outside of major releases. Otherwise this is official and the only way to mock ESM modules.

At some point it will become `jest.mockModule`. This means I will send another PR to remove `unstable_` from the regex.