### PR TITLE
adding jest.enable setting and adjust workspace operations accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Users can use the following settings to tailor the extension for their environme
 |[coverageFormatter](#coverageFormatter)|Determine the coverage overlay style|"DefaultFormatter"|`"jest.coverageFormatter": "GutterFormatter"`|
 |[coverageColors](#coverageColors)|Coverage indicator color override|undefined|`"jest.coverageColors": { "uncovered": "rgba(255,99,71, 0.2)", "partially-covered": "rgba(255,215,0, 0.2)"}`|
 |**Misc**|
+|enable|Enable/disable jest extension for the given workspace folder|true|`"jest.enable": false`|
 |debugMode|Enable debug mode to diagnose plugin issues. (see developer console)|false|`"jest.debugMode": true`|
 |disabledWorkspaceFolders 💼|Disabled workspace folders names in multiroot environment|[]|`"jest.disabledWorkspaceFolders": ["package-a", "package-b"]`|
 |[autoRevealOutput](#autoRevealOutput)|Determine when to show test output|"on-run"|`"jest.autoRevealOutput": "on-exec-error"`|
@@ -322,6 +323,8 @@ for example:
 </details>
 
 ##### autoRun
+
+AutoRun controls when **tests** should be executed automatically.
 
 Performance and automation/completeness are often a trade-off. autoRun is the tool to fine-tune the balance, which is unique for every project and user. 
 
@@ -397,6 +400,8 @@ There are 2 ways to change autoRun:
     ```
 
 </details>
+
+**Please note**, _even when the `autoRun` is "off", the extension will still perform the usual setup upon start-up, such as checking jest env and parsing test blocks, so users can run test blocks manually. To turn off the extension completely for the given workspace, you can use `jest.enable` setting instead._
 
 ##### testExplorer
   ```ts

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -15,6 +15,7 @@ const window = {
   createTextEditorDecorationType: jest.fn(),
   createOutputChannel: jest.fn(),
   showWorkspaceFolderPick: jest.fn(),
+  showQuickPick: jest.fn(),
   onDidChangeActiveTextEditor: jest.fn(),
   showInformationMessage: jest.fn(),
   createWebviewPanel: jest.fn(),

--- a/package.json
+++ b/package.json
@@ -68,6 +68,12 @@
       "type": "object",
       "title": "Jest",
       "properties": {
+        "jest.enable": {
+          "markdownDescription": "enable/disable jest extension for the workspace folder. Default is true", 
+          "type": "boolean",
+          "scope": "resource",
+          "default": true 
+        },
         "jest.jestCommandLine": {
           "description": "The command line to start jest tests. It should be the same command line users run jest tests from a terminal/shell, with ability to append extra arguments (by the extension at runtime)",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
       "title": "Jest",
       "properties": {
         "jest.enable": {
-          "markdownDescription": "enable/disable jest extension for the workspace folder. Default is true", 
+          "markdownDescription": "enable/disable jest extension for the workspace folder. Default is true",
           "type": "boolean",
           "scope": "resource",
-          "default": true 
+          "default": true
         },
         "jest.jestCommandLine": {
           "description": "The command line to start jest tests. It should be the same command line users run jest tests from a terminal/shell, with ability to append extra arguments (by the extension at runtime)",

--- a/src/setup-wizard/index.ts
+++ b/src/setup-wizard/index.ts
@@ -5,3 +5,5 @@ export {
   PendingSetupTask,
   PendingSetupTaskKey,
 } from './start-wizard';
+
+export { IgnoreWorkspaceChanges } from './tasks';

--- a/src/setup-wizard/tasks/setup-monorepo.ts
+++ b/src/setup-wizard/tasks/setup-monorepo.ts
@@ -136,7 +136,6 @@ export const setupMonorepo: SetupTask = async (context: WizardContext): Promise<
             .catch((e) => reject(e))
             .finally(() => {
               subscription.dispose();
-              context.vscodeContext.workspaceState.update(IgnoreWorkspaceChanges, undefined);
             });
         });
 
@@ -155,7 +154,10 @@ export const setupMonorepo: SetupTask = async (context: WizardContext): Promise<
       });
     } catch (e) {
       message(`Failed to add/validate workspace folders:\r\n${toErrorString(e)}`, 'error');
+    } finally {
+      context.vscodeContext.workspaceState.update(IgnoreWorkspaceChanges, undefined);
     }
+
     return 'abort';
   };
 

--- a/src/workspace-manager.ts
+++ b/src/workspace-manager.ts
@@ -26,6 +26,23 @@ interface ValidatePatternType {
   binary: string[];
 }
 
+export const enabledWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
+  if (!vscode.workspace.workspaceFolders) {
+    return [];
+  }
+
+  const windowConfig = vscode.workspace.getConfiguration('jest');
+  const disabledWorkspaceFolders = windowConfig.get<string[]>('disabledWorkspaceFolders') ?? [];
+
+  return vscode.workspace.workspaceFolders.filter((ws) => {
+    if (disabledWorkspaceFolders.includes(ws.name)) {
+      return false;
+    }
+    const config = vscode.workspace.getConfiguration('jest', ws);
+    return config.get<boolean>('enable') ?? true;
+  });
+};
+
 export const isSameWorkspace = (
   ws1: vscode.WorkspaceFolder,
   ws2: vscode.WorkspaceFolder
@@ -42,7 +59,7 @@ export class WorkspaceManager {
     }
 
     const validWorkspaces: Map<string, WorkspaceInfo> = new Map();
-    for (const ws of vscode.workspace.workspaceFolders) {
+    for (const ws of enabledWorkspaceFolders()) {
       if (validWorkspaces.has(ws.uri.path)) {
         continue;
       }

--- a/tests/setup-wizard/tasks/setup-monorepo.test.ts
+++ b/tests/setup-wizard/tasks/setup-monorepo.test.ts
@@ -185,8 +185,6 @@ describe('setupMonorepo', () => {
           context.wsManager.getValidWorkspaces.mockRejectedValue('error');
           (vscode.workspace.updateWorkspaceFolders as jest.Mocked<any>).mockReturnValue(true);
 
-          // const result = await setupMonorepo(context);
-          // expect(result).toEqual('abort');
           await expect(setupMonorepo(context)).rejects.toEqual('error');
           expect(context.vscodeContext.workspaceState.update).toHaveBeenLastCalledWith(
             IgnoreWorkspaceChanges,

--- a/tests/setup-wizard/tasks/setup-monorepo.test.ts
+++ b/tests/setup-wizard/tasks/setup-monorepo.test.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 import * as helper from '../../../src/setup-wizard/wizard-helper';
 import {
+  IgnoreWorkspaceChanges,
   MonorepoSetupActionId,
   setupMonorepo,
 } from '../../../src/setup-wizard/tasks/setup-monorepo';
@@ -141,6 +142,17 @@ describe('setupMonorepo', () => {
           if (!isError) {
             expect(vscode.workspace.onDidChangeWorkspaceFolders).toHaveBeenCalled();
             expect(subscription.dispose).toHaveBeenCalled();
+            expect(context.vscodeContext.workspaceState.update).toHaveBeenCalledTimes(2);
+            expect(context.vscodeContext.workspaceState.update).toHaveBeenNthCalledWith(
+              1,
+              IgnoreWorkspaceChanges,
+              true
+            );
+            expect(context.vscodeContext.workspaceState.update).toHaveBeenNthCalledWith(
+              2,
+              IgnoreWorkspaceChanges,
+              undefined
+            );
           }
           if (folderUris) {
             expect(vscode.workspace.updateWorkspaceFolders).toHaveBeenCalledWith(

--- a/tests/setup-wizard/tasks/task-test-helper.ts
+++ b/tests/setup-wizard/tasks/task-test-helper.ts
@@ -12,6 +12,10 @@ export const createWizardContext = (debugConfigProvider: any, wsName?: string): 
       get: jest.fn(),
       update: jest.fn(),
     },
+    workspaceState: {
+      get: jest.fn(),
+      update: jest.fn(),
+    },
   },
   workspace: wsName ? workspaceFolder(wsName) : undefined,
   message: jest.fn(),

--- a/tests/workspace-manager.test.ts
+++ b/tests/workspace-manager.test.ts
@@ -1,253 +1,306 @@
 jest.unmock('../src/workspace-manager');
 jest.unmock('./setup-wizard/test-helper');
+jest.unmock('./test-helper');
 jest.unmock('./setup-wizard/tasks/task-test-helper');
 
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-import { WorkspaceManager } from '../src/workspace-manager';
+import { enabledWorkspaceFolders, WorkspaceManager } from '../src/workspace-manager';
 
 import { workspaceFolder } from './setup-wizard/test-helper';
 import { getPackageJson } from '../src/helpers';
 import { toUri } from './setup-wizard/tasks/task-test-helper';
+import { makeWorkspaceFolder } from './test-helper';
 
-describe('workspaceFolder', () => {
-  let mockFindFiles;
+const mockGetConfiguration = (disabledWorkspaceFolders: string[], enabled: 'all' | string[]) => {
+  const getConfiguration = (scope, key) => {
+    if (key === 'disabledWorkspaceFolders') {
+      return disabledWorkspaceFolders;
+    }
+    if (key === 'enable') {
+      return enabled === 'all' ? true : enabled.includes(scope.name);
+    }
+  };
+  return jest.fn().mockImplementation((_section, scope) => ({
+    get: (key) => getConfiguration(scope, key),
+  }));
+};
+describe('workspace-manager', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    (vscode as any).RelativePattern = jest.fn((_ws, p) => p);
-    (vscode.Uri as any).file = jest.fn((f) => ({ fsPath: f, path: f }));
-    mockFindFiles = jest.fn();
-    (vscode.workspace as any).findFiles = mockFindFiles;
+    vscode.workspace.getConfiguration = mockGetConfiguration([], 'all');
+  });
+  describe('enabledWorkspaceFolders', () => {
+    it('returns empty array if no workspace', () => {
+      (vscode.workspace as any).workspaceFolders = undefined;
+      expect(enabledWorkspaceFolders()).toEqual([]);
+    });
+    it.each`
+      case | disabledWorkspaceFolders | enableSettings    | result
+      ${1} | ${[]}                    | ${['ws1']}        | ${['ws1']}
+      ${2} | ${['ws1']}               | ${['ws1', 'ws2']} | ${['ws2']}
+      ${3} | ${['ws2']}               | ${['ws1', 'ws2']} | ${['ws1']}
+      ${4} | ${[]}                    | ${['ws1', 'ws2']} | ${['ws1', 'ws2']}
+    `('case $case', ({ disabledWorkspaceFolders, enableSettings, result }) => {
+      const folders = ['ws1', 'ws2'].map((name) => makeWorkspaceFolder(name));
+      (vscode.workspace as any).workspaceFolders = folders;
+      const disabled = disabledWorkspaceFolders.map(
+        (name) => folders.find((f) => f.name === name)?.name
+      );
+      const enabled = enableSettings.map((name) => folders.find((f) => f.name === name)?.name);
+      vscode.workspace.getConfiguration = mockGetConfiguration(disabled, enabled);
+
+      expect(enabledWorkspaceFolders().map((f) => f.name)).toEqual(result);
+    });
   });
 
-  describe('getFoldersFromFilesystem: find workspace folders', () => {
-    const root = workspaceFolder('root');
+  describe('WorkspaceManager', () => {
+    let mockFindFiles;
     beforeEach(() => {
-      (vscode.workspace as any).workspaceFolders = [root];
+      (vscode as any).RelativePattern = jest.fn((_ws, p) => p);
+      (vscode.Uri as any).file = jest.fn((f) => ({ fsPath: f, path: f }));
+      mockFindFiles = jest.fn();
+      (vscode.workspace as any).findFiles = mockFindFiles;
     });
-    it('error if no workspace folder', async () => {
-      expect.hasAssertions();
 
-      (vscode.workspace as any).workspaceFolders = [];
-      const wsManager = new WorkspaceManager();
-      await expect(wsManager.getFoldersFromFilesystem).rejects.toThrow();
-    });
-    describe('can check for any workspace', () => {
-      const w1 = workspaceFolder('w1');
-      describe.each`
-        desc                    | workspace    | rootWorkspace
-        ${'from project root'}  | ${undefined} | ${root}
-        ${'from sub workspace'} | ${w1}        | ${w1}
-      `('$desc', ({ workspace, rootWorkspace }) => {
-        it('from workspaces property in package.json', async () => {
-          expect.hasAssertions();
-
-          (getPackageJson as jest.Mocked<any>).mockReturnValue({ workspaces: ['folder-1'] });
-
-          mockFindFiles.mockReturnValue(Promise.resolve([{ fsPath: 'folder-1/package.json' }]));
-          const wsManager = new WorkspaceManager();
-          const uris = await wsManager.getFoldersFromFilesystem(workspace);
-
-          expect(vscode.workspace.findFiles).toHaveBeenCalledTimes(1);
-          expect(vscode.RelativePattern).toHaveBeenCalledWith(
-            rootWorkspace,
-            'folder-1/**/package.json'
-          );
-          expect(uris).toHaveLength(1);
-          expect(uris.map((uri) => uri.fsPath)).toEqual(['folder-1']);
-        });
-        it('from directory contains package.json', async () => {
-          expect.hasAssertions();
-
-          // package.json did not contain workspaces
-          (getPackageJson as jest.Mocked<any>).mockReturnValue({});
-
-          mockFindFiles.mockReturnValue(
-            Promise.resolve([
-              { fsPath: path.join('folder-1', 'package.json') },
-              { fsPath: path.join('folder-2', 'package.json') },
-            ])
-          );
-          const wsManager = new WorkspaceManager();
-          const uris = await wsManager.getFoldersFromFilesystem(workspace);
-
-          expect(vscode.workspace.findFiles).toHaveBeenCalledTimes(1);
-          expect(vscode.RelativePattern).toHaveBeenCalledWith(rootWorkspace, '**/package.json');
-
-          expect(uris).toHaveLength(2);
-          expect(uris.map((uri) => uri.fsPath)).toEqual(['folder-1', 'folder-2']);
-        });
+    describe('getFoldersFromFilesystem: find workspace folders', () => {
+      const root = workspaceFolder('root');
+      beforeEach(() => {
+        (vscode.workspace as any).workspaceFolders = [root];
       });
-    });
-    it('if no folder is found, returns empyt list', async () => {
-      (vscode.workspace as any).workspaceFolders = [];
-      mockFindFiles.mockReturnValue(Promise.resolve([]));
-      const wsManager = new WorkspaceManager();
-      await expect(wsManager.getFoldersFromFilesystem()).resolves.toEqual([]);
-    });
-  });
-  describe('can validate jest eligible workspaces', () => {
-    beforeEach(() => {
-      (vscode.workspace as any).workspaceFolders = [
-        workspaceFolder('root'),
-        workspaceFolder('folder-1'),
-        workspaceFolder('folder-2'),
-      ];
-      (vscode.workspace.getWorkspaceFolder as jest.Mocked<any>).mockImplementation((u) => {
-        const ws = u.fsPath.split(path.sep)[0];
-        if (['root', 'folder-1', 'folder-2'].includes(ws)) {
-          return { uri: toUri(ws), name: ws };
-        }
-      });
-      (vscode as any).RelativePattern = jest.fn((ws, p) => [ws, p]);
-    });
-    describe('getValidWorkspaces: returns all valid workspaces', () => {
-      it('throw error if no workspace folders', async () => {
+      it('error if no workspace folder', async () => {
         expect.hasAssertions();
+
         (vscode.workspace as any).workspaceFolders = [];
         const wsManager = new WorkspaceManager();
-        await expect(wsManager.getValidWorkspaces()).rejects.toThrow();
+        await expect(wsManager.getFoldersFromFilesystem).rejects.toThrow();
       });
-      describe('validate algorithms', () => {
-        const byJestConfig = () => {
-          mockFindFiles.mockImplementation(([ws, pattern]) => {
-            // 'folder-1' and 'folder-2' have 'jest-config.xxx' file
-            if (pattern.startsWith('**/jest.config.') && ws.name === 'root') {
-              return Promise.resolve([
-                toUri('folder-1', 'jest.config.js'),
-                toUri('folder-2', 'jest.config.ts'),
-              ]);
-            }
-            return Promise.resolve([]);
+      describe('can check for any workspace', () => {
+        const w1 = workspaceFolder('w1');
+        describe.each`
+          desc                    | workspace    | rootWorkspace
+          ${'from project root'}  | ${undefined} | ${root}
+          ${'from sub workspace'} | ${w1}        | ${w1}
+        `('$desc', ({ workspace, rootWorkspace }) => {
+          it('from workspaces property in package.json', async () => {
+            expect.hasAssertions();
+
+            (getPackageJson as jest.Mocked<any>).mockReturnValue({ workspaces: ['folder-1'] });
+
+            mockFindFiles.mockReturnValue(Promise.resolve([{ fsPath: 'folder-1/package.json' }]));
+            const wsManager = new WorkspaceManager();
+            const uris = await wsManager.getFoldersFromFilesystem(workspace);
+
+            expect(vscode.workspace.findFiles).toHaveBeenCalledTimes(1);
+            expect(vscode.RelativePattern).toHaveBeenCalledWith(
+              rootWorkspace,
+              'folder-1/**/package.json'
+            );
+            expect(uris).toHaveLength(1);
+            expect(uris.map((uri) => uri.fsPath)).toEqual(['folder-1']);
           });
-        };
-        const byVscodeJest = () => {
-          mockFindFiles.mockImplementation(([ws, pattern]) => {
-            // 'folder-1' and 'folder-2' have '.vscode-jest' file
-            if (pattern.startsWith('**/.vscode-jest') && ws.name === 'root') {
-              return Promise.resolve([
-                toUri('folder-1', '.vscode-jest'),
-                toUri('folder-2', '.vscode-jest'),
-              ]);
-            }
-            return Promise.resolve([]);
+          it('from directory contains package.json', async () => {
+            expect.hasAssertions();
+
+            // package.json did not contain workspaces
+            (getPackageJson as jest.Mocked<any>).mockReturnValue({});
+
+            mockFindFiles.mockReturnValue(
+              Promise.resolve([
+                { fsPath: path.join('folder-1', 'package.json') },
+                { fsPath: path.join('folder-2', 'package.json') },
+              ])
+            );
+            const wsManager = new WorkspaceManager();
+            const uris = await wsManager.getFoldersFromFilesystem(workspace);
+
+            expect(vscode.workspace.findFiles).toHaveBeenCalledTimes(1);
+            expect(vscode.RelativePattern).toHaveBeenCalledWith(rootWorkspace, '**/package.json');
+
+            expect(uris).toHaveLength(2);
+            expect(uris.map((uri) => uri.fsPath)).toEqual(['folder-1', 'folder-2']);
           });
-        };
-        const byBinary = () => {
+        });
+      });
+      it('if no folder is found, returns empyt list', async () => {
+        (vscode.workspace as any).workspaceFolders = [];
+        mockFindFiles.mockReturnValue(Promise.resolve([]));
+        const wsManager = new WorkspaceManager();
+        await expect(wsManager.getFoldersFromFilesystem()).resolves.toEqual([]);
+      });
+    });
+    describe('can validate jest eligible workspaces', () => {
+      beforeEach(() => {
+        (vscode.workspace as any).workspaceFolders = [
+          workspaceFolder('root'),
+          workspaceFolder('folder-1'),
+          workspaceFolder('folder-2'),
+        ];
+        (vscode.workspace.getWorkspaceFolder as jest.Mocked<any>).mockImplementation((u) => {
+          const ws = u.fsPath.split(path.sep)[0];
+          if (['root', 'folder-1', 'folder-2'].includes(ws)) {
+            return { uri: toUri(ws), name: ws };
+          }
+        });
+        (vscode as any).RelativePattern = jest.fn((ws, p) => [ws, p]);
+      });
+      describe('getValidWorkspaces: returns all valid workspaces', () => {
+        it('throw error if no workspace folders', async () => {
+          expect.hasAssertions();
+          (vscode.workspace as any).workspaceFolders = [];
+          const wsManager = new WorkspaceManager();
+          await expect(wsManager.getValidWorkspaces()).rejects.toThrow();
+        });
+        describe('validate algorithms', () => {
+          const byJestConfig = () => {
+            mockFindFiles.mockImplementation(([ws, pattern]) => {
+              // 'folder-1' and 'folder-2' have 'jest-config.xxx' file
+              if (pattern.startsWith('**/jest.config.') && ws.name === 'root') {
+                return Promise.resolve([
+                  toUri('folder-1', 'jest.config.js'),
+                  toUri('folder-2', 'jest.config.ts'),
+                ]);
+              }
+              return Promise.resolve([]);
+            });
+          };
+          const byVscodeJest = () => {
+            mockFindFiles.mockImplementation(([ws, pattern]) => {
+              // 'folder-1' and 'folder-2' have '.vscode-jest' file
+              if (pattern.startsWith('**/.vscode-jest') && ws.name === 'root') {
+                return Promise.resolve([
+                  toUri('folder-1', '.vscode-jest'),
+                  toUri('folder-2', '.vscode-jest'),
+                ]);
+              }
+              return Promise.resolve([]);
+            });
+          };
+          const byBinary = () => {
+            mockFindFiles.mockImplementation(([ws, pattern]) => {
+              // 'folder-1' and 'folder-2' has jest binary in node_modules
+              if (pattern.startsWith('node_modules') && ws.name !== 'root') {
+                return Promise.resolve([toUri(ws.name, 'jest')]);
+              }
+              return Promise.resolve([]);
+            });
+          };
+          const byJestInPackageJson = () => {
+            mockFindFiles.mockResolvedValue([]);
+            // folder-1 and folder-2 have jest config embedded inside package.json
+            (getPackageJson as jest.Mocked<any>).mockImplementation((aPath: string) => {
+              return aPath !== 'root' ? { jest: {} } : {};
+            });
+          };
+          it.each`
+            desc                                | init
+            ${'by jest.config'}                 | ${byJestConfig}
+            ${'by binary'}                      | ${byBinary}
+            ${'by .vscode-jest'}                | ${byVscodeJest}
+            ${'by jest config in package.json'} | ${byJestInPackageJson}
+          `('$desc', async ({ init }) => {
+            expect.hasAssertions();
+            init();
+
+            const wsManager = new WorkspaceManager();
+            const wsList = await wsManager.getValidWorkspaces();
+            expect(wsList.map((ws) => ws.workspace.name)).toEqual(['folder-1', 'folder-2']);
+          });
+          it('will ignore disabled folders', async () => {
+            expect.hasAssertions();
+            byBinary();
+            vscode.workspace.getConfiguration = mockGetConfiguration([], ['folder-1']);
+
+            const wsManager = new WorkspaceManager();
+            const wsList = await wsManager.getValidWorkspaces();
+            expect(wsList.map((ws) => ws.workspace.name)).toEqual(['folder-1']);
+          });
+        });
+      });
+      describe('can validate individual workspace', () => {
+        beforeEach(() => {
+          //root has jest in package.json
+          (getPackageJson as jest.Mocked<any>).mockImplementation((aPath: string) => {
+            return aPath === 'root' ? { jest: {} } : {};
+          });
+
+          // folder-1 has a jest.config
+          //folder-2 has binary
           mockFindFiles.mockImplementation(([ws, pattern]) => {
-            // 'folder-1' and 'folder-2' has jest binary in node_modules
-            if (pattern.startsWith('node_modules') && ws.name !== 'root') {
+            if (
+              (pattern.startsWith('**/jest.config.') && ['root', 'folder-1'].includes(ws.name)) ||
+              (pattern.startsWith('jest.config.') && ws.name === 'folder-1')
+            ) {
+              return Promise.resolve([toUri('folder-1', 'jest.config.mjs')]);
+            }
+            if (pattern.startsWith('node_modules') && ws.name === 'folder-2') {
               return Promise.resolve([toUri(ws.name, 'jest')]);
             }
             return Promise.resolve([]);
           });
-        };
-        const byJestInPackageJson = () => {
-          mockFindFiles.mockResolvedValue([]);
-          // folder-1 and folder-2 have jest config embedded inside package.json
-          (getPackageJson as jest.Mocked<any>).mockImplementation((aPath: string) => {
-            return aPath !== 'root' ? { jest: {} } : {};
-          });
-        };
+        });
         it.each`
-          desc                                | init
-          ${'by jest.config'}                 | ${byJestConfig}
-          ${'by binary'}                      | ${byBinary}
-          ${'by .vscode-jest'}                | ${byVscodeJest}
-          ${'by jest config in package.json'} | ${byJestInPackageJson}
-        `('$desc', async ({ init }) => {
-          expect.hasAssertions();
-          init();
+          types                                           | rootResult              | folder1Result   | folder2Result
+          ${['deep-config']}                              | ${['folder-1']}         | ${['folder-1']} | ${[]}
+          ${['shallow-config']}                           | ${[]}                   | ${['folder-1']} | ${[]}
+          ${['binary']}                                   | ${[]}                   | ${[]}           | ${['folder-2']}
+          ${['jest-in-package']}                          | ${['root']}             | ${[]}           | ${[]}
+          ${['deep-config', 'binary']}                    | ${['folder-1']}         | ${['folder-1']} | ${['folder-2']}
+          ${['deep-config', 'binary', 'jest-in-package']} | ${['root', 'folder-1']} | ${['folder-1']} | ${['folder-2']}
+        `(
+          'can validate by types=$types',
+          async ({ types, rootResult, folder1Result, folder2Result }) => {
+            expect.hasAssertions();
 
-          const wsManager = new WorkspaceManager();
-          const wsList = await wsManager.getValidWorkspaces();
-          expect(wsList.map((ws) => ws.workspace.name)).toEqual(['folder-1', 'folder-2']);
-        });
-      });
-    });
-    describe('can validate individual workspace', () => {
-      beforeEach(() => {
-        //root has jest in package.json
-        (getPackageJson as jest.Mocked<any>).mockImplementation((aPath: string) => {
-          return aPath === 'root' ? { jest: {} } : {};
-        });
+            const wsManager = new WorkspaceManager();
+            let wsList = await wsManager.validateWorkspace(workspaceFolder('root'), types);
+            expect(wsList.map((ws) => ws.workspace.name).sort()).toEqual(rootResult.sort());
 
-        // folder-1 has a jest.config
-        //folder-2 has binary
-        mockFindFiles.mockImplementation(([ws, pattern]) => {
-          if (
-            (pattern.startsWith('**/jest.config.') && ['root', 'folder-1'].includes(ws.name)) ||
-            (pattern.startsWith('jest.config.') && ws.name === 'folder-1')
-          ) {
-            return Promise.resolve([toUri('folder-1', 'jest.config.mjs')]);
+            wsList = await wsManager.validateWorkspace(workspaceFolder('folder-1'), types);
+            expect(wsList.map((ws) => ws.workspace.name).sort()).toEqual(folder1Result.sort());
+
+            wsList = await wsManager.validateWorkspace(workspaceFolder('folder-2'), types);
+            expect(wsList.map((ws) => ws.workspace.name).sort()).toEqual(folder2Result.sort());
           }
-          if (pattern.startsWith('node_modules') && ws.name === 'folder-2') {
-            return Promise.resolve([toUri(ws.name, 'jest')]);
-          }
-          return Promise.resolve([]);
-        });
-      });
-      it.each`
-        types                                           | rootResult              | folder1Result   | folder2Result
-        ${['deep-config']}                              | ${['folder-1']}         | ${['folder-1']} | ${[]}
-        ${['shallow-config']}                           | ${[]}                   | ${['folder-1']} | ${[]}
-        ${['binary']}                                   | ${[]}                   | ${[]}           | ${['folder-2']}
-        ${['jest-in-package']}                          | ${['root']}             | ${[]}           | ${[]}
-        ${['deep-config', 'binary']}                    | ${['folder-1']}         | ${['folder-1']} | ${['folder-2']}
-        ${['deep-config', 'binary', 'jest-in-package']} | ${['root', 'folder-1']} | ${['folder-1']} | ${['folder-2']}
-      `(
-        'can validate by types=$types',
-        async ({ types, rootResult, folder1Result, folder2Result }) => {
+        );
+        it('can detect rootPath', async () => {
           expect.hasAssertions();
 
+          const activation = toUri('folder-1', 'src', 'jest.config.mjs');
+          mockFindFiles.mockImplementation(([ws, pattern]) => {
+            if (pattern.startsWith('**/jest.config.') && ['folder-1'].includes(ws.name)) {
+              return Promise.resolve([activation]);
+            }
+            return Promise.resolve([]);
+          });
+
+          const workspace = workspaceFolder('folder-1');
           const wsManager = new WorkspaceManager();
-          let wsList = await wsManager.validateWorkspace(workspaceFolder('root'), types);
-          expect(wsList.map((ws) => ws.workspace.name).sort()).toEqual(rootResult.sort());
-
-          wsList = await wsManager.validateWorkspace(workspaceFolder('folder-1'), types);
-          expect(wsList.map((ws) => ws.workspace.name).sort()).toEqual(folder1Result.sort());
-
-          wsList = await wsManager.validateWorkspace(workspaceFolder('folder-2'), types);
-          expect(wsList.map((ws) => ws.workspace.name).sort()).toEqual(folder2Result.sort());
-        }
-      );
-      it('can detect rootPath', async () => {
-        expect.hasAssertions();
-
-        const activation = toUri('folder-1', 'src', 'jest.config.mjs');
-        mockFindFiles.mockImplementation(([ws, pattern]) => {
-          if (pattern.startsWith('**/jest.config.') && ['folder-1'].includes(ws.name)) {
-            return Promise.resolve([activation]);
-          }
-          return Promise.resolve([]);
+          const wsList = await wsManager.validateWorkspace(workspace, ['deep-config']);
+          expect(wsList).toHaveLength(1);
+          expect(wsList[0]).toEqual({
+            workspace,
+            rootPath: `.${path.sep}src`,
+            activation,
+          });
         });
+        it('can ignore activation if not a workspace', async () => {
+          expect.hasAssertions();
 
-        const workspace = workspaceFolder('folder-1');
-        const wsManager = new WorkspaceManager();
-        const wsList = await wsManager.validateWorkspace(workspace, ['deep-config']);
-        expect(wsList).toHaveLength(1);
-        expect(wsList[0]).toEqual({
-          workspace,
-          rootPath: `.${path.sep}src`,
-          activation,
+          const activation = toUri('folder-3', 'jest.config.mjs');
+          mockFindFiles.mockImplementation(([ws, pattern]) => {
+            if (pattern.startsWith('**/jest.config.') && ['folder-1'].includes(ws.name)) {
+              return Promise.resolve([activation]);
+            }
+            return Promise.resolve([]);
+          });
+
+          const workspace = workspaceFolder('folder-1');
+          const wsManager = new WorkspaceManager();
+          const wsList = await wsManager.validateWorkspace(workspace, ['deep-config']);
+          expect(wsList).toHaveLength(0);
         });
-      });
-      it('can ignore activation if not a workspace', async () => {
-        expect.hasAssertions();
-
-        const activation = toUri('folder-3', 'jest.config.mjs');
-        mockFindFiles.mockImplementation(([ws, pattern]) => {
-          if (pattern.startsWith('**/jest.config.') && ['folder-1'].includes(ws.name)) {
-            return Promise.resolve([activation]);
-          }
-          return Promise.resolve([]);
-        });
-
-        const workspace = workspaceFolder('folder-1');
-        const wsManager = new WorkspaceManager();
-        const wsList = await wsManager.validateWorkspace(workspace, ['deep-config']);
-        expect(wsList).toHaveLength(0);
       });
     });
   });

--- a/tests/workspace-manager.test.ts
+++ b/tests/workspace-manager.test.ts
@@ -13,12 +13,15 @@ import { getPackageJson } from '../src/helpers';
 import { toUri } from './setup-wizard/tasks/task-test-helper';
 import { makeWorkspaceFolder } from './test-helper';
 
-const mockGetConfiguration = (disabledWorkspaceFolders: string[], enabled: 'all' | string[]) => {
+const mockGetConfiguration = (disabledWorkspaceFolders?: string[], enabled?: 'all' | string[]) => {
   const getConfiguration = (scope, key) => {
     if (key === 'disabledWorkspaceFolders') {
       return disabledWorkspaceFolders;
     }
     if (key === 'enable') {
+      if (!enabled) {
+        return enabled;
+      }
       return enabled === 'all' ? true : enabled.includes(scope.name);
     }
   };
@@ -38,6 +41,7 @@ describe('workspace-manager', () => {
     });
     it.each`
       case | disabledWorkspaceFolders | enableSettings    | result
+      ${1} | ${undefined}             | ${undefined}      | ${['ws1', 'ws2']}
       ${1} | ${[]}                    | ${['ws1']}        | ${['ws1']}
       ${2} | ${['ws1']}               | ${['ws1', 'ws2']} | ${['ws2']}
       ${3} | ${['ws2']}               | ${['ws1', 'ws2']} | ${['ws1']}
@@ -45,10 +49,10 @@ describe('workspace-manager', () => {
     `('case $case', ({ disabledWorkspaceFolders, enableSettings, result }) => {
       const folders = ['ws1', 'ws2'].map((name) => makeWorkspaceFolder(name));
       (vscode.workspace as any).workspaceFolders = folders;
-      const disabled = disabledWorkspaceFolders.map(
+      const disabled = disabledWorkspaceFolders?.map(
         (name) => folders.find((f) => f.name === name)?.name
       );
-      const enabled = enableSettings.map((name) => folders.find((f) => f.name === name)?.name);
+      const enabled = enableSettings?.map((name) => folders.find((f) => f.name === name)?.name);
       vscode.workspace.getConfiguration = mockGetConfiguration(disabled, enabled);
 
       expect(enabledWorkspaceFolders().map((f) => f.name)).toEqual(result);


### PR DESCRIPTION
Adding a new setting `jest.enable` to completely turn the extension off for a given workspace. Also, incorporate this in the monorepo setup tool so we will ignore the disabled workspace.

Note 
1. this indeed overlaps with the "disabledWorkspaceFolders" setting, albeit served different use cases.
2. I wasn't sure if we really needed this feature since the user could simply use the vscode feature to disable the extension for the specific workspace. But it might be useful for the monorepo use cases, where you just want to disable a specific folder rather than the whole workspace. So go ahead added it to close the requirement. 

resolve #984 
resolve #981
resolve #993