### PR TITLE
Dashed-args

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,12 @@
           "type": "object",
           "default": null,
           "scope": "resource"
+        },
+        "jest.useDashedArgs": {
+          "markdownDescription": "Use dashed args for jest command line.",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource" 
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
           "markdownDescription": "Use dashed args for jest command line.",
           "type": "boolean",
           "default": false,
-          "scope": "resource" 
+          "scope": "resource"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -492,7 +492,7 @@
   "dependencies": {
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-source-maps": "^4.0.1",
-    "jest-editor-support": "^31.0.1"
+    "jest-editor-support": "^31.1.0"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.4",

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -66,7 +66,8 @@ export const createJestExtContext = (
       options?.collectCoverage ?? settings.showCoverageOnLoad,
       settings.debugMode,
       settings.nodeEnv,
-      settings.shell.toSetting()
+      settings.shell.toSetting(),
+      settings.useDashedArgs
     );
   };
   return {
@@ -121,6 +122,7 @@ export const getExtensionResourceSettings = (uri: vscode.Uri): PluginResourceSet
     autoRun: new AutoRun(config.get<JestExtAutoRunSetting | null>('autoRun')),
     autoRevealOutput: config.get<AutoRevealOutputType>('autoRevealOutput') ?? 'on-run',
     parserPluginOptions: config.get<JESParserPluginOptions>('parserPluginOptions'),
+    useDashedArgs: config.get<boolean>('useDashedArgs') ?? false,
   };
 };
 

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -51,6 +51,7 @@ export interface PluginResourceSettings {
   monitorLongRun?: MonitorLongRun;
   autoRevealOutput: AutoRevealOutputType;
   parserPluginOptions?: JESParserPluginOptions;
+  useDashedArgs?: boolean;
 }
 
 export interface PluginWindowSettings {

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -56,6 +56,17 @@ describe('createJestExtContext', () => {
       expect(toFilePath).toHaveBeenCalledWith(rootPath);
       expect(runnerWorkspace).toEqual(mockRunnerWorkspace);
     });
+    it('will pass through useDashedArgs', () => {
+      const settings: any = { ...baseSettings, useDashedArgs: true };
+
+      jest.clearAllMocks();
+
+      const { createRunnerWorkspace } = createJestExtContext(workspaceFolder, settings, output);
+      createRunnerWorkspace();
+      const args = (ProjectWorkspace as jest.Mocked<any>).mock.calls[0];
+      const [useDashedArgs] = [args[9]];
+      expect(useDashedArgs).toBeTruthy();
+    });
     describe('allow creating runnerWorkspace with custom options', () => {
       it('outputFileSuffix and collectCoverage', () => {
         const settings: any = { ...baseSettings, showCoverageOnLoad: false };
@@ -163,6 +174,7 @@ describe('getExtensionResourceSettings()', () => {
       shell: mockShell,
       autoRevealOutput: 'on-run',
       parserPluginOptions: null,
+      useDashedArgs: false,
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,10 +2344,10 @@ jest-each@^29.3.1:
     jest-util "^29.3.1"
     pretty-format "^29.3.1"
 
-jest-editor-support@^31.0.1:
-  version "31.0.1"
-  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-31.0.1.tgz#029d2fb29c5a455b628a3ddc0f07bab810ab3bbd"
-  integrity sha512-pzY3MypHzZaNNmawFZoEc5N7X+GQvtiy4KuPcsYC3ROXdVoGh0qdladd4pRrbuaggrTAGPOMxAq3x+BDVvqErw==
+jest-editor-support@^31.1.0:
+  version "31.1.0"
+  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-31.1.0.tgz#087a8954d465288f3c544c75feb223f4bc31cea5"
+  integrity sha512-CGDZh5gO4NRthr6ocmD13pkuSDqZ03Cq+f6UuvwELoNN7p7rkZrEwjPZ/ysMDWoEzRtlTFZ+7sYmfE4kuyhIhQ==
   dependencies:
     "@babel/parser" "^7.20.7"
     "@babel/runtime" "^7.20.7"


### PR DESCRIPTION
adding a new setting `jest.useDashedArgs` to convert all camelcase arguments (default) to dashed arguments. This is mainly to support angular projects that are deprecating camelcase arguments.

The actual conversion is done in `jest-editor-support` (see jest-community/jest-editor-support#103). We are merely passing through this setting.

resolve #923