### PR TITLE
Virtual-folder

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -8,6 +8,7 @@ const StatusBarAlignment = { Left: 1, Right: 2 };
 const window = {
   createStatusBarItem: jest.fn(() => ({
     show: jest.fn(),
+    hide: jest.fn(),
     tooltip: jest.fn(),
   })),
   showErrorMessage: jest.fn(),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.68.1"
@@ -36,7 +36,6 @@
     "workspaceContains:node_modules/.bin/jest",
     "workspaceContains:node_modules/react-scripts/node_modules/.bin/jest",
     "workspaceContains:node_modules/react-native-scripts",
-    "onCommand:io.orta.jest.start",
     "workspaceContains:**/.vscode-jest"
   ],
   "main": "./out/extension",
@@ -180,6 +179,12 @@
           "type": "object",
           "default": null,
           "scope": "resource"
+        },
+        "jest.virtualFolders": {
+          "markdownDescription": "Allows multiple jest run config for a given (physical) folder. See valid [format](TODO)",
+          "type": "array",
+          "default": null,
+          "scope": "resource"
         }
       }
     },
@@ -272,40 +277,64 @@
       "commandPalette": [
         {
           "command": "io.orta.jest.workspace.start",
-          "when": "workspaceFolderCount > 1"
+          "when": "jest.folderCount > 1"
         },
         {
           "command": "io.orta.jest.workspace.stop",
-          "when": "workspaceFolderCount > 1"
+          "when": "jest.folderCount > 1"
         },
         {
           "command": "io.orta.jest.workspace.toggle-coverage",
-          "when": "workspaceFolderCount > 1"
+          "when": "jest.folderCount > 1"
         },
         {
           "command": "io.orta.jest.editor.workspace.toggle-coverage",
-          "when": "workspaceFolderCount > 1"
+          "when": "jest.folderCount > 1"
         },
         {
           "command": "io.orta.jest.workspace.run-all-tests",
-          "when": "jest:run.interactive && workspaceFolderCount > 1"
-        },
-        {
-          "command": "io.orta.jest.run-all-tests",
-          "when": "jest:run.interactive"
+          "when": "jest.folderCount > 1"
         },
         {
           "command": "io.orta.jest.editor.workspace.run-all-tests",
-          "when": "jest:run.interactive && workspaceFolderCount > 1"
+          "when": "jest.folderCount > 1"
         },
         {
           "command": "io.orta.jest.editor.run-all-tests",
-          "when": "jest:never"
+          "when": "jest.never"
+        },
+        {
+          "command": "io.orta.jest.test-item.auto-run.toggle-on",
+          "when": "jest.never"
+        },
+        {
+          "command": "io.orta.jest.test-item.auto-run.toggle-off",
+          "when": "jest.never"
+        },
+        {
+          "command": "io.orta.jest.test-item.coverage.toggle-on",
+          "when": "jest.never"
+        },
+        {
+          "command": "io.orta.jest.test-item.coverage.toggle-off",
+          "when": "jest.never"
+        },
+        {
+          "command": "io.orta.jest.test-item.reveal-output",
+          "when": "jest.never"
+        },
+        {
+          "command": "io.orta.jest.test-item.view-snapshot",
+          "when": "jest.never"
+        },
+        {
+          "command": "io.orta.jest.test-item.update-snapshot",
+          "when": "jest.never"
         }
       ],
       "editor/context": [
         {
-          "when": "jest:run.interactive && editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact|vue)/ ",
+          "when": "editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact|vue)/ ",
           "command": "io.orta.jest.editor.run-all-tests",
           "group": "Jest"
         }
@@ -356,7 +385,7 @@
         "command": "io.orta.jest.editor.run-all-tests",
         "key": "ctrl+alt+t",
         "mac": "ctrl+alt+t",
-        "when": "jest:run.interactive && editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact|vue)/ "
+        "when": "editorLangId =~ /(javascript|javascriptreact|typescript|typescriptreact|vue)/ "
       }
     ],
     "debuggers": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.68.1"

--- a/src/Coverage/CoverageCodeLensProvider.ts
+++ b/src/Coverage/CoverageCodeLensProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { GetJestExtByURI } from '../extensionManager';
+import { FileCoverage } from 'istanbul-lib-coverage';
 
 export class CoverageCodeLensProvider implements vscode.CodeLensProvider {
   private getJestExt: GetJestExtByURI;
@@ -13,18 +14,7 @@ export class CoverageCodeLensProvider implements vscode.CodeLensProvider {
     this.onDidChangeCodeLenses = this.onDidChange.event;
   }
 
-  public provideCodeLenses(
-    document: vscode.TextDocument
-  ): vscode.ProviderResult<vscode.CodeLens[]> {
-    const ext = this.getJestExt(document.uri);
-    const coverage =
-      ext &&
-      ext.coverageOverlay.enabled &&
-      ext.coverageMapProvider.getFileCoverage(document.fileName);
-    if (!coverage) {
-      return;
-    }
-
+  private createCodeLensForCoverage(coverage: FileCoverage, name?: string): vscode.CodeLens {
     const summary = coverage.toSummary();
     const json = summary.toJSON();
     const metrics = (Object.keys(json) as Array<keyof typeof json>).reduce((previous, metric) => {
@@ -33,11 +23,31 @@ export class CoverageCodeLensProvider implements vscode.CodeLensProvider {
 
     const range = new vscode.Range(0, 0, 0, 0);
     const command: vscode.Command = {
-      title: metrics,
+      title: name ? `${name}: ${metrics}` : metrics,
       command: '',
     };
 
-    return [new vscode.CodeLens(range, command)];
+    return new vscode.CodeLens(range, command);
+  }
+
+  public provideCodeLenses(
+    document: vscode.TextDocument
+  ): vscode.ProviderResult<vscode.CodeLens[]> {
+    const coverages: [FileCoverage, string][] = this.getJestExt(document.uri)
+      .map((ext) => {
+        if (ext.coverageOverlay.enabled) {
+          return [ext.coverageMapProvider.getFileCoverage(document.fileName), ext.name];
+        }
+      })
+      .filter((coverageInfo) => coverageInfo?.[0] != null) as [FileCoverage, string][];
+
+    if (coverages.length === 0) {
+      return undefined;
+    }
+    if (coverages.length === 1) {
+      return [this.createCodeLensForCoverage(coverages[0][0])];
+    }
+    return coverages.map(([coverage, name]) => this.createCodeLensForCoverage(coverage, name));
   }
   public coverageChanged(): void {
     this.onDidChange.fire();

--- a/src/Coverage/CoverageCodeLensProvider.ts
+++ b/src/Coverage/CoverageCodeLensProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { GetJestExtByURI } from '../extensionManager';
+import { GetJestExtByURI } from '../extension-manager';
 import { FileCoverage } from 'istanbul-lib-coverage';
 
 export class CoverageCodeLensProvider implements vscode.CodeLensProvider {

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -8,6 +8,7 @@ import {
   isCreateReactAppTestCommand,
   escapeRegExp,
   parseCmdLine,
+  toAbsoluteRootPath,
 } from './helpers';
 import { platform } from 'os';
 
@@ -216,13 +217,11 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       throw new Error(`invalid cmdLine: ${cmdLine}`);
     }
 
-    const absoluteRootPath =
-      rootPath &&
-      (path.isAbsolute(rootPath) ? rootPath : path.resolve(workspace.uri.fsPath, rootPath));
+    const absoluteRootPath = rootPath && toAbsoluteRootPath(workspace, rootPath);
 
     let finalConfig: vscode.DebugConfiguration = { ...config };
 
-    const cwd = absoluteRootPath ? absoluteRootPath : config.cwd;
+    const cwd = absoluteRootPath ?? config.cwd;
 
     const pmConfig = this.usePM(cmd, cmdArgs);
     if (pmConfig) {

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -39,7 +39,7 @@ import { WizardTaskId } from '../setup-wizard';
 import { ItemCommand, JestExtExplorerContext } from '../test-provider/types';
 import { JestTestProvider } from '../test-provider';
 import { JestProcessInfo } from '../JestProcessManagement';
-import { addFolderToDisabledWorkspaceFolders } from '../extensionManager';
+import { addFolderToDisabledWorkspaceFolders } from '../extension-manager';
 import { MessageAction } from '../messaging';
 import { getExitErrorDef } from '../errors';
 import { WorkspaceManager } from '../workspace-manager';
@@ -445,7 +445,7 @@ export class JestExt {
 
   private isInWorkspace(editor: vscode.TextEditor): boolean {
     if (isVirtualWorkspaceFolder(this.extContext.workspace)) {
-      return this.extContext.workspace.isInWorkspace(editor.document.uri);
+      return this.extContext.workspace.isInWorkspaceFolder(editor.document.uri);
     } else {
       return vscode.workspace.getWorkspaceFolder(editor.document.uri) === this.extContext.workspace;
     }

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -369,7 +369,8 @@ export class JestExt {
   }
 
   public triggerUpdateActiveEditor(editor: vscode.TextEditor): void {
-    if (!this.isInWorkspace(editor)) {
+    // there is use case that the active editor is not in the workspace but is in jest test file list
+    if (!this.isInWorkspace(editor) && !this.isTestFileEditor(editor)) {
       return;
     }
     this.updateEditorContext();
@@ -712,7 +713,11 @@ export class JestExt {
    */
   private refreshDocumentChange(document?: vscode.TextDocument): void {
     for (const editor of vscode.window.visibleTextEditors) {
-      if ((document && editor.document === document) || this.isInWorkspace(editor)) {
+      if (
+        (document && editor.document === document) ||
+        this.isInWorkspace(editor) ||
+        this.isTestFileEditor(editor)
+      ) {
         this.triggerUpdateActiveEditor(editor);
       }
     }

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -122,9 +122,13 @@ export const getExtensionResourceSettings = (
     }
   }
 
-  // get setting from venv first, fallback to workspace setting if not found
+  // get setting from virtual folder first, fallback to workspace setting if not found
   const getSetting = <T>(key: VirtualFolderSettingKey): T | undefined => {
-    return vFolder && key in vFolder ? (vFolder[key] as T) : config.get<T>(key);
+    // we already incorporated rootPath in the virtual folder uri, so do not repeat it here
+    if (vFolder && key in vFolder) {
+      return key === 'rootPath' ? undefined : (vFolder[key] as T);
+    }
+    return config.get<T>(key);
   };
 
   return {

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -51,8 +51,15 @@ export interface PluginResourceSettings {
   monitorLongRun?: MonitorLongRun;
   autoRevealOutput: AutoRevealOutputType;
   parserPluginOptions?: JESParserPluginOptions;
+  enable?: boolean;
 }
 
 export interface PluginWindowSettings {
   disabledWorkspaceFolders: string[];
 }
+
+export type VirtualFolderSettingKey = keyof PluginResourceSettings;
+export type VirtualFolderSettings = {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} & Record<VirtualFolderSettingKey, any>;

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -1,7 +1,9 @@
+import * as vscode from 'vscode';
 import { CoverageColors } from '../Coverage/CoverageOverlay';
 import { JESParserPluginOptions, ProjectWorkspace } from 'jest-editor-support';
 import { AutoRun } from '../JestExt/auto-run';
 import { RunShell } from '../JestExt/run-shell';
+import { isVirtualWorkspaceFolder } from '../virtual-workspace-folder';
 
 export type JestTestProcessType =
   | 'all-tests'
@@ -63,3 +65,37 @@ export type VirtualFolderSettings = {
   name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & Record<VirtualFolderSettingKey, any>;
+
+export type GetConfigFunction = <T>(key: VirtualFolderSettingKey) => T | undefined;
+/**
+ * Returns a function that retrieves Jest configuration settings for a given workspace folder.
+ * If the workspace folder is a virtual folder, it first checks for the corresponding virtual folder setting.
+ * If the setting is not found, it falls back to the workspace setting.
+ * @param workspaceFolder The workspace folder to retrieve Jest configuration settings for.
+ * @returns A function that takes a `VirtualFolderSettingKey` as an argument and returns the corresponding setting value.
+ */
+export const createJestSettingGetter = (
+  workspaceFolder: vscode.WorkspaceFolder
+): GetConfigFunction => {
+  const config = vscode.workspace.getConfiguration('jest', workspaceFolder.uri);
+  let vFolder: VirtualFolderSettings | undefined;
+
+  if (isVirtualWorkspaceFolder(workspaceFolder)) {
+    const virtualFolders = config.get<VirtualFolderSettings[]>('virtualFolders');
+    vFolder = virtualFolders?.find((v) => v.name === workspaceFolder.name);
+    if (!vFolder) {
+      throw new Error(`[${workspaceFolder.name}] is missing corresponding virtual folder setting`);
+    }
+  }
+
+  // get setting from virtual folder first, fallback to workspace setting if not found
+  const getSetting = <T>(key: VirtualFolderSettingKey): T | undefined => {
+    if (key === 'enable') {
+      // if any of the folders is disabled, then the whole workspace is disabled
+      return (config.get<boolean>(key) !== false && vFolder?.enable !== false) as T;
+    }
+
+    return vFolder?.[key] ?? config.get<T>(key);
+  };
+  return getSetting;
+};

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -196,9 +196,6 @@ export class StatusBar {
   }
 
   private updateSummaryStatus() {
-    if (!this.needsSummaryStatus()) {
-      return;
-    }
     this.updateSummaryOutput();
 
     const summaryStats: SBTestStats = { fail: 0, success: 0, unknown: 0 };
@@ -297,10 +294,6 @@ export class StatusBar {
       messages.push(`${item.workspaceFolder.name}:\t\t${summary}`);
     });
     this.summaryOutput.append(messages.join('\n'));
-  }
-
-  private needsSummaryStatus() {
-    return this.cache.size > 0;
   }
 
   private getStateInfo(

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -103,14 +103,10 @@ export class StatusBar {
   }
 
   private createFolderStatusBarItem(workspaceFolder: vscode.WorkspaceFolder): FolderStatusBarItem {
-    let item = this.cache.getItemByFolderName(workspaceFolder.name);
-    if (item) {
-      return item;
-    }
     const actual = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 2);
     actual.tooltip = 'Jest status of the active folder';
 
-    item = new FolderStatusBarItem(StatusType.active, actual, workspaceFolder);
+    const item = new FolderStatusBarItem(StatusType.active, actual, workspaceFolder);
 
     const { showActiveOutput } = this.itemCommands();
     actual.command = { title: 'show test output', command: showActiveOutput, arguments: [item] };

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { extensionName } from './appGlobals';
 import { JestExt } from './JestExt';
 import { TestStats, TestStatsCategory } from './types';
-import { VirtualFolderBasedCache } from './virtual-workspace-folder';
+import { VirtualFolderBasedCache, isVirtualWorkspaceFolder } from './virtual-workspace-folder';
 
 export enum StatusType {
   active,
@@ -36,14 +36,39 @@ export type StatusBarUpdate = Partial<ExtensionStatus>;
 export interface StatusBarUpdateRequest {
   update: (status: StatusBarUpdate) => void;
 }
-interface TypedStatusBarItem {
-  actual: vscode.StatusBarItem;
-  readonly type: StatusType;
-}
 
-interface FolderStatusBarItem extends TypedStatusBarItem {
-  workspaceFolder: vscode.WorkspaceFolder;
-  status: ExtensionStatus;
+class TypedStatusBarItem {
+  public status: ExtensionStatus = {};
+  public isVisible = false;
+  constructor(public readonly type: StatusType, protected readonly actual: vscode.StatusBarItem) {
+    this.actual.hide();
+  }
+  hide() {
+    this.actual.hide();
+    this.isVisible = false;
+  }
+  show() {
+    this.actual.show();
+    this.isVisible = true;
+  }
+  render(options: { text?: string; tooltip?: string; backgroundColor?: vscode.ThemeColor }) {
+    const { text, tooltip, backgroundColor } = options;
+    this.actual.text = text ?? this.actual.text;
+    this.actual.tooltip = tooltip ?? this.actual.tooltip;
+    this.actual.backgroundColor = backgroundColor ?? this.actual.backgroundColor;
+  }
+  dispose() {
+    this.actual.dispose();
+  }
+}
+class FolderStatusBarItem extends TypedStatusBarItem {
+  constructor(
+    public readonly type: StatusType,
+    protected readonly actual: vscode.StatusBarItem,
+    public readonly workspaceFolder: vscode.WorkspaceFolder
+  ) {
+    super(type, actual);
+  }
 }
 
 type BGColor = 'error' | 'warning';
@@ -59,7 +84,7 @@ export class StatusBar {
   private errorColor = new vscode.ThemeColor('statusBarItem.errorBackground');
 
   private cache = new VirtualFolderBasedCache<FolderStatusBarItem>();
-  private _activeFolder?: string;
+  // private _activeFolder?: string;
   private summaryOutput?: vscode.OutputChannel;
 
   constructor() {
@@ -73,10 +98,7 @@ export class StatusBar {
     const { showSummaryOutput } = this.itemCommands();
     actual.command = showSummaryOutput;
 
-    return {
-      type: StatusType.summary,
-      actual,
-    };
+    return new TypedStatusBarItem(StatusType.summary, actual);
   }
 
   private createFolderStatusBarItem(workspaceFolder: vscode.WorkspaceFolder): FolderStatusBarItem {
@@ -87,12 +109,7 @@ export class StatusBar {
     const actual = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 2);
     actual.tooltip = 'Jest status of the active folder';
 
-    item = {
-      type: StatusType.active,
-      workspaceFolder,
-      status: {},
-      actual,
-    };
+    item = new FolderStatusBarItem(StatusType.active, actual, workspaceFolder);
 
     const { showActiveOutput } = this.itemCommands();
     actual.command = { title: 'show test output', command: showActiveOutput, arguments: [item] };
@@ -128,6 +145,12 @@ export class StatusBar {
     const item =
       this.cache.getItemByFolderName(folder.name) ?? this.createFolderStatusBarItem(folder);
 
+    if (
+      vscode.window.activeTextEditor?.document.uri &&
+      this.isInFolder(vscode.window.activeTextEditor?.document.uri, folder)
+    ) {
+      item.show();
+    }
     return {
       update: (update: StatusBarUpdate) => {
         this.handleUpdate(item, update);
@@ -136,62 +159,41 @@ export class StatusBar {
   }
 
   onDidChangeActiveTextEditor(editor: vscode.TextEditor): void {
+    const visibleItems = this.cache.getAllItems().filter((item) => item.isVisible);
     if (editor && editor.document) {
-      const folder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
-      if (folder && folder.name !== this._activeFolder) {
-        this._activeFolder = folder.name;
-        this.updateActiveStatus();
-      }
+      const items = this.cache.findRelatedItems(editor.document.uri);
+      items?.forEach((item) => {
+        if (!item.isVisible) {
+          this.updateItemStatus(item);
+        } else {
+          visibleItems.splice(visibleItems.indexOf(item), 1);
+        }
+      });
     }
+    // hide the items no longer relevant
+    visibleItems.forEach((item) => item.hide());
   }
 
   private handleUpdate(item: FolderStatusBarItem, update: StatusBarUpdate) {
     item.status = { ...item.status, ...update };
 
-    this.updateActiveStatus();
+    if (item.isVisible) {
+      this.updateItemStatus(item);
+    }
     this.updateSummaryStatus();
   }
 
-  private get activeFolder() {
-    if (!this._activeFolder) {
-      if (vscode.workspace.workspaceFolders?.length === 1) {
-        // there's only one workspaceFolder, so let's take it
-        this._activeFolder = vscode.workspace.workspaceFolders[0].name;
-      } else if (vscode.window.activeTextEditor) {
-        // otherwise select correct workspaceFolder based on the currently open textEditor
-        const folder = vscode.workspace.getWorkspaceFolder(
-          vscode.window.activeTextEditor.document.uri
-        );
-        if (folder) {
-          this._activeFolder = folder.name;
-        }
-      }
+  private isInFolder(uri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder): boolean {
+    if (isVirtualWorkspaceFolder(workspaceFolder)) {
+      return workspaceFolder.isInWorkspaceFolder(uri);
     }
-    return this._activeFolder;
+    return vscode.workspace.getWorkspaceFolder(uri)?.name === workspaceFolder.name;
   }
 
-  private updateActiveStatus() {
-    let matchedItems: FolderStatusBarItem[] | undefined;
-    const allItems = this.cache.getAllItems();
-
-    if (this.activeFolder) {
-      matchedItems = this.cache.getItemsByActualFolderName(this.activeFolder);
-    } else {
-      if (allItems.length === 1) {
-        matchedItems = allItems;
-      }
-    }
-
-    allItems.forEach((item) => {
-      if (matchedItems?.find((mi) => mi.actual === item.actual)) {
-        const tooltip = this.getModes(item.status.mode, false);
-        const stateInfo = this.buildSourceStatusString(item.status);
-        this.render(stateInfo, tooltip, item);
-        item.actual.show();
-      } else {
-        item.actual.hide();
-      }
-    });
+  private updateItemStatus(item: TypedStatusBarItem) {
+    const tooltip = this.getModes(item.status.mode, false);
+    const stateInfo = this.buildSourceStatusString(item.status);
+    this.render(stateInfo, tooltip, item);
   }
 
   private updateSummaryStats(status: ExtensionStatus, summaryStats: SBTestStats): void {
@@ -226,7 +228,7 @@ export class StatusBar {
       );
       return;
     }
-    this.summaryStatusItem.actual.hide();
+    this.summaryStatusItem.hide();
   }
   private buildStatsString(stats: SBTestStats, showIcon = true, alwaysShowDetails = false): string {
     const summary: SummaryState = stats.isDirty
@@ -271,18 +273,22 @@ export class StatusBar {
         const item = statusBarItem as FolderStatusBarItem;
         const name = this.cache.size > 1 ? `Jest (${item.workspaceFolder.name})` : 'Jest';
 
-        statusBarItem.actual.text = `${name}: ${stateInfo.label}`;
-        statusBarItem.actual.tooltip = `'${this.activeFolder}' Jest: ${tooltip}`;
-        statusBarItem.actual.backgroundColor = this.toThemeColor(stateInfo.backgroundColor);
+        statusBarItem.render({
+          text: `${name}: ${stateInfo.label}`,
+          tooltip: `'${item.workspaceFolder.name}' Jest: ${tooltip}`,
+          backgroundColor: this.toThemeColor(stateInfo.backgroundColor),
+        });
         break;
       }
       case StatusType.summary:
-        statusBarItem.actual.text = `Jest-WS: ${stateInfo.label}`;
-        statusBarItem.actual.tooltip = `Workspace(s) stats: ${tooltip}`;
-        statusBarItem.actual.backgroundColor = this.toThemeColor(stateInfo.backgroundColor);
+        statusBarItem.render({
+          text: `Jest-WS: ${stateInfo.label}`,
+          tooltip: `Workspace(s) stats: ${tooltip}`,
+          backgroundColor: this.toThemeColor(stateInfo.backgroundColor),
+        });
         break;
     }
-    statusBarItem.actual.show();
+    statusBarItem.show();
   }
 
   private updateSummaryOutput() {
@@ -374,11 +380,11 @@ export class StatusBar {
     const item = this.cache.getItemByFolderName(folder.name);
     if (item) {
       this.cache.deleteItemByFolder(folder);
-      item.actual.dispose();
+      item.dispose();
     }
   }
   public dispose() {
-    this.cache.getAllItems().forEach((item) => item.actual.dispose());
+    this.cache.getAllItems().forEach((item) => item.dispose());
   }
 }
 

--- a/src/TestResults/match-by-context.ts
+++ b/src/TestResults/match-by-context.ts
@@ -40,7 +40,7 @@ export const buildAssertionContainer = (
     assertions.forEach((a) => {
       const container = root.findContainer(
         a.ancestorTitles,
-        (name: string) => new ContainerNode(name, { isGroup: 'maybe' })
+        (name: string) => new ContainerNode(name, undefined, { isGroup: 'maybe' })
       );
       // regardless the document: https://jestjs.io/docs/26.x/cli#--testlocationinresults
       // the location are actually zero-based, but the "line" attribute is 1-based.
@@ -81,7 +81,7 @@ export const buildSourceContainer = (sourceRoot: ParsedNode): ContainerNode<ItBl
       },
     });
     if (isDescribeBlock(node)) {
-      container = new ContainerNode(node.name, attrs(node));
+      container = new ContainerNode(node.name, node.start?.line - 1, attrs(node));
       parent.addContainerNode(container);
     } else if (isItBlock(node)) {
       parent.addDataNode(new DataNode(node.name, node.start.line - 1, node, attrs(node)));

--- a/src/TestResults/match-node.ts
+++ b/src/TestResults/match-node.ts
@@ -253,8 +253,8 @@ export class ContainerNode<T> extends BaseNode {
   public childContainers: ContainerNode<T>[] = [];
   public childData: DataNode<T>[] = [];
 
-  constructor(name: string, attrs?: OptionalAttributes) {
-    super(name, -1, attrs);
+  constructor(name: string, zeroBasedLine = -1, attrs?: OptionalAttributes) {
+    super(name, zeroBasedLine, attrs);
   }
 
   public addContainerNode(container: ContainerNode<T>): void {

--- a/src/extension-manager.ts
+++ b/src/extension-manager.ts
@@ -254,9 +254,9 @@ export class ExtensionManager {
     }
   }
 
-  async onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): Promise<void> {
+  onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): void {
     if (!vscode.workspace.workspaceFolders) {
-      return Promise.resolve();
+      return;
     }
     let shouldApplySettings = true;
     for (const [idx, workspaceFolder] of vscode.workspace.workspaceFolders.entries()) {

--- a/src/extension-manager.ts
+++ b/src/extension-manager.ts
@@ -151,8 +151,7 @@ export class ExtensionManager {
   };
 
   public getByDocUri: GetJestExtByURI = (uri: vscode.Uri): JestExt[] => {
-    const workspace = vscode.workspace.getWorkspaceFolder(uri);
-    return (workspace && this.extCache.getItemsByActualFolderName(workspace.name)) ?? [];
+    return this.extCache.findRelatedItems(uri) ?? [];
   };
   private getExtensionsByFolder(folder: vscode.WorkspaceFolder): JestExt[] {
     const ext = this.extCache.getItemByFolderName(folder.name);
@@ -235,11 +234,13 @@ export class ExtensionManager {
         return vscode.commands.registerTextEditorCommand(
           commandName,
           async (editor: vscode.TextEditor, _edit, ...args: unknown[]) => {
-            const workspace = vscode.workspace.getWorkspaceFolder(editor.document.uri);
-            if (!workspace) {
+            const extensions = this.extCache.findRelatedItems(editor.document.uri);
+            if (!extensions || extensions.length === 0) {
+              vscode.window.showWarningMessage(
+                `No Jest extension activated for this file. Please check your vscode settings.`
+              );
               return;
             }
-            const extensions = this.getExtensionsByFolder(workspace);
             let targeteExt;
             if (extensions.length > 1) {
               targeteExt = await this.selectExtensions(extensions);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,5 +33,5 @@ export function activate(context: vscode.ExtensionContext): void {
   extensionManager.activate();
 }
 export function deactivate(): void {
-  extensionManager.unregisterAllWorkspaces();
+  extensionManager.deleteAllExtensions();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { statusBar } from './StatusBar';
-import { ExtensionManager } from './extensionManager';
+import { ExtensionManager } from './extension-manager';
 import { tiContextManager } from './test-provider/test-item-context-manager';
 import * as languageProvider from './language-provider';
 

--- a/src/extensionManager.ts
+++ b/src/extensionManager.ts
@@ -14,8 +14,9 @@ import {
 } from './setup-wizard';
 import { ItemCommand } from './test-provider/types';
 import { enabledWorkspaceFolders } from './workspace-manager';
+import { VirtualFolderBasedCache } from './virtual-workspace-folder';
 
-export type GetJestExtByURI = (uri: vscode.Uri) => JestExt | undefined;
+export type GetJestExtByURI = (uri: vscode.Uri) => JestExt[];
 
 export function addFolderToDisabledWorkspaceFolders(folder: string): void {
   const config = vscode.workspace.getConfiguration('jest');
@@ -58,17 +59,21 @@ const CommandPrefix: Record<CommandType, string> = {
   'active-text-editor-workspace': `${extensionName}.editor.workspace`,
 };
 export type StartWizardFunc = (options?: StartWizardOptions) => ReturnType<typeof startWizard>;
+
 export class ExtensionManager {
   debugConfigurationProvider: DebugConfigurationProvider;
   coverageCodeLensProvider: CoverageCodeLensProvider;
   startWizard: StartWizardFunc;
 
-  private extByWorkspace: Map<string, JestExt> = new Map();
+  private extCache: VirtualFolderBasedCache<JestExt>;
+  private enabledFolders: vscode.WorkspaceFolder[] = [];
+
   private context: vscode.ExtensionContext;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
 
+    this.extCache = new VirtualFolderBasedCache<JestExt>();
     this.debugConfigurationProvider = new DebugConfigurationProvider();
     this.coverageCodeLensProvider = new CoverageCodeLensProvider(this.getByDocUri);
     this.startWizard = (options?: StartWizardOptions) =>
@@ -91,18 +96,27 @@ export class ExtensionManager {
       this.startWizard({ taskId: setupTask });
       return;
     }
-    const enabled = enabledWorkspaceFolders();
-    vscode.workspace.workspaceFolders?.forEach((ws) => {
-      if (enabled.includes(ws)) {
-        this.registerWorkspace(ws);
-      } else {
-        this.unregisterWorkspace(ws);
+    this.enabledFolders = enabledWorkspaceFolders();
+
+    // update context setting
+    vscode.commands.executeCommand('setContext', 'jest.folderCount', this.enabledFolders.length);
+
+    const enabledNames = this.enabledFolders.map((w) => w.name);
+
+    // unregister the not enabled workspaces
+    this.extCache.getAllItems().forEach((ext) => {
+      if (!enabledNames.includes(ext.name)) {
+        this.deleteExtension(ext);
       }
     });
+    this.enabledFolders.forEach((folder) => this.addExtension(folder));
   }
-  registerWorkspace(workspaceFolder: vscode.WorkspaceFolder): void {
-    const enabled = enabledWorkspaceFolders();
-    if (!enabled.includes(workspaceFolder) || this.extByWorkspace.has(workspaceFolder.name)) {
+  addExtension(workspaceFolder: vscode.WorkspaceFolder): void {
+    // abort if extension already exists or not enabled
+    if (
+      this.extCache.getItemByFolderName(workspaceFolder.name) ||
+      !this.enabledFolders.find((f) => f.name === workspaceFolder.name)
+    ) {
       return;
     }
 
@@ -112,56 +126,69 @@ export class ExtensionManager {
       this.debugConfigurationProvider,
       this.coverageCodeLensProvider
     );
-    this.extByWorkspace.set(workspaceFolder.name, jestExt);
+    this.extCache.addItem(jestExt);
     jestExt.startSession();
   }
 
-  unregisterWorkspace(workspaceFolder: vscode.WorkspaceFolder): void {
-    this.unregisterWorkspaceByName(workspaceFolder.name);
+  deleteExtensionByFolder(workspaceFolder: vscode.WorkspaceFolder): void {
+    this.deleteExtension(this.extCache.getItemByFolderName(workspaceFolder.name));
   }
-  unregisterWorkspaceByName(name: string): void {
-    const extension = this.extByWorkspace.get(name);
+  deleteExtension(extension?: JestExt): void {
     if (extension) {
       extension.deactivate();
-      this.extByWorkspace.delete(name);
+      this.extCache.deleteItemByFolder(extension.workspaceFolder);
     }
   }
-  unregisterAllWorkspaces(): void {
-    const keys = this.extByWorkspace.keys();
-    for (const key of keys) {
-      this.unregisterWorkspaceByName(key);
+  deleteAllExtensions(): void {
+    const extensions = this.extCache.getAllItems();
+    for (const ext of extensions) {
+      this.deleteExtension(ext);
     }
   }
 
   public getByName = (workspaceFolderName: string): JestExt | undefined => {
-    return this.extByWorkspace.get(workspaceFolderName);
-  };
-  public getByDocUri: GetJestExtByURI = (uri: vscode.Uri) => {
-    const workspace = vscode.workspace.getWorkspaceFolder(uri);
-    if (workspace) {
-      return this.getByName(workspace.name);
-    }
+    return this.extCache.getItemByFolderName(workspaceFolderName);
   };
 
-  private async showWorkspaceFolderPick(): Promise<vscode.WorkspaceFolder | undefined> {
-    const folders = enabledWorkspaceFolders();
-    if (folders.length <= 0) {
+  public getByDocUri: GetJestExtByURI = (uri: vscode.Uri): JestExt[] => {
+    const workspace = vscode.workspace.getWorkspaceFolder(uri);
+    return (workspace && this.extCache.getItemsByActualFolderName(workspace.name)) ?? [];
+  };
+  private getExtensionsByFolder(folder: vscode.WorkspaceFolder): JestExt[] {
+    const ext = this.extCache.getItemByFolderName(folder.name);
+    if (ext) {
+      return [ext];
+    }
+    return this.extCache.getItemsByActualFolderName(folder.name) ?? [];
+  }
+
+  async selectExtension(fromExtensions?: JestExt[]): Promise<JestExt | undefined> {
+    const selections = await this.selectExtensions(fromExtensions, false);
+    if (selections && selections.length === 1) {
+      return selections[0];
+    }
+  }
+  async selectExtensions(
+    fromExtensions?: JestExt[],
+    canPickMany = true
+  ): Promise<JestExt[] | undefined> {
+    const extensions = fromExtensions ?? this.extCache.getAllItems();
+    if (extensions.length <= 0) {
       return Promise.resolve(undefined);
     }
-    if (folders.length === 1) {
-      return Promise.resolve(folders[0]);
+    if (extensions.length === 1) {
+      return Promise.resolve(extensions);
     }
-    const folderName = await vscode.window.showQuickPick(folders.map((f) => f.name));
-    return folders.find((f) => f.name === folderName);
-  }
-  async selectExtension(): Promise<JestExt | undefined> {
-    const workspace = await this.showWorkspaceFolderPick();
-    const instance = workspace && this.getByName(workspace.name);
-    if (instance) {
-      return instance;
-    } else if (workspace) {
-      throw new Error(`No Jest instance in ${workspace.name} workspace`);
+    const pick: string | string[] | undefined = await vscode.window.showQuickPick(
+      extensions.map((f) => f.name),
+      { canPickMany }
+    );
+    if (!pick) {
+      return undefined;
     }
+    return extensions.filter((ext) =>
+      typeof pick === 'string' ? ext.name === pick : (pick as string[]).includes(ext.name)
+    );
   }
 
   /**
@@ -175,29 +202,30 @@ export class ExtensionManager {
     switch (command.type) {
       case 'all-workspaces': {
         return vscode.commands.registerCommand(commandName, async (...args) => {
-          enabledWorkspaceFolders().forEach((ws) => {
-            const extension = this.getByName(ws.name);
-            if (extension) {
-              command.callback.call(thisArg, extension, ...args);
-            }
-          });
+          this.extCache
+            .getAllItems()
+            .forEach((extension) => command.callback.call(thisArg, extension, ...args));
         });
       }
       case 'select-workspace': {
         return vscode.commands.registerCommand(commandName, async (...args) => {
-          const extension = await this.selectExtension();
-          if (extension) {
-            command.callback.call(thisArg, extension, ...args);
-          }
+          const extensions = await this.selectExtensions();
+          extensions?.forEach((ext) => command.callback.call(thisArg, ext, ...args));
         });
       }
       case 'workspace': {
         return vscode.commands.registerCommand(
           commandName,
           async (workspace: vscode.WorkspaceFolder, ...args) => {
-            const extension = this.getByName(workspace.name);
-            if (extension) {
-              command.callback.call(thisArg, extension, ...args);
+            const extensions = this.getExtensionsByFolder(workspace);
+            let ext;
+            if (extensions.length > 1) {
+              ext = await this.selectExtension(extensions);
+            } else if (extensions.length === 1) {
+              ext = extensions[0];
+            }
+            if (ext) {
+              command.callback.call(thisArg, ext, ...args);
             }
           }
         );
@@ -206,94 +234,98 @@ export class ExtensionManager {
       case 'active-text-editor-workspace': {
         return vscode.commands.registerTextEditorCommand(
           commandName,
-          (editor: vscode.TextEditor, _edit, ...args: unknown[]) => {
+          async (editor: vscode.TextEditor, _edit, ...args: unknown[]) => {
             const workspace = vscode.workspace.getWorkspaceFolder(editor.document.uri);
             if (!workspace) {
               return;
             }
-            const extension = this.getByName(workspace.name);
-            if (extension) {
-              command.callback.call(thisArg, extension, editor, ...args);
+            const extensions = this.getExtensionsByFolder(workspace);
+            let targeteExt;
+            if (extensions.length > 1) {
+              targeteExt = await this.selectExtensions(extensions);
+            } else if (extensions.length === 1) {
+              targeteExt = extensions;
             }
+            targeteExt?.forEach((ext) => command.callback.call(thisArg, ext, editor, ...args));
           }
         );
       }
     }
   }
 
-  onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): void {
-    let applied = false;
-    vscode.workspace.workspaceFolders?.forEach((workspaceFolder, idx) => {
-      if (e.affectsConfiguration('jest', workspaceFolder.uri)) {
-        if (!applied && (idx === 0 || e.affectsConfiguration('jest.enable', workspaceFolder.uri))) {
+  async onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): Promise<void> {
+    if (!vscode.workspace.workspaceFolders) {
+      return Promise.resolve();
+    }
+    let shouldApplySettings = true;
+    for (const [idx, workspaceFolder] of vscode.workspace.workspaceFolders.entries()) {
+      if (e.affectsConfiguration('jest', workspaceFolder)) {
+        if (idx === 0 || shouldApplySettings) {
           this.applySettings();
-          applied = true;
+          shouldApplySettings = false;
         }
 
-        this.getByName(workspaceFolder.name)?.triggerUpdateSettings();
+        this.getExtensionsByFolder(workspaceFolder).forEach((ext) => ext.triggerUpdateSettings());
       }
-    });
+    }
   }
-  onDidChangeWorkspaceFolders(e: vscode.WorkspaceFoldersChangeEvent): void {
+  onDidChangeWorkspaceFolders(): void {
     if (this.context.workspaceState.get<boolean>(IgnoreWorkspaceChanges)) {
       return;
     }
+    this.applySettings();
+  }
 
-    e.added.forEach(this.registerWorkspace, this);
-    e.removed.forEach(this.unregisterWorkspace, this);
+  private onExtensionByUri(
+    uri: vscode.Uri | readonly vscode.Uri[],
+    handler: (ext: JestExt) => unknown
+  ): void {
+    const uriList = Array.isArray(uri) ? uri : [uri];
+    const extension = uriList.flatMap((uri) => this.getByDocUri(uri));
+    // dedup
+    const set = new Set(extension);
+    set.forEach(handler);
   }
   onDidCloseTextDocument(document: vscode.TextDocument): void {
-    const ext = this.getByDocUri(document.uri);
-    if (ext) {
-      ext.onDidCloseTextDocument(document);
-    }
+    this.onExtensionByUri(document.uri, (ext) => ext.onDidCloseTextDocument(document));
   }
   onDidChangeActiveTextEditor(editor?: vscode.TextEditor): void {
     if (editor && editor.document) {
       statusBar.onDidChangeActiveTextEditor(editor);
-      const ext = this.getByDocUri(editor.document.uri);
-      if (ext) {
+      this.onExtensionByUri(editor?.document?.uri, (ext) => {
         ext.onDidChangeActiveTextEditor(editor);
-      }
+      });
     }
   }
   onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
-    const ext = this.getByDocUri(event.document.uri);
-    if (ext) {
+    this.onExtensionByUri(event.document.uri, (ext) => {
       ext.onDidChangeTextDocument(event);
-    }
+    });
   }
 
   onWillSaveTextDocument(event: vscode.TextDocumentWillSaveEvent): void {
-    const ext = this.getByDocUri(event.document.uri);
-    if (ext) {
+    this.onExtensionByUri(event.document.uri, (ext) => {
       ext.onWillSaveTextDocument(event);
-    }
+    });
   }
   onDidSaveTextDocument(document: vscode.TextDocument): void {
-    const ext = this.getByDocUri(document.uri);
-    if (ext) {
+    this.onExtensionByUri(document.uri, (ext) => {
       ext.onDidSaveTextDocument(document);
-    }
-  }
-  private onFilesChange(files: readonly vscode.Uri[], handler: (ext: JestExt) => void) {
-    const exts = files.map((f) => this.getByDocUri(f)).filter((ext) => ext != null) as JestExt[];
-    const set = new Set<JestExt>(exts);
-    set.forEach(handler);
+    });
   }
 
   onDidCreateFiles(event: vscode.FileCreateEvent): void {
-    this.onFilesChange(event.files, (ext) => ext.onDidCreateFiles(event));
+    this.onExtensionByUri(event.files, (ext) => ext.onDidCreateFiles(event));
   }
   onDidDeleteFiles(event: vscode.FileDeleteEvent): void {
-    this.onFilesChange(event.files, (ext) => ext.onDidDeleteFiles(event));
+    this.onExtensionByUri(event.files, (ext) => ext.onDidDeleteFiles(event));
   }
   onDidRenameFiles(event: vscode.FileRenameEvent): void {
     const files = event.files.reduce((list, f) => {
       list.push(f.newUri, f.oldUri);
       return list;
     }, [] as vscode.Uri[]);
-    this.onFilesChange(files, (ext) => ext.onDidRenameFiles(event));
+    this.onExtensionByUri(files, (ext) => ext.onDidRenameFiles(event));
   }
 
   public register(): vscode.Disposable[] {
@@ -441,8 +473,11 @@ export class ExtensionManager {
 
   activate(): void {
     this.showReleaseMessage();
+
     if (vscode.window.activeTextEditor?.document.uri) {
-      this.getByDocUri(vscode.window.activeTextEditor.document.uri)?.activate();
+      this.onExtensionByUri(vscode.window.activeTextEditor?.document.uri, (ext) => {
+        ext.activate();
+      });
     }
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -311,6 +311,13 @@ export const parseCmdLine = (cmdLine: string): string[] => {
   return parts;
 };
 
+/**
+ * Converts a relative or absolute root path to an absolute root path based on the provided workspace folder.
+ * If no root path is provided, returns the absolute path of the workspace folder.
+ * @param workspace The workspace folder to use as a base for the absolute root path.
+ * @param rootPath The relative or absolute root path to convert to an absolute root path.
+ * @returns The absolute root path.
+ */
 export const toAbsoluteRootPath = (
   workspace: vscode.WorkspaceFolder,
   rootPath?: string
@@ -318,7 +325,7 @@ export const toAbsoluteRootPath = (
   if (!rootPath) {
     return workspace.uri.fsPath;
   }
-  return isAbsolute(rootPath) ? rootPath : resolve(workspace.uri.fsPath, rootPath);
+  return isAbsolute(rootPath) ? normalize(rootPath) : resolve(workspace.uri.fsPath, rootPath);
 };
 
 export interface JestCommandSettings {

--- a/src/setup-wizard/types.ts
+++ b/src/setup-wizard/types.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { DebugConfigurationProvider } from '../DebugConfigurationProvider';
 import { JestExtOutput } from '../JestExt/output-terminal';
-import { JestExtAutoRunSetting } from '../Settings';
 import { WorkspaceManager } from '../workspace-manager';
 
 export interface WizardContext {
@@ -58,15 +57,12 @@ export interface ActionInputBoxOptions<T> extends AllowBackButton, Verbose {
 export type SetupTask = (context: WizardContext) => Promise<WizardStatus>;
 
 // settings
-export const JestSettings = ['jestCommandLine', 'rootPath'];
-type JestSettingKey = (typeof JestSettings)[number];
-
-// prettier-ignore
-export type WizardSettings = 
-  { [key in JestSettingKey]?: string } & 
-  { ['autoRun']?: JestExtAutoRunSetting} &
-  { ['configurations']?: vscode.DebugConfiguration[] } & 
-  { ['absoluteRootPath']?: string };
+export interface WizardSettings {
+  jestCommandLine?: string;
+  rootPath?: string;
+  absoluteRootPath?: string;
+  configurations?: vscode.DebugConfiguration[];
+}
 
 export interface ConfigEntry {
   name: string;

--- a/src/setup-wizard/wizard-helper.ts
+++ b/src/setup-wizard/wizard-helper.ts
@@ -67,6 +67,7 @@ const handleButtonClick = <T>(button: vscode.QuickInputButton): ActionableButton
   if (isActionableButton(button)) {
     return button as ActionableButton<T>;
   }
+  /* istanbul ignore next */
   throw new Error(`expect actionableButton but got ${JSON.stringify(button)}`);
 };
 
@@ -290,9 +291,6 @@ export const validateRootPath = (workspace: vscode.WorkspaceFolder, rootPath: st
   const _rootPath = removeSurroundingQuote(rootPath);
   return existsSync(toAbsoluteRootPath(workspace, _rootPath));
 };
-
-export const actualWorkspaceFolder = (folder: vscode.WorkspaceFolder): vscode.WorkspaceFolder =>
-  isVirtualWorkspaceFolder(folder) ? folder.actualWorkspaceFolder : folder;
 
 export const toVirtualFolderSettings = (
   vFolder: VirtualWorkspaceFolder,

--- a/src/test-provider/test-item-context-manager.ts
+++ b/src/test-provider/test-item-context-manager.ts
@@ -20,12 +20,7 @@ export type ItemContext =
       itemIds: string[];
     }
   | {
-      key: 'jest.editor-view-snapshot' | 'jest.editor-update-snapshot';
-      workspace: vscode.WorkspaceFolder;
-      itemIds: string[];
-    }
-  | {
-      key: 'jest.workspaceRoot';
+      key: 'jest.editor-view-snapshot' | 'jest.editor-update-snapshot' | 'jest.workspaceRoot';
       workspace: vscode.WorkspaceFolder;
       itemIds: string[];
     };
@@ -33,32 +28,22 @@ export type TEItemContextKey = ItemContext['key'];
 
 export class TestItemContextManager {
   private cache = new Map<TEItemContextKey, ItemContext[]>();
+  private wsCache: Record<string, vscode.WorkspaceFolder> = {};
 
   private contextKey(key: TEItemContextKey, value: boolean): string {
     return `${key}.${value ? 'on' : 'off'}`;
   }
+  // context are stored by key, one per workspace
   private updateContextCache(context: ItemContext): ItemContext[] {
-    switch (context.key) {
-      case 'jest.autoRun':
-      case 'jest.coverage':
-      case 'jest.workspaceRoot': {
-        let list = this.cache.get(context.key);
-        if (!list) {
-          list = [context];
-        } else {
-          // itemIds are not accumulated, but toggled
-          list = list.filter((c) => c.workspace.name !== context.workspace.name).concat(context);
-        }
-        this.cache.set(context.key, list);
-        return list;
-      }
-      case 'jest.editor-view-snapshot':
-      case 'jest.editor-update-snapshot': {
-        const list = [context];
-        this.cache.set(context.key, list);
-        return list;
-      }
+    this.wsCache[context.workspace.name] = context.workspace;
+    let list = this.cache.get(context.key);
+    if (!list) {
+      list = [context];
+    } else {
+      list = list.filter((c) => c.workspace.name !== context.workspace.name).concat(context);
     }
+    this.cache.set(context.key, list);
+    return list;
   }
   public setItemContext(context: ItemContext): void {
     const list = this.updateContextCache(context);
@@ -78,33 +63,27 @@ export class TestItemContextManager {
         break;
       }
       case 'jest.editor-view-snapshot':
-      case 'jest.editor-update-snapshot': {
-        vscode.commands.executeCommand('setContext', context.key, context.itemIds);
-        break;
-      }
+      case 'jest.editor-update-snapshot':
       case 'jest.workspaceRoot': {
         const itemIds = list.flatMap((c) => c.itemIds);
         vscode.commands.executeCommand('setContext', context.key, itemIds);
       }
     }
   }
-  private getItemWorkspace(
-    key: TEItemContextKey,
-    item: vscode.TestItem
-  ): vscode.WorkspaceFolder | undefined {
-    const workspace = item.uri && vscode.workspace.getWorkspaceFolder(item.uri);
-    if (workspace) {
-      return workspace;
+  private getItemWorkspace(item: vscode.TestItem): vscode.WorkspaceFolder | undefined {
+    let target = item;
+    while (target.parent) {
+      target = target.parent;
     }
-    const list = this.cache.get(key);
-    const c = list?.find((c) => c.itemIds.includes(item.id));
-    return c?.workspace;
+    const workspace = this.wsCache[target.id.split(':')[1]];
+    return workspace ?? (item.uri && vscode.workspace.getWorkspaceFolder(item.uri));
   }
+
   public registerCommands(): vscode.Disposable[] {
     const revealOutputCommand = vscode.commands.registerCommand(
       `${extensionName}.test-item.reveal-output`,
       (testItem: vscode.TestItem) => {
-        const workspace = this.getItemWorkspace('jest.workspaceRoot', testItem);
+        const workspace = this.getItemWorkspace(testItem);
         if (workspace) {
           vscode.commands.executeCommand(
             `${extensionName}.with-workspace.item-command`,
@@ -118,7 +97,7 @@ export class TestItemContextManager {
     const autoRunCommands = ['test-item.auto-run.toggle-off', 'test-item.auto-run.toggle-on'].map(
       (n) =>
         vscode.commands.registerCommand(`${extensionName}.${n}`, (testItem: vscode.TestItem) => {
-          const workspace = this.getItemWorkspace('jest.autoRun', testItem);
+          const workspace = this.getItemWorkspace(testItem);
           if (workspace) {
             vscode.commands.executeCommand(
               `${extensionName}.with-workspace.toggle-auto-run`,
@@ -130,7 +109,7 @@ export class TestItemContextManager {
     const coverageCommands = ['test-item.coverage.toggle-off', 'test-item.coverage.toggle-on'].map(
       (n) =>
         vscode.commands.registerCommand(`${extensionName}.${n}`, (testItem: vscode.TestItem) => {
-          const workspace = this.getItemWorkspace('jest.coverage', testItem);
+          const workspace = this.getItemWorkspace(testItem);
           if (workspace) {
             vscode.commands.executeCommand(
               `${extensionName}.with-workspace.toggle-coverage`,
@@ -142,7 +121,7 @@ export class TestItemContextManager {
     const viewSnapshotCommand = vscode.commands.registerCommand(
       `${extensionName}.test-item.view-snapshot`,
       (testItem: vscode.TestItem) => {
-        const workspace = this.getItemWorkspace('jest.editor-view-snapshot', testItem);
+        const workspace = this.getItemWorkspace(testItem);
         if (workspace) {
           vscode.commands.executeCommand(
             `${extensionName}.with-workspace.item-command`,
@@ -156,7 +135,7 @@ export class TestItemContextManager {
     const updateSnapshotCommand = vscode.commands.registerCommand(
       `${extensionName}.test-item.update-snapshot`,
       (testItem: vscode.TestItem) => {
-        const workspace = this.getItemWorkspace('jest.editor-update-snapshot', testItem);
+        const workspace = this.getItemWorkspace(testItem);
         if (workspace) {
           vscode.commands.executeCommand(
             `${extensionName}.with-workspace.item-command`,

--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -14,6 +14,7 @@ import { JestProcessInfo, JestProcessRequest } from '../JestProcessManagement';
 import { GENERIC_ERROR, getExitErrorDef, LONG_RUNNING_TESTS } from '../errors';
 import { JestExtOutput } from '../JestExt/output-terminal';
 import { tiContextManager } from './test-item-context-manager';
+import { toAbsoluteRootPath } from '../helpers';
 
 interface JestRunable {
   getJestRunRequest: () => JestExtRequestType;
@@ -198,7 +199,11 @@ export class WorkspaceRoot extends TestItemDataBase {
     );
   };
   private addPath = (absoluteFileName: string): FolderData | undefined => {
-    const relativePath = path.relative(this.context.ext.workspace.uri.fsPath, absoluteFileName);
+    const absoluteRoot = toAbsoluteRootPath(
+      this.context.ext.workspace,
+      this.context.ext.settings.rootPath
+    );
+    const relativePath = path.relative(absoluteRoot, absoluteFileName);
     const folders = relativePath.split(path.sep).slice(0, -1);
 
     return folders.reduce(this.addFolder, undefined);

--- a/src/virtual-workspace-folder.ts
+++ b/src/virtual-workspace-folder.ts
@@ -1,0 +1,104 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export interface FolderAwareItem {
+  workspaceFolder: vscode.WorkspaceFolder;
+}
+
+export class VirtualFolderBasedCache<T extends FolderAwareItem> {
+  // cache folder by its name, which could be either the actual or virtual workspace folder name
+  private byFolderName: Record<string, T>;
+  // group folder list by its actual folder name
+  private byActualFolderName: Record<string, T[]>;
+
+  constructor() {
+    this.byFolderName = {};
+    this.byActualFolderName = {};
+  }
+
+  get size(): number {
+    return Object.keys(this.byFolderName).length;
+  }
+
+  /** get all cached items */
+  getAllItems(): T[] {
+    return Object.values(this.byFolderName);
+  }
+  addItem(item: T) {
+    this.byFolderName[item.workspaceFolder.name] = item;
+    const actualFolderName = isVirtualWorkspaceFolder(item.workspaceFolder)
+      ? item.workspaceFolder.actualWorkspaceFolder.name
+      : item.workspaceFolder.name;
+    let items = this.byActualFolderName[actualFolderName] ?? [];
+
+    // in case the item is already in the list, remove it first
+    items = items.filter((i) => i.workspaceFolder.name !== item.workspaceFolder.name);
+
+    items.push(item);
+    this.byActualFolderName[actualFolderName] = items;
+  }
+  deleteItemByFolder(workspaceFolder: vscode.WorkspaceFolder) {
+    delete this.byFolderName[workspaceFolder.name];
+
+    if (isVirtualWorkspaceFolder(workspaceFolder)) {
+      // delete the virtual folder from the actual folder
+      let items = this.byActualFolderName[workspaceFolder.actualWorkspaceFolder.name];
+      items = items.filter((i) => i.workspaceFolder.name !== workspaceFolder.name);
+      this.byActualFolderName[workspaceFolder.actualWorkspaceFolder.name] = items;
+    } else {
+      // delete all the virtual folders under the actual folder
+      const items = this.byActualFolderName[workspaceFolder.name];
+      items.forEach((item) => delete this.byFolderName[item.workspaceFolder.name]);
+      delete this.byActualFolderName[workspaceFolder.name];
+    }
+  }
+  getItemByFolderName(name: string): T | undefined {
+    return this.byFolderName[name];
+  }
+  getItemsByActualFolderName(actualFolderName: string): T[] | undefined {
+    return this.byActualFolderName[actualFolderName];
+  }
+  reset() {
+    this.byFolderName = {};
+    this.byActualFolderName = {};
+  }
+}
+
+/**
+ * a virtual workspace folder is a folder resides in a physical workspace folder but might have
+ * different name and separate jest settings. A physical workspace folder can have multiple virtual folders.
+
+ * Note: The class will have the same index as the actual workspace folder, but different name and uri (if it has set a different rootPath).
+ */
+export class VirtualWorkspaceFolder implements vscode.WorkspaceFolder {
+  public readonly uri: vscode.Uri;
+  constructor(
+    public readonly actualWorkspaceFolder: vscode.WorkspaceFolder,
+    public readonly name: string,
+    rootPath?: string
+  ) {
+    if (rootPath) {
+      this.uri = path.isAbsolute(rootPath)
+        ? vscode.Uri.file(rootPath)
+        : vscode.Uri.joinPath(actualWorkspaceFolder.uri, rootPath);
+    } else {
+      this.uri = actualWorkspaceFolder.uri;
+    }
+  }
+
+  get index(): number {
+    return this.actualWorkspaceFolder.index;
+  }
+
+  /** check if the given uri falls within the virtual folder's path */
+  isInWorkspace(uri: vscode.Uri): boolean {
+    return uri.fsPath.startsWith(this.uri.fsPath);
+  }
+}
+
+export const isVirtualWorkspaceFolder = (
+  workspaceFolder: vscode.WorkspaceFolder
+): workspaceFolder is VirtualWorkspaceFolder => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (workspaceFolder as any).actualWorkspaceFolder != undefined;
+};

--- a/src/workspace-manager.ts
+++ b/src/workspace-manager.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { getPackageJson } from './helpers';
+import { VirtualWorkspaceFolder, isVirtualWorkspaceFolder } from './virtual-workspace-folder';
+import { VirtualFolderSettings } from './Settings';
 
 const ActivationFilePattern = [
   '**/jest.config.{js, ts, mjs, cjs, json}',
@@ -13,8 +15,8 @@ const ActivationBinary = [
   'node_modules/react-native-scripts',
 ];
 
-export interface WorkspaceInfo {
-  workspace: vscode.WorkspaceFolder;
+export interface WorkspaceFolderInfo {
+  folder: vscode.WorkspaceFolder;
   rootPath?: string;
   activation?: vscode.Uri;
 }
@@ -26,54 +28,112 @@ interface ValidatePatternType {
   binary: string[];
 }
 
-export const enabledWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
+/**
+ * return all workspace folders, including virtual ones within the given workspace folder.
+ * If no virtual workspace folder is found, return the given workspace folder in an array;
+ * otherwise return an array of virtual workspace folders.
+ * @param workspaceFolder
+ * @returns
+ */
+const expandWithVirtualFolders = (
+  workspaceFolder: vscode.WorkspaceFolder,
+  enableFilter?: EnableFolderFilter
+): vscode.WorkspaceFolder[] => {
+  // check if there is venv
+  const config = vscode.workspace.getConfiguration('jest', workspaceFolder);
+  const vFolders = config.get<VirtualFolderSettings[]>('virtualFolders');
+  if (!vFolders || vFolders.length <= 0) {
+    return [workspaceFolder];
+  }
+
+  const isEnabled = enableFilter ?? createEnableFilter();
+
+  return vFolders
+    .map((folder) => new VirtualWorkspaceFolder(workspaceFolder, folder.name, folder.rootPath))
+    .filter(isEnabled);
+};
+
+type EnableFolderFilter = (folder: vscode.WorkspaceFolder) => boolean;
+/**
+ * Returns a function that filters out disabled workspace folders and virtual folders that are disabled in the Jest configuration.
+ * @returns A EnableFolderFilter filter function that takes a `vscode.WorkspaceFolder` object as an argument and returns a boolean value.
+ */
+const createEnableFilter = (): EnableFolderFilter => {
+  const windowConfig = vscode.workspace.getConfiguration('jest');
+  const disabledWorkspaceFolders = windowConfig.get<string[]>('disabledWorkspaceFolders') ?? [];
+
+  return (folder: vscode.WorkspaceFolder) => {
+    if (disabledWorkspaceFolders.includes(folder.name)) {
+      return false;
+    }
+    const actualFolder = isVirtualWorkspaceFolder(folder) ? folder.actualWorkspaceFolder : folder;
+    const config = vscode.workspace.getConfiguration('jest', actualFolder);
+    if (config.get<boolean>('enable') === false) {
+      return false;
+    }
+    if (isVirtualWorkspaceFolder(folder)) {
+      const vFolder = config
+        .get<VirtualFolderSettings[]>('virtualFolders')
+        ?.find((f) => f.name === folder.name);
+
+      if (!vFolder) {
+        throw new Error(
+          `Virtual folder "${folder.name}" not found in workspace folder "${folder.actualWorkspaceFolder.name}"`
+        );
+      }
+      return vFolder['enable'] ?? true;
+    }
+    return true;
+  };
+};
+export const enabledWorkspaceFolders = (includingVirtual = true): vscode.WorkspaceFolder[] => {
   if (!vscode.workspace.workspaceFolders) {
     return [];
   }
 
-  const windowConfig = vscode.workspace.getConfiguration('jest');
-  const disabledWorkspaceFolders = windowConfig.get<string[]>('disabledWorkspaceFolders') ?? [];
+  const enableFilter = createEnableFilter();
+  const enabled = vscode.workspace.workspaceFolders.filter(enableFilter);
 
-  return vscode.workspace.workspaceFolders.filter((ws) => {
-    if (disabledWorkspaceFolders.includes(ws.name)) {
-      return false;
-    }
-    const config = vscode.workspace.getConfiguration('jest', ws);
-    return config.get<boolean>('enable') ?? true;
-  });
+  return includingVirtual
+    ? enabled.flatMap((ws) => expandWithVirtualFolders(ws, enableFilter))
+    : enabled;
 };
 
 export const isSameWorkspace = (
   ws1: vscode.WorkspaceFolder,
   ws2: vscode.WorkspaceFolder
 ): boolean => ws1.uri.path === ws2.uri.path;
+
+/**
+ * A class to manage all workspace folders and their jest configurations.
+ */
 export class WorkspaceManager {
   /**
-   * validate each workspace folder for jest run eligibility.
+   * validate each workspace (physical) folder for jest run eligibility.
    * throw error if no workspace folder to validate.
    * @returns valid workspaceInfo array, [] if none is valid
    */
-  async getValidWorkspaces(): Promise<WorkspaceInfo[]> {
+  async getValidWorkspaceFolders(): Promise<WorkspaceFolderInfo[]> {
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 0) {
       return Promise.reject(new Error('no workspace folder to validate'));
     }
 
-    const validWorkspaces: Map<string, WorkspaceInfo> = new Map();
-    for (const ws of enabledWorkspaceFolders()) {
+    const validWorkspaces: Map<string, WorkspaceFolderInfo> = new Map();
+    for (const ws of enabledWorkspaceFolders(false)) {
       if (validWorkspaces.has(ws.uri.path)) {
         continue;
       }
-      const list = await this.validateWorkspace(ws);
+      const list = await this.validateWorkspaceFolder(ws);
       list.forEach((info) => {
-        if (!validWorkspaces.has(info.workspace.uri.path)) {
-          validWorkspaces.set(info.workspace.uri.path, info);
+        if (!validWorkspaces.has(info.folder.uri.path)) {
+          validWorkspaces.set(info.folder.uri.path, info);
         }
       });
     }
     return Array.from(validWorkspaces.values());
   }
 
-  private toWorkspaceInfo(uri: vscode.Uri): WorkspaceInfo | undefined {
+  private toWorkspaceFolderInfo(uri: vscode.Uri): WorkspaceFolderInfo | undefined {
     const workspace = vscode.workspace.getWorkspaceFolder(uri);
     if (!workspace) {
       return;
@@ -83,7 +143,7 @@ export class WorkspaceManager {
       rootPath = rootPath.replace(workspace.uri.fsPath, '.');
     }
     return {
-      workspace,
+      folder: workspace,
       activation: uri,
       rootPath: rootPath === '.' ? undefined : rootPath,
     };
@@ -112,10 +172,10 @@ export class WorkspaceManager {
   /** validate if given workspace is a valid jest workspace
    * @retrun WorkspaceInfo if jest root is different from project root; otherwise undefined.
    */
-  async validateWorkspace(
+  async validateWorkspaceFolder(
     workspace: vscode.WorkspaceFolder,
     types: WSValidationType[] = ['deep-config', 'binary', 'jest-in-package']
-  ): Promise<WorkspaceInfo[]> {
+  ): Promise<WorkspaceFolderInfo[]> {
     const validatePatterns = this.toValidatePatterns(types);
 
     // find activation files deeply outside of node_modules
@@ -130,10 +190,10 @@ export class WorkspaceManager {
     const results = await Promise.allSettled(activationFiles);
     const wsInfo = results
       .flatMap((result) => (result.status === 'fulfilled' ? result.value : []))
-      .map((uri) => this.toWorkspaceInfo(uri))
-      .filter((wsInfo) => wsInfo != null) as WorkspaceInfo[];
+      .map((uri) => this.toWorkspaceFolderInfo(uri))
+      .filter((wsInfo) => wsInfo != null) as WorkspaceFolderInfo[];
 
-    if (wsInfo.length > 0 && wsInfo.find((info) => isSameWorkspace(info.workspace, workspace))) {
+    if (wsInfo.length > 0 && wsInfo.find((info) => isSameWorkspace(info.folder, workspace))) {
       return wsInfo;
     }
 
@@ -145,7 +205,7 @@ export class WorkspaceManager {
         1
       );
       if (results.length > 0) {
-        return [...wsInfo, { workspace }];
+        return [...wsInfo, { folder: workspace }];
       }
     }
 
@@ -153,7 +213,7 @@ export class WorkspaceManager {
     if (types.includes('jest-in-package')) {
       const packageJson = getPackageJson(workspace.uri.fsPath);
       if (packageJson && packageJson.jest) {
-        return [...wsInfo, { workspace }];
+        return [...wsInfo, { folder: workspace }];
       }
     }
 

--- a/src/workspace-manager.ts
+++ b/src/workspace-manager.ts
@@ -99,6 +99,13 @@ export const enabledWorkspaceFolders = (includingVirtual = true): vscode.Workspa
     : enabled;
 };
 
+export const isInFolder = (uri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder): boolean => {
+  if (isVirtualWorkspaceFolder(workspaceFolder)) {
+    return workspaceFolder.isInWorkspaceFolder(uri);
+  }
+  return vscode.workspace.getWorkspaceFolder(uri)?.name === workspaceFolder.name;
+};
+
 export const isSameWorkspace = (
   ws1: vscode.WorkspaceFolder,
   ws2: vscode.WorkspaceFolder

--- a/tests/Coverage/CoverageCodeLensProvider.test.ts
+++ b/tests/Coverage/CoverageCodeLensProvider.test.ts
@@ -53,8 +53,9 @@ describe('CoverageCodeLensProvider', () => {
     mockJestExt = {
       coverageMapProvider: { getFileCoverage: jest.fn() },
       coverageOverlay: { enabled: true },
+      name: 'venv1',
     };
-    const mockGetExt = jest.fn().mockReturnValue(mockJestExt);
+    const mockGetExt = jest.fn().mockReturnValue([mockJestExt]);
     provider = new CoverageCodeLensProvider(mockGetExt);
   });
   describe('provideCodeLenses', () => {
@@ -78,7 +79,7 @@ describe('CoverageCodeLensProvider', () => {
       mockJestExt.coverageMapProvider.getFileCoverage = () => coverage;
       const result = provider.provideCodeLenses(doc);
       expect(result).toHaveLength(1);
-      expect(result[0].command.title).toEqual('branches: 10%, lines: 46.15%');
+      expect(result[0].command.title).toContain('branches: 10%, lines: 46.15%');
     });
     test('do nothing when coverage is disabled', () => {
       mockJestExt.coverageMapProvider.getFileCoverage = () => coverage;
@@ -98,6 +99,33 @@ describe('CoverageCodeLensProvider', () => {
 
       provider.coverageChanged();
       expect(fireMock).toHaveBeenCalled();
+    });
+    describe('venv', () => {
+      test('can provide separate summaries for each qualified venv', () => {
+        const mockJestExt2: any = {
+          coverageMapProvider: { getFileCoverage: jest.fn() },
+          coverageOverlay: { enabled: true },
+          name: 'venv2',
+        };
+        const coverage2 = {
+          toSummary: () => ({
+            toJSON: () => ({
+              branches: { pct: 90 },
+              lines: { pct: 97.85 },
+            }),
+          }),
+        };
+        const mockGetExt = jest.fn().mockReturnValue([mockJestExt, mockJestExt2]);
+        provider = new CoverageCodeLensProvider(mockGetExt);
+        mockJestExt.coverageMapProvider.getFileCoverage = () => coverage;
+        mockJestExt2.coverageMapProvider.getFileCoverage = () => coverage2;
+        const result = provider.provideCodeLenses(doc);
+        expect(result).toHaveLength(2);
+        expect(result[0].command.title).toContain('branches: 10%, lines: 46.15%');
+        expect(result[0].command.title).toContain('venv1');
+        expect(result[1].command.title).toContain('branches: 90%, lines: 97.85%');
+        expect(result[1].command.title).toContain('venv2');
+      });
     });
   });
 });

--- a/tests/DebugConfigurationProvider.test.ts
+++ b/tests/DebugConfigurationProvider.test.ts
@@ -17,13 +17,13 @@ describe('DebugConfigurationProvider', () => {
   const testName = 'a test';
 
   it('should by default return a DebugConfiguration for Jest', () => {
-    const folder: any = { uri: { fsPath: null } };
+    const folder: any = { name: 'folder', uri: { fsPath: null } };
     const sut = new DebugConfigurationProvider();
     const configurations = sut.provideDebugConfigurations(folder);
 
     expect(configurations).toHaveLength(1);
     const config = configurations[0];
-    expect(config.name).toBe('vscode-jest-tests.v2');
+    expect(config.name).toBe('vscode-jest-tests.v2.folder');
     expect(config.type).toBe('node');
     expect(config.program).toMatch('jest');
     expect(config.args).toEqual(
@@ -43,13 +43,13 @@ describe('DebugConfigurationProvider', () => {
     );
     (isCreateReactAppTestCommand as unknown as jest.Mock<{}>).mockReturnValueOnce(true);
 
-    const folder: any = { uri: { fsPath: null } };
+    const folder: any = { name: 'cra-app', uri: { fsPath: null } };
     const sut = new DebugConfigurationProvider();
     const configurations = sut.provideDebugConfigurations(folder);
 
     expect(configurations).toHaveLength(1);
     const config = configurations[0];
-    expect(config.name).toBe('vscode-jest-tests.v2');
+    expect(config.name).toBe('vscode-jest-tests.v2.cra-app');
     expect(config.type).toBe('node');
     // tslint:disable-next-line no-invalid-template-strings
     expect(config.runtimeExecutable).toBe('${workspaceFolder}/node_modules/.bin/react-scripts');
@@ -79,7 +79,8 @@ describe('DebugConfigurationProvider', () => {
       let configuration: any = { name: 'vscode-jest-tests', args: debugConfigArgs };
 
       const sut = new DebugConfigurationProvider();
-      sut.prepareTestRun(fileName, testName);
+      const ws = makeWorkspaceFolder('whatever');
+      sut.prepareTestRun(fileName, testName, ws);
 
       configuration = sut.resolveDebugConfiguration(undefined, configuration);
 
@@ -118,7 +119,8 @@ describe('DebugConfigurationProvider', () => {
       let configuration: any = { name: 'vscode-jest-tests.v2', args };
 
       const sut = new DebugConfigurationProvider();
-      sut.prepareTestRun(fileName, testName);
+      const ws = makeWorkspaceFolder('whatever');
+      sut.prepareTestRun(fileName, testName, ws);
 
       configuration = sut.resolveDebugConfiguration(undefined, configuration);
 

--- a/tests/DebugConfigurationProvider.test.ts
+++ b/tests/DebugConfigurationProvider.test.ts
@@ -7,6 +7,7 @@ import {
   toFilePath,
   escapeRegExp,
   parseCmdLine,
+  toAbsoluteRootPath,
 } from '../src/helpers';
 import * as os from 'os';
 import * as fs from 'fs';
@@ -171,6 +172,9 @@ describe('DebugConfigurationProvider', () => {
     beforeEach(() => {
       (parseCmdLine as jest.Mocked<any>).mockImplementation(
         jest.requireActual('../src/helpers').parseCmdLine
+      );
+      (toAbsoluteRootPath as jest.Mocked<any>).mockImplementation(
+        jest.requireActual('../src/helpers').toAbsoluteRootPath
       );
     });
 

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -42,7 +42,7 @@ import {
 } from '../test-helper';
 import { JestTestProvider } from '../../src/test-provider';
 import { MessageAction } from '../../src/messaging';
-import { addFolderToDisabledWorkspaceFolders } from '../../src/extensionManager';
+import { addFolderToDisabledWorkspaceFolders } from '../../src/extension-manager';
 import { JestOutputTerminal } from '../../src/JestExt/output-terminal';
 import { RunShell } from '../../src/JestExt/run-shell';
 import * as errors from '../../src/errors';

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -1102,12 +1102,16 @@ describe('JestExt', () => {
       expect(sut.testResultProvider.getTestSuiteStats).toHaveBeenCalled();
       expect(sbUpdateMock).toHaveBeenCalled();
     });
-    it('will update visible editors for the current workspace', () => {
+    it('will update visible editors for the current workspace and test file list', () => {
       (vscode.window.visibleTextEditors as any) = [
         mockEditor('a'),
         mockEditor('b'),
         mockEditor('c'),
       ];
+      (sut.testResultProvider.isTestFile as jest.Mocked<any>)
+        .mockReturnValueOnce('yes')
+        .mockReturnValueOnce('no')
+        .mockReturnValueOnce('maybe');
       (vscode.workspace.getWorkspaceFolder as jest.Mocked<any>).mockImplementation((uri) =>
         uri !== 'b' ? workspaceFolder : undefined
       );

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -227,20 +227,24 @@ describe('getExtensionResourceSettings()', () => {
         case | virtualFolders                                                                                    | expectedSettings
         ${1} | ${undefined}                                                                                      | ${'throw'}
         ${2} | ${[{ name: 'v1', debugMode: true }]}                                                              | ${{ debugMode: true }}
-        ${3} | ${[{ name: 'v1', jestCommandLine: 'yarn integ-test' }]}                                           | ${{ jestCommandLine: 'yarn integ-test' }}
+        ${3} | ${[{ name: 'v1', jestCommandLine: 'yarn integ-test', rootPath: 'whatever' }]}                     | ${{ jestCommandLine: 'yarn integ-test' }}
         ${4} | ${[{ name: 'v2', jestCommandLine: 'yarn integ-test' }]}                                           | ${'throw'}
         ${5} | ${[{ name: 'v1', jestCommandLine: 'yarn test1' }, { name: 'v2', jestCommandLine: 'yarn test2' }]} | ${{ jestCommandLine: 'yarn test1' }}
-      `('case $case: can load virtualFolder settings', ({ virtualFolders, expectedSettings }) => {
-        const folder = makeWorkspaceFolder('workspaceFolder1');
-        const vFolder = new VirtualWorkspaceFolder(folder, 'v1');
-        userSettings = { ...folderSetting, virtualFolders };
-        if (expectedSettings === 'throw') {
-          expect(() => getExtensionResourceSettings(vFolder)).toThrow();
-        } else {
-          const settings = getExtensionResourceSettings(vFolder);
-          expect(settings).toEqual(expect.objectContaining(expectedSettings ?? folderSetting));
+        ${6} | ${[{ name: 'v1', rootPath: 'packages/v1' }, { name: 'v2', rootPath: 'packages/v2' }]}             | ${{}}
+      `(
+        'case $case: can load virtualFolder settings for a specific folder',
+        ({ virtualFolders, expectedSettings }) => {
+          const folder = makeWorkspaceFolder('workspaceFolder1');
+          const vFolder = new VirtualWorkspaceFolder(folder, 'v1');
+          userSettings = { ...folderSetting, virtualFolders };
+          if (expectedSettings === 'throw') {
+            expect(() => getExtensionResourceSettings(vFolder)).toThrow();
+          } else {
+            const settings = getExtensionResourceSettings(vFolder);
+            expect(settings).toEqual(expect.objectContaining(expectedSettings ?? folderSetting));
+          }
         }
-      });
+      );
       it('will ignore virtualFolder setting for regular WorkspaceFolder', () => {
         const folder = makeWorkspaceFolder('workspaceFolder1');
         userSettings = {

--- a/tests/Settings/index.test.ts
+++ b/tests/Settings/index.test.ts
@@ -1,0 +1,84 @@
+jest.unmock('../../src/Settings/index');
+jest.unmock('../test-helper');
+jest.unmock('../../src/virtual-workspace-folder');
+
+import * as vscode from 'vscode';
+import { createJestSettingGetter } from '../../src/Settings/index';
+import { VirtualWorkspaceFolder } from '../../src/virtual-workspace-folder';
+import { makeWorkspaceFolder } from '../test-helper';
+
+const mockConfiguration = (userSettings: any) => {
+  vscode.workspace.getConfiguration = jest.fn().mockImplementation(() => ({
+    get: (key) => userSettings[key],
+  }));
+};
+describe('createJestSettingGetter', () => {
+  let folderSetting;
+  beforeEach(() => {
+    folderSetting = {
+      jestCommandLine: 'yarn test',
+    };
+  });
+  it.each`
+    case | virtualFolders                                                                                    | jestCommandLine
+    ${1} | ${undefined}                                                                                      | ${'throw'}
+    ${2} | ${[{ name: 'v1', debugMode: true }]}                                                              | ${'yarn test'}
+    ${3} | ${[{ name: 'v1', jestCommandLine: '' }]}                                                          | ${''}
+    ${4} | ${[{ name: 'v1', jestCommandLine: undefined }]}                                                   | ${'yarn test'}
+    ${5} | ${[{ name: 'v1', jestCommandLine: 'yarn integ-test', rootPath: 'whatever' }]}                     | ${'yarn integ-test'}
+    ${6} | ${[{ name: 'v2', jestCommandLine: 'yarn integ-test' }]}                                           | ${'throw'}
+    ${7} | ${[{ name: 'v1', jestCommandLine: 'yarn test1' }, { name: 'v2', jestCommandLine: 'yarn test2' }]} | ${'yarn test1'}
+    ${8} | ${[{ name: 'v1', rootPath: 'packages/v1' }, { name: 'v2', rootPath: 'packages/v2' }]}             | ${'yarn test'}
+  `(
+    'case $case: virtualFolder settings override the actual folder settings',
+    ({ virtualFolders, jestCommandLine }) => {
+      const userSettings = { ...folderSetting, virtualFolders };
+      mockConfiguration(userSettings);
+
+      const folder = makeWorkspaceFolder('workspaceFolder1');
+      const vFolder = new VirtualWorkspaceFolder(folder, 'v1');
+
+      if (jestCommandLine === 'throw') {
+        expect(() => createJestSettingGetter(vFolder)).toThrow();
+      } else {
+        const getSetting = createJestSettingGetter(vFolder);
+        expect(getSetting('jestCommandLine')).toEqual(jestCommandLine);
+      }
+    }
+  );
+  it('will ignore virtualFolder setting for regular WorkspaceFolder', () => {
+    const userSettings = {
+      debugMode: false,
+      virtualFolders: [{ name: 'workspaceFolder1', debugMode: true }],
+    };
+    mockConfiguration(userSettings);
+
+    const folder = makeWorkspaceFolder('workspaceFolder1');
+    const getSetting = createJestSettingGetter(folder);
+
+    expect(getSetting('debugMode')).toEqual(false);
+  });
+  it.each`
+    case | folderSetting | vFolderSetting | expected
+    ${1} | ${undefined}  | ${undefined}   | ${true}
+    ${2} | ${undefined}  | ${false}       | ${false}
+    ${3} | ${false}      | ${undefined}   | ${false}
+    ${4} | ${false}      | ${true}        | ${false}
+    ${5} | ${undefined}  | ${false}       | ${false}
+  `(
+    'case $case: for "enable" setting, any false value means disabled',
+    ({ folderSetting, vFolderSetting, expected }) => {
+      const userSettings = {
+        enable: folderSetting,
+        virtualFolders: [{ name: 'v1', enable: vFolderSetting }],
+      };
+      mockConfiguration(userSettings);
+
+      const folder = makeWorkspaceFolder('workspaceFolder1');
+      const vFolder = new VirtualWorkspaceFolder(folder, 'v1');
+      const getSetting = createJestSettingGetter(vFolder);
+
+      expect(getSetting('enable')).toEqual(expected);
+    }
+  );
+});

--- a/tests/StatusBar.test.ts
+++ b/tests/StatusBar.test.ts
@@ -159,6 +159,15 @@ describe('StatusBar', () => {
       expect(createFolderItemSpy).toHaveBeenCalledWith(ws1);
       expect(createFolderItemSpy).toHaveBeenCalledWith(ws2);
     });
+    it('will not duplicate status bar items for same workspace (source)', () => {
+      const ws1 = makeWorkspaceFolder('ws1');
+      statusBar.bind(ws1);
+      expect(createFolderItemSpy).toHaveBeenCalledTimes(1);
+      expect(createFolderItemSpy).toHaveBeenCalledWith(ws1);
+
+      statusBar.bind(ws1);
+      expect(createFolderItemSpy).toHaveBeenCalledTimes(1);
+    });
     it('binding same workspace (source) multiple times will not create duplicate statusBarItem', () => {
       const ws1 = makeWorkspaceFolder('ws1');
       const ws2 = makeWorkspaceFolder('ws1');

--- a/tests/StatusBar.test.ts
+++ b/tests/StatusBar.test.ts
@@ -1,21 +1,21 @@
 jest.unmock('../src/StatusBar');
+jest.unmock('../src/virtual-workspace-folder');
+jest.unmock('./test-helper');
 jest.useFakeTimers();
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "assertRender"] }] */
-const newStatusBarItem = (type: StatusType) => ({
-  text: '',
-  command: '',
-  show: jest.fn(),
-  hide: jest.fn(),
-  tooltip: '',
-  type,
-});
 
 import * as vscode from 'vscode';
 import { StatusBar, StatusType, ProcessState } from '../src/StatusBar';
 import { TestStats } from '../src/types';
+import { makeUri, makeWorkspaceFolder } from './test-helper';
+import { VirtualWorkspaceFolder } from '../src/virtual-workspace-folder';
 
-const mockSummaryChannel = { append: jest.fn(), clear: jest.fn(), show: jest.fn() } as any;
+const mockSummaryChannel = {
+  append: jest.fn(),
+  clear: jest.fn(),
+  show: jest.fn(),
+} as any;
 const makeStats = (success: number, fail: number, unknown: number): TestStats => ({
   success,
   fail,
@@ -26,29 +26,51 @@ describe('StatusBar', () => {
   let statusBar: StatusBar;
   let updateSpy;
   let renderSpy;
-  let mockActiveSBItem;
-  let mockSummarySBItem;
+  // let mockActiveSBItem;
+  // let mockSummarySBItem;
+  let createFolderItemSpy;
+  let createSummaryItemSpy;
+  let mockSummarySBItems;
+  let mockActiveSBItems;
 
   const setupWorkspace = (active: string, ...additional: string[]) => {
-    const folders = [active, ...additional].map((ws) => ({ name: ws }));
+    const folders = [active, ...additional].map((ws) => makeWorkspaceFolder(ws));
     (vscode.workspace as any).workspaceFolders = folders;
-    (vscode.window.activeTextEditor as any) = { document: { uri: 'whatever' } };
+    (vscode.window.activeTextEditor as any) = { document: { uri: makeUri('whatever') } };
     vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValue(folders[0]);
+    return folders;
   };
 
   beforeEach(() => {
     jest.resetAllMocks();
 
-    mockActiveSBItem = newStatusBarItem(StatusType.active);
-    mockSummarySBItem = newStatusBarItem(StatusType.summary);
+    mockSummarySBItems = [];
+    mockActiveSBItems = [];
 
     vscode.window.createOutputChannel = jest.fn(() => mockSummaryChannel);
     vscode.window.createStatusBarItem = jest.fn().mockImplementation((_, priority) => {
+      let isVisible = false;
+      const show = jest.fn().mockImplementation(() => (isVisible = true));
+      const hide = jest.fn().mockImplementation(() => (isVisible = false));
+      const newStatusBarItem = (type: StatusType) => ({
+        text: '',
+        command: '',
+        show,
+        hide,
+        dispose: jest.fn(),
+        tooltip: '',
+        type,
+        isVisible: () => isVisible,
+      });
       if (priority === 2) {
-        return mockActiveSBItem;
+        const item = newStatusBarItem(StatusType.active);
+        mockActiveSBItems.push(item);
+        return item;
       }
       if (priority === 1) {
-        return mockSummarySBItem;
+        const item = newStatusBarItem(StatusType.summary);
+        mockSummarySBItems.push(item);
+        return item;
       }
       throw new Error(`unexpected createStatusBarItem priority ${priority}`);
     });
@@ -56,11 +78,18 @@ describe('StatusBar', () => {
       id,
     }));
 
+    createFolderItemSpy = jest.spyOn(StatusBar.prototype as any, 'createFolderStatusBarItem');
+    createSummaryItemSpy = jest.spyOn(StatusBar.prototype as any, 'createSummaryStatusBarItem');
+
     statusBar = new StatusBar();
     updateSpy = jest.spyOn(statusBar as any, 'handleUpdate');
     renderSpy = jest.spyOn(statusBar as any, 'render');
     updateSpy.mockClear();
     renderSpy.mockClear();
+  });
+  afterEach(() => {
+    // restore the spy created with spyOn
+    jest.restoreAllMocks();
   });
 
   describe('register', () => {
@@ -80,16 +109,17 @@ describe('StatusBar', () => {
       const calls = (vscode.commands.registerCommand as jest.Mock<any>).mock.calls;
 
       setupWorkspace('testSource1');
-      statusBar.bind('testSource1').update({ state: 'initial' });
+      statusBar.bind(makeWorkspaceFolder('testSource1')).update({ state: 'initial' });
 
       let found = 0;
       for (const call of calls) {
         //invoke the command
-        call[1]();
         if (call[0].includes('show-summary-output')) {
+          call[1]();
           expect(mockSummaryChannel.show).toHaveBeenCalled();
           found |= 0x1;
         } else if (call[0].includes('show-active-output')) {
+          call[1]({ workspaceFolder: makeWorkspaceFolder('testSource1') });
           expect(ext.showOutput).toHaveBeenCalled();
           found |= 0x2;
         }
@@ -100,12 +130,31 @@ describe('StatusBar', () => {
 
   describe('bind()', () => {
     it('returns binded helpers for each workspace (source) to update its status', () => {
-      const source = 'testSource';
+      const source = makeWorkspaceFolder('testSource');
       const helpers = statusBar.bind(source);
       ['initial', 'running', 'success', 'failed', 'stopped'].forEach((state) => {
         helpers.update({ state: state as ProcessState });
-        expect(updateSpy).toHaveBeenCalledWith(source, { state });
+        expect(updateSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ workspaceFolder: source }),
+          { state }
+        );
       });
+    });
+    it('will create status bar items for each workspace (source)', () => {
+      const ws1 = makeWorkspaceFolder('ws1');
+      const ws2 = makeWorkspaceFolder('ws2');
+      statusBar.bind(ws1);
+      statusBar.bind(ws2);
+      expect(createFolderItemSpy).toHaveBeenCalledTimes(2);
+      expect(createFolderItemSpy).toHaveBeenCalledWith(ws1);
+      expect(createFolderItemSpy).toHaveBeenCalledWith(ws2);
+    });
+    it('binding same workspace (source) multiple times will not create duplicate statusBarItem', () => {
+      const ws1 = makeWorkspaceFolder('ws1');
+      const ws2 = makeWorkspaceFolder('ws1');
+      statusBar.bind(ws1);
+      statusBar.bind(ws2);
+      expect(createFolderItemSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -132,16 +181,16 @@ describe('StatusBar', () => {
           ${8} | ${{ state: 'stopped' }}                                   | ${'stopped'}              | ${emptyStatsString} | ${'statusBarItem.errorBackground'}
           ${9} | ${{ mode: ['auto-run-on-save-test'], stats: alertStats }} | ${'$(save)'}              | ${alertSummary}     | ${undefined}
         `('update: $update', ({ update, active, summary, backgroundColor }) => {
-          statusBar.bind('testSource1').update(update);
+          statusBar.bind(makeWorkspaceFolder('testSource1')).update(update);
           expect(renderSpy).toHaveBeenCalledTimes(2);
-          expect(mockActiveSBItem.text).toContain(active);
-          expect(mockSummarySBItem.text).toContain(summary);
+          expect(mockActiveSBItems[0].text).toContain(active);
+          expect(mockSummarySBItems[0].text).toContain(summary);
           if (backgroundColor) {
-            expect(mockActiveSBItem.backgroundColor.id).toEqual(
+            expect(mockActiveSBItems[0].backgroundColor.id).toEqual(
               expect.stringContaining(backgroundColor)
             );
           } else {
-            expect(mockActiveSBItem.backgroundColor).toBeUndefined();
+            expect(mockActiveSBItems[0].backgroundColor).toBeUndefined();
           }
         });
         it.each`
@@ -152,17 +201,17 @@ describe('StatusBar', () => {
           ${{ success: 0, fail: 0, unknown: 0 }}                | ${'$(pass) 0 $(error) 0 $(question) 0'}
           ${{ isDirty: true, success: 0, fail: 0, unknown: 0 }} | ${'$(sync-ignored) | $(pass) 0 $(error) 0 $(question) 0'}
         `('shows stats summary: $stats => $summary', ({ stats, summary }) => {
-          statusBar.bind('testSource1').update({ stats });
+          statusBar.bind(makeWorkspaceFolder('testSource1')).update({ stats });
           expect(renderSpy).toHaveBeenCalledTimes(2);
-          expect(mockActiveSBItem.text).not.toContain(`Jest: ${summary}`);
-          expect(mockSummarySBItem.text).toContain(`Jest-WS: ${summary}`);
+          expect(mockActiveSBItems[0].text).not.toContain(`Jest: ${summary}`);
+          expect(mockSummarySBItems[0].text).toContain(`Jest-WS: ${summary}`);
         });
         it('shows tooltip by the actual status', () => {
           statusBar
-            .bind('testSource1')
+            .bind(makeWorkspaceFolder('testSource1'))
             .update({ mode: ['auto-run-on-save'], stats: { success: 1, fail: 2, unknown: 3 } });
-          expect(mockActiveSBItem.tooltip).toContain('auto-run-on-save');
-          expect(mockSummarySBItem.tooltip).toContain('success 1, fail 2, unknown 3');
+          expect(mockActiveSBItems[0].tooltip).toContain('auto-run-on-save');
+          expect(mockSummarySBItems[0].tooltip).toContain('success 1, fail 2, unknown 3');
         });
       });
     });
@@ -177,83 +226,108 @@ describe('StatusBar', () => {
     });
 
     it('will update both active and summary status', () => {
-      statusBar.bind('testSource1').update({ state: 'initial' });
-      expect(mockActiveSBItem.text).toEqual('Jest: ...');
-      expect(mockActiveSBItem.show).toHaveBeenCalled();
-      expect(mockSummarySBItem.text).toEqual('Jest-WS: $(pass) 0 $(error) 0 $(question) 0');
-      expect(mockSummarySBItem.show).toHaveBeenCalled();
+      statusBar.bind(makeWorkspaceFolder('testSource1')).update({ state: 'initial' });
+      const summaryItem = createSummaryItemSpy.mock.results[0].value;
+      const item1 = createFolderItemSpy.mock.results[0].value;
+      expect(item1.isVisible).toBeTruthy();
+      expect(summaryItem.isVisible).toBeTruthy();
+
+      expect(renderSpy).toHaveBeenCalledTimes(2);
+      expect(renderSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), item1);
+      expect(renderSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), summaryItem);
     });
     it('when multiple workspace status updated', () => {
-      statusBar.bind('testSource1').update({ state: 'initial' });
-      expect(mockActiveSBItem.show).toHaveBeenCalledTimes(1);
-      expect(mockActiveSBItem.text).toEqual('Jest: ...');
-      expect(mockSummarySBItem.show).toHaveBeenCalledTimes(1);
+      const summaryItem = createSummaryItemSpy.mock.results[0].value;
+      expect(summaryItem.isVisible).toBeFalsy();
 
-      statusBar.bind('testSource2').update({ state: 'initial' });
-      expect(mockSummarySBItem.show).toHaveBeenCalledTimes(2);
-      expect(mockSummarySBItem.text).toMatchInlineSnapshot(
+      statusBar.bind(makeWorkspaceFolder('testSource1')).update({ state: 'initial' });
+      const item1 = createFolderItemSpy.mock.results[0].value;
+
+      expect(item1.isVisible).toBeTruthy();
+      expect(summaryItem.isVisible).toBeTruthy();
+      expect(mockActiveSBItems[0].text).toEqual('Jest: ...');
+
+      statusBar.bind(makeWorkspaceFolder('testSource2')).update({ state: 'initial' });
+      const item2 = createFolderItemSpy.mock.results[1].value;
+      expect(item2.isVisible).toBeFalsy();
+
+      expect(summaryItem.isVisible).toBeTruthy();
+      expect(mockSummarySBItems[0].text).toMatchInlineSnapshot(
         `"Jest-WS: $(pass) 0 $(error) 0 $(question) 0"`
       );
-
-      expect(mockActiveSBItem.hide).toHaveBeenCalledTimes(0);
     });
     it('will not show active status if no active workspace can be determined', () => {
       vscode.window.activeTextEditor = undefined;
-      statusBar.bind('testSource1').update({ state: 'initial' });
-      expect(mockActiveSBItem.show).toHaveBeenCalledTimes(1);
-      mockActiveSBItem.show.mockClear();
+      statusBar.bind(makeWorkspaceFolder('testSource1')).update({ state: 'initial' });
+      const item1 = createFolderItemSpy.mock.results[0].value;
+      expect(item1.isVisible).toBeFalsy();
 
       // with boh workspaces reported and no active text editor, can't determine the active workspace
-      statusBar.bind('testSource2').update({ state: 'initial' });
-      expect(mockActiveSBItem.show).toHaveBeenCalledTimes(0);
-      expect(mockActiveSBItem.hide).toHaveBeenCalledTimes(1);
+      statusBar.bind(makeWorkspaceFolder('testSource2')).update({ state: 'initial' });
+      const item2 = createFolderItemSpy.mock.results[1].value;
+      expect(item2.isVisible).toBeFalsy();
     });
     describe('onDidChangeActiveTextEditor', () => {
+      let item1, item2;
       beforeEach(() => {
-        statusBar.bind('testSource1').update({ state: 'initial' });
-        statusBar.bind('testSource2').update({ state: 'running' });
-        mockActiveSBItem.show.mockClear();
+        statusBar.bind(makeWorkspaceFolder('testSource1')).update({ state: 'initial' });
+        statusBar.bind(makeWorkspaceFolder('testSource2')).update({ state: 'running' });
+        item1 = createFolderItemSpy.mock.results[0].value;
+        item2 = createFolderItemSpy.mock.results[1].value;
       });
 
       it('can switch to new active workspace status when active editor changed', () => {
         // active workspace is 'testSource1' so testSource1 status is displayed
-        expect(mockActiveSBItem.text).toEqual('Jest: ...');
+        expect(item1.isVisible).toBeTruthy();
+        expect(mockActiveSBItems[0].text).toEqual('Jest: ...');
 
         // now switch to testSource2, testSource2 status (running) should be displayed
         vscode.workspace.getWorkspaceFolder = jest
           .fn()
           .mockReturnValueOnce({ name: 'testSource2' });
         statusBar.onDidChangeActiveTextEditor(editor);
-        expect(mockActiveSBItem.text).toEqual('Jest: $(sync~spin)');
-        expect(mockActiveSBItem.show).toHaveBeenCalledTimes(1);
+        expect(mockActiveSBItems[1].text).toEqual('Jest (testSource2): $(sync~spin)');
+        expect(item1.isVisible).toBeFalsy();
+        expect(item2.isVisible).toBeTruthy();
       });
       it('nothing will happen if switch to an empty editor', () => {
-        vscode.workspace.getWorkspaceFolder = jest
-          .fn()
-          .mockReturnValueOnce({ name: 'testSource2' });
+        vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(undefined);
         statusBar.onDidChangeActiveTextEditor({} as any);
-        expect(mockActiveSBItem.show).not.toHaveBeenCalled();
+        expect(item1.isVisible).toBeFalsy();
+        expect(item2.isVisible).toBeFalsy();
       });
-      it('nothing will happen if switch switch to an the editor under the same workspace', () => {
+      it('if no folder matches, will hide all active items', () => {
+        vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(undefined);
+        statusBar.onDidChangeActiveTextEditor(editor);
+        expect(item1.isVisible).toBeFalsy();
+        expect(item2.isVisible).toBeFalsy();
+      });
+      it('if new text editor belongs to the same workspace, will not update', () => {
+        // item1 (testSource1) is already visible
+        expect(updateSpy).toHaveBeenCalled();
+        expect(item1.isVisible).toBeTruthy();
+        updateSpy.mockClear();
+
         vscode.workspace.getWorkspaceFolder = jest
           .fn()
           .mockReturnValueOnce({ name: 'testSource1' });
         statusBar.onDidChangeActiveTextEditor(editor);
-        expect(mockActiveSBItem.show).not.toHaveBeenCalled();
+        expect(item1.isVisible).toBeTruthy();
+        expect(updateSpy).not.toHaveBeenCalled();
       });
     });
     describe('summary render', () => {
       beforeEach(() => {
         setupWorkspace('testSource1', 'testSource2', 'testSource3');
-        statusBar.bind('testSource1').update({
+        statusBar.bind(makeWorkspaceFolder('testSource1')).update({
           state: 'initial',
           mode: ['auto-run-off'],
         });
-        statusBar.bind('testSource2').update({
+        statusBar.bind(makeWorkspaceFolder('testSource2')).update({
           state: 'running',
           mode: ['auto-run-watch', 'coverage'],
         });
-        statusBar.bind('testSource3').update({
+        statusBar.bind(makeWorkspaceFolder('testSource3')).update({
           state: 'done',
           mode: ['auto-run-on-save-test', 'coverage'],
         });
@@ -264,15 +338,15 @@ describe('StatusBar', () => {
         ${makeStats(0, 0, 3)} | ${makeStats(0, 0, 0)} | ${undefined}          | ${'$(pass) 0 $(error) 0 $(question) 3'}
         ${makeStats(0, 0, 0)} | ${makeStats(0, 0, 0)} | ${makeStats(1, 0, 0)} | ${'$(check)'}
       `('show total stats in statusBar', ({ stats1, stats2, stats3, expectedText }) => {
-        statusBar.bind('testSource1').update({ stats: stats1 });
-        statusBar.bind('testSource2').update({ stats: stats2 });
-        statusBar.bind('testSource3').update({ stats: stats3 });
-        expect(mockSummarySBItem.text).toContain(expectedText);
+        statusBar.bind(makeWorkspaceFolder('testSource1')).update({ stats: stats1 });
+        statusBar.bind(makeWorkspaceFolder('testSource2')).update({ stats: stats2 });
+        statusBar.bind(makeWorkspaceFolder('testSource3')).update({ stats: stats3 });
+        expect(mockSummarySBItems[0].text).toContain(expectedText);
       });
       describe('output channel', () => {
         it('display status in plain text', () => {
           mockSummaryChannel.append.mockClear();
-          statusBar.bind('testSource1').update({
+          statusBar.bind(makeWorkspaceFolder('testSource1')).update({
             state: 'running',
             mode: ['auto-run-watch', 'coverage'],
             stats: makeStats(1, 2, 3),
@@ -292,62 +366,145 @@ describe('StatusBar', () => {
       (vscode.workspace as any).workspaceFolders = [];
       vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(undefined);
     });
-    it('will still show active if only one workspace reported', () => {
-      statusBar.bind('testSource1').update({ state: 'running' });
-      expect(mockActiveSBItem.show).toHaveBeenCalledTimes(1);
-      expect(mockActiveSBItem.hide).not.toHaveBeenCalled();
+    it('no active item will be shown even if only one workspace reported', () => {
+      statusBar.bind(makeWorkspaceFolder('testSource1')).update({ state: 'running' });
+      const item1 = createFolderItemSpy.mock.results[0].value;
+      expect(item1.isVisible).toBeFalsy();
+      expect(renderSpy).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), item1);
     });
     it('active status bar should be hidden if multiple workspaces reported', () => {
-      statusBar.bind('testSource1').update({ state: 'running' });
-      statusBar.bind('testSource2').update({ state: 'done' });
-      expect(mockActiveSBItem.hide).toHaveBeenCalledTimes(1);
+      statusBar.bind(makeWorkspaceFolder('testSource1')).update({ state: 'running' });
+      statusBar.bind(makeWorkspaceFolder('testSource2')).update({ state: 'done' });
+      const item1 = createFolderItemSpy.mock.results[0].value;
+      const item2 = createFolderItemSpy.mock.results[1].value;
+      expect(item1.isVisible).toBeFalsy();
+      expect(item2.isVisible).toBeFalsy();
     });
   });
 
-  describe('StatusBarItem', () => {
-    const registerCommand = vscode.commands.registerCommand as unknown as jest.Mock<{}>;
+  describe('virtual workspace folders', () => {
+    let ws1, ws2, v1, v2, v3;
+    let isInWorkspaceFolderSpy;
+    beforeEach(() => {
+      [ws1, ws2] = setupWorkspace('ws-1', 'ws-2');
+      v1 = new VirtualWorkspaceFolder(ws1, 'v1');
+      v2 = new VirtualWorkspaceFolder(ws1, 'v2');
+      v3 = new VirtualWorkspaceFolder(ws2, 'v3');
 
-    afterEach(() => {
-      (vscode.workspace as any).workspaceFolders = [];
-      vscode.window.activeTextEditor = undefined;
+      isInWorkspaceFolderSpy = jest.spyOn(VirtualWorkspaceFolder.prototype, 'isInWorkspaceFolder');
     });
 
-    it('responds to clicks for one active WorkspaceFolder', () => {
-      const getExtensionByName = jest.fn();
-      statusBar.register(getExtensionByName);
+    it.each`
+      case | inWorkspaceFolder
+      ${1} | ${[true, true]}
+      ${2} | ${[true, false]}
+      ${3} | ${[false, false]}
+    `(
+      'case $case: will only show status bar items if the uri is in the specific worksppace folder',
+      ({ inWorkspaceFolder }) => {
+        // active document are in both v1 and v2 folders
+        isInWorkspaceFolderSpy
+          .mockReturnValueOnce(inWorkspaceFolder[0])
+          .mockReturnValueOnce(inWorkspaceFolder[1])
+          .mockReturnValueOnce(false);
 
-      const statusBarClickHandler = registerCommand.mock.calls.find((c) =>
-        c[0].includes('show-active-output')
-      )[1];
-      expect(statusBarClickHandler).toBeDefined();
-      (vscode.workspace as any).workspaceFolders = [
-        { name: 'testproject', uri: vscode.Uri.file(''), index: 0 },
-      ];
-      statusBarClickHandler();
-      expect(getExtensionByName).toHaveBeenCalledWith('testproject');
+        statusBar.bind(v1).update({ state: 'running' });
+        statusBar.bind(v2).update({ state: 'done' });
+        statusBar.bind(v3).update({ state: 'initial' });
+        // 3 items created
+        expect(createFolderItemSpy.mock.results).toHaveLength(3);
+        expect(isInWorkspaceFolderSpy).toHaveBeenCalledTimes(3);
+
+        // since the URI will match ws1, so only the virtual folders under ws1 will be visible
+        expect(createFolderItemSpy.mock.results[0].value.isVisible).toEqual(inWorkspaceFolder[0]); // v1
+        expect(createFolderItemSpy.mock.results[1].value.isVisible).toEqual(inWorkspaceFolder[1]); // v2
+        expect(createFolderItemSpy.mock.results[2].value.isVisible).toBeFalsy(); //v3
+      }
+    );
+    it('will display the correct status bar item when active editor changed', () => {
+      const editor: any = { document: { uri: makeUri('test') } };
+
+      statusBar.bind(v1).update({ state: 'running' });
+      statusBar.bind(v2).update({ state: 'done' });
+      statusBar.bind(ws2).update({ state: 'initial' });
+
+      // active editor is in ws1
+      vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(ws1);
+      isInWorkspaceFolderSpy.mockReturnValueOnce(true).mockReturnValueOnce(true);
+
+      statusBar.onDidChangeActiveTextEditor(editor);
+      expect(createFolderItemSpy.mock.results[0].value.isVisible).toBeTruthy();
+      expect(createFolderItemSpy.mock.results[1].value.isVisible).toBeTruthy();
+      expect(createFolderItemSpy.mock.results[2].value.isVisible).toBeFalsy();
+
+      // active editor is in ws2
+      vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(ws2);
+      statusBar.onDidChangeActiveTextEditor(editor);
+      expect(createFolderItemSpy.mock.results[0].value.isVisible).toBeFalsy();
+      expect(createFolderItemSpy.mock.results[1].value.isVisible).toBeFalsy();
+      expect(createFolderItemSpy.mock.results[2].value.isVisible).toBeTruthy();
     });
+  });
 
-    it('responds to clicks for two WorkspaceFolders but only one active', () => {
-      const getExtensionByName = jest.fn();
-      statusBar.register(getExtensionByName);
+  describe('clear up functions', () => {
+    let ws1, ws2, v1, v2, editor;
+    let isInWorkspaceFolderSpy;
+    beforeEach(() => {
+      // setup 2 workspace folders with 2 virtual folders
+      [ws1, ws2] = setupWorkspace('ws-1', 'ws-2');
+      v1 = new VirtualWorkspaceFolder(ws1, 'v1');
+      v2 = new VirtualWorkspaceFolder(ws1, 'v2');
+      isInWorkspaceFolderSpy = jest.spyOn(VirtualWorkspaceFolder.prototype, 'isInWorkspaceFolder');
+      editor = { document: { uri: makeUri('test') } };
+    });
+    it('when workspace folder is removed, the status bar item will be removed', () => {
+      // active editor is in ws1
+      vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(ws1);
+      isInWorkspaceFolderSpy.mockReturnValue(true);
+      vscode.window.activeTextEditor = editor;
 
-      const statusBarClickHandler = registerCommand.mock.calls.find((c) =>
-        c[0].includes('show-active-output')
-      )[1];
-      expect(statusBarClickHandler).toBeDefined();
-      (vscode.workspace as any).workspaceFolders = [
-        { name: 'testproject1', uri: vscode.Uri.file(''), index: 0 },
-        { name: 'testproject2', uri: vscode.Uri.file(''), index: 1 },
-        { name: 'testproject3', uri: vscode.Uri.file(''), index: 2 },
-      ];
-      const projectUrl = vscode.Uri.file('projecturl');
-      vscode.window.activeTextEditor = {
-        document: { uri: projectUrl },
-      } as unknown as vscode.TextEditor;
-      vscode.workspace.getWorkspaceFolder = (url) =>
-        url === projectUrl ? vscode.workspace.workspaceFolders[1] : undefined;
-      statusBarClickHandler();
-      expect(getExtensionByName).toHaveBeenCalledWith(vscode.workspace.workspaceFolders[1].name);
+      statusBar.bind(ws2).update({ state: 'running' });
+      statusBar.bind(v1).update({ state: 'running' });
+      statusBar.bind(v2).update({ state: 'running' });
+
+      // created 3 items total. v1 and v2 are visible
+      expect(createFolderItemSpy.mock.results).toHaveLength(3);
+      const [ws2Item, v1Item, v2Item] = createFolderItemSpy.mock.results.map((r) => r.value);
+      expect(ws2Item.isVisible).toBeFalsy(); // ws2
+      expect(v1Item.isVisible).toBeTruthy(); // v1
+      expect(v2Item.isVisible).toBeTruthy(); // v2
+
+      expect(ws2Item.workspaceFolder).toBe(ws2);
+      const disposeSpy = jest.spyOn(ws2Item, 'dispose');
+
+      // rmeove ws2 folder
+      statusBar.removeWorkspaceFolder(ws2);
+      expect(disposeSpy).toHaveBeenCalled();
+
+      // switch active editor to ws2
+      vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(ws2);
+      statusBar.onDidChangeActiveTextEditor(editor);
+
+      //now v1 and v2 are not visible
+      expect(v1Item.isVisible).toBeFalsy(); // v1
+      expect(v2Item.isVisible).toBeFalsy(); // v2
+    });
+    it('when dispose, all status bar items will be disposed', () => {
+      vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValueOnce(ws1);
+      isInWorkspaceFolderSpy.mockReturnValue(true);
+      vscode.window.activeTextEditor = editor;
+
+      statusBar.bind(ws2).update({ state: 'running' });
+      statusBar.bind(v1).update({ state: 'running' });
+      statusBar.bind(v2).update({ state: 'running' });
+
+      const [ws2Spy, v1Spy, v2Spy] = createFolderItemSpy.mock.results.map((r) =>
+        jest.spyOn(r.value, 'dispose')
+      );
+
+      statusBar.dispose();
+
+      [ws2Spy, v1Spy, v2Spy].forEach((disposeSpy) => expect(disposeSpy).toHaveBeenCalled());
     });
   });
 });

--- a/tests/extension-manager.test.ts
+++ b/tests/extension-manager.test.ts
@@ -684,6 +684,13 @@ describe('ExtensionManager', () => {
         ws1Ext = extensionManager.getByName('ws-1');
         ws2Ext = extensionManager.getByName('ws-2');
       });
+      it('no op if no workspace folders', () => {
+        expect.hasAssertions();
+        (vscode.workspace as any).workspaceFolders = undefined;
+        const event = mockEvent(true);
+        extensionManager.onDidChangeConfiguration(event);
+        expect(event.affectsConfiguration).not.toHaveBeenCalled();
+      });
       describe('only trigger action if change affects the extensions', () => {
         it.each`
           eventValue          | EMCount | Ws1Count | Ws2Count

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -28,6 +28,7 @@ const extensionManager = {
   unregisterAllWorkspaces: jest.fn(),
   activate: jest.fn(),
   register: jest.fn(() => []),
+  deleteAllExtensions: jest.fn(),
 };
 
 // tslint:disable-next-line: variable-name
@@ -41,17 +42,16 @@ jest.mock('../src/extensionManager', () => mockExtensionManager);
 import { activate, deactivate } from '../src/extension';
 
 describe('Extension', () => {
+  const context: any = {
+    subscriptions: {
+      push: jest.fn(),
+    },
+  };
   beforeEach(() => {
     jest.clearAllMocks();
     // ExtensionManager.mockImplementation(() => extensionManager);
   });
   describe('activate()', () => {
-    const context: any = {
-      subscriptions: {
-        push: jest.fn(),
-      },
-    };
-
     beforeEach(() => {
       context.subscriptions.push.mockReset();
     });
@@ -74,8 +74,9 @@ describe('Extension', () => {
 
   describe('deactivate()', () => {
     it('should call unregisterAll on instancesManager', () => {
+      activate(context);
       deactivate();
-      expect(extensionManager.unregisterAllWorkspaces).toHaveBeenCalled();
+      expect(extensionManager.deleteAllExtensions).toHaveBeenCalled();
     });
   });
 });

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -37,7 +37,7 @@ const mockExtensionManager = {
   getExtensionWindowSettings: jest.fn(() => ({})),
 };
 
-jest.mock('../src/extensionManager', () => mockExtensionManager);
+jest.mock('../src/extension-manager', () => mockExtensionManager);
 
 import { activate, deactivate } from '../src/extension';
 

--- a/tests/extensionManager.test.ts
+++ b/tests/extensionManager.test.ts
@@ -1,4 +1,5 @@
 jest.unmock('../src/extensionManager');
+jest.unmock('../src/virtual-workspace-folder');
 jest.unmock('../src/appGlobals');
 
 import * as vscode from 'vscode';
@@ -9,6 +10,7 @@ import { JestExt } from '../src/JestExt';
 import { DebugConfigurationProvider } from '../src/DebugConfigurationProvider';
 import { CoverageCodeLensProvider } from '../src/Coverage';
 import { startWizard } from '../src/setup-wizard';
+import { VirtualWorkspaceFolder } from '../src/virtual-workspace-folder';
 
 const mockEnabledWorkspaceFolders = jest.fn();
 jest.mock('../src/workspace-manager', () => ({
@@ -17,7 +19,6 @@ jest.mock('../src/workspace-manager', () => ({
 
 const updateConfigurationMock = jest.fn();
 
-// (vscode.commands as any).registerCommand = jest.fn().mockImplementation((...args) => args);
 (vscode.window as any).onDidChangeActiveTextEditor = jest
   .fn()
   .mockReturnValue('onDidChangeActiveTextEditor');
@@ -72,14 +73,17 @@ const makeJestExt = (workspace: vscode.WorkspaceFolder): any => {
     toggleCoverageOverlay: jest.fn(),
     enableLoginShell: jest.fn(),
     runItemCommand: jest.fn(),
-    workspace,
+    workspaceFolder: workspace,
+    name: workspace.name,
   };
 };
 const makeWorkspaceFolder = (name: string): any => ({ uri: { fsPath: name }, name });
 const makeEditor = (name: string): any => ({ document: { uri: name, fileName: name } });
-const mockJestExt = () => {
+const mockJestExt = (callback?: (ext: any) => void) => {
   (JestExt as jest.Mocked<any>).mockImplementation((...args: any[]) => {
-    return makeJestExt(args[1]);
+    const ext = makeJestExt(args[1]);
+    callback?.(ext);
+    return ext;
   });
 };
 const createExtensionContext = () => ({
@@ -102,26 +106,52 @@ const initWorkspaces = (all: string[], enabled?: string[]): any[] => {
   return allWorspaces;
 };
 
-const createExtensionManager = (workspaceFolders: string[], context?: any): ExtensionManager => {
-  const allFolders = initWorkspaces(workspaceFolders);
+const createExtensionManager = (
+  workspaceFolders: string[],
+  context?: any,
+  recordJestInstances?: (ext: any) => void
+): ExtensionManager => {
+  const allFolders = initWorkspaces(workspaceFolders, workspaceFolders);
 
   (vscode.workspace.getWorkspaceFolder as jest.Mocked<any>).mockImplementation((uri) => {
     return allFolders.find((ws) => ws.name === uri);
   });
-  mockJestExt();
+
+  mockJestExt(recordJestInstances);
   const extensionContext = context ?? createExtensionContext();
   const em = new ExtensionManager(extensionContext);
-  allFolders.forEach((ws) => em.registerWorkspace(ws));
   return em;
 };
 
+/**
+ * setup an use case where there are 2 actual workspace folders (ws1, ws2); in ws2 there are 2 virtual folders (ws2_v1, ws2_v2)
+ * @param em
+ * @returns
+ */
+const setupVirtualFolders = (em: ExtensionManager) => {
+  const ws1 = makeWorkspaceFolder('ws-1');
+  const ws2 = makeWorkspaceFolder('ws-2');
+  const ws2_v1 = new VirtualWorkspaceFolder(ws2, 'ws-2-v1');
+  const ws2_v2 = new VirtualWorkspaceFolder(ws2, 'ws-2-v2');
+
+  (vscode.workspace as any).workspaceFolders = [ws1, ws2];
+  // but only f1 is enabled
+  const enabledFolders = [ws1, ws2_v1, ws2_v2];
+  mockEnabledWorkspaceFolders.mockReturnValue(enabledFolders);
+
+  em.applySettings();
+
+  return { ws1, ws2, ws2_v1, ws2_v2 };
+};
+
 describe('ExtensionManager', () => {
-  const jestInstance = makeJestExt(makeWorkspaceFolder('workspace-1'));
+  const jestInstance = makeJestExt(makeWorkspaceFolder('workspaceFolder1'));
   let context;
   let extensionManager: ExtensionManager;
 
-  const registerSpy = jest.spyOn(ExtensionManager.prototype, 'registerWorkspace');
-  const unregisterSpy = jest.spyOn(ExtensionManager.prototype, 'unregisterWorkspace');
+  const registerSpy = jest.spyOn(ExtensionManager.prototype, 'addExtension');
+  const unregisterSpy = jest.spyOn(ExtensionManager.prototype, 'deleteExtension');
+
   let workspaceFolder1;
   beforeEach(() => {
     jest.clearAllMocks();
@@ -168,8 +198,11 @@ describe('ExtensionManager', () => {
     });
   });
   describe('with an extensionManager', () => {
+    const jestInstances = [];
     beforeEach(() => {
-      extensionManager = new ExtensionManager(context);
+      jestInstances.length = 0;
+      const recordInstances = (ext: any) => jestInstances.push(ext);
+      extensionManager = createExtensionManager([workspaceFolder1.name], context, recordInstances);
       registerSpy.mockClear();
       unregisterSpy.mockClear();
       (vscode.window.showQuickPick as any).mockReset();
@@ -185,10 +218,12 @@ describe('ExtensionManager', () => {
       it('will register enabled workspace and unregister disabled ones', () => {
         //set up
         mockEnabledWorkspaceFolders.mockReturnValue([ws1, ws2]);
-        extensionManager.registerWorkspace(ws1);
-        extensionManager.registerWorkspace(ws2);
+        extensionManager.applySettings();
+        expect(jestInstances).toHaveLength(3);
+
         expect(extensionManager.getByName(ws1.name)).toBeDefined();
         expect(extensionManager.getByName(ws2.name)).toBeDefined();
+        expect(extensionManager.getByName(workspaceFolder1.name)).toBeUndefined();
 
         // when disable ws2
         mockEnabledWorkspaceFolders.mockReturnValue([ws1]);
@@ -196,9 +231,34 @@ describe('ExtensionManager', () => {
         expect(extensionManager.getByName(ws1.name)).toBeDefined();
         expect(extensionManager.getByName(ws2.name)).toBeUndefined();
       });
+      it('can handle virtual workspace folders just like actual folders', () => {
+        const v_1 = new VirtualWorkspaceFolder(ws2, 'ws-2-front');
+        const v_2 = new VirtualWorkspaceFolder(ws2, 'ws-2-back');
+
+        mockEnabledWorkspaceFolders.mockReturnValue([ws1, v_1, v_2]);
+        jestInstances.length = 0;
+        extensionManager.applySettings();
+        expect(jestInstances).toHaveLength(3);
+
+        expect(jestInstances.map((ext) => ext.name)).toEqual(
+          expect.arrayContaining([ws1.name, v_1.name, v_2.name])
+        );
+
+        expect(extensionManager.getByName(ws1.name)).toBeDefined();
+        expect(extensionManager.getByName(ws2.name)).toBeUndefined();
+        expect(extensionManager.getByName(v_1.name)).toBeDefined();
+        expect(extensionManager.getByName(v_2.name)).toBeDefined();
+
+        // can disable virtual workspace
+        mockEnabledWorkspaceFolders.mockReturnValue([ws1, v_2]);
+        extensionManager.applySettings();
+
+        expect(extensionManager.getByName(v_2.name)).toBeDefined();
+        expect(extensionManager.getByName(v_1.name)).toBeUndefined();
+      });
     });
 
-    describe('registerWorkspace', () => {
+    describe('addExtension', () => {
       const ws1 = makeWorkspaceFolder('ws-1');
       const ws2 = makeWorkspaceFolder('ws-2');
       beforeEach(() => {
@@ -206,112 +266,176 @@ describe('ExtensionManager', () => {
       });
       it('should register an instance', () => {
         mockEnabledWorkspaceFolders.mockReturnValue([ws1, ws2]);
-        extensionManager.registerWorkspace(ws1);
-        expect(extensionManager.getByName(ws1.name)).toBeDefined();
+        extensionManager.applySettings();
+        const ext = extensionManager.getByName(ws1.name);
+        expect(ext.name).toEqual(ws1.name);
+        expect(ext).toBe(jestInstances[1]);
       });
       it('should not register disabled workspace', () => {
         mockEnabledWorkspaceFolders.mockReturnValue([ws2]);
-        extensionManager.registerWorkspace(ws1);
+        extensionManager.applySettings();
+        extensionManager.addExtension(ws1);
         expect(extensionManager.getByName(ws1.name)).toBeUndefined();
       });
     });
 
-    describe('unregisterWorkspace', () => {
+    describe('deleteExtension', () => {
       it('should unregister instance by wokspaceFolder', () => {
-        extensionManager.registerWorkspace(workspaceFolder1);
-        extensionManager.unregisterWorkspace(workspaceFolder1);
+        extensionManager.addExtension(workspaceFolder1);
+        const ext = extensionManager.getByName(workspaceFolder1.name);
+        expect(ext).not.toBeUndefined();
+        extensionManager.deleteExtension(ext);
         expect(extensionManager.getByName(workspaceFolder1.name)).toBeUndefined();
-        expect(jestInstance.deactivate).toHaveBeenCalled();
+        expect(ext.deactivate).toHaveBeenCalled();
       });
     });
 
-    describe('unregisterByName', () => {
+    describe('deleteExtensionByFolder', () => {
       it('should unregister instance by wokspaceFolder name', () => {
-        extensionManager.registerWorkspace(workspaceFolder1);
-        extensionManager.unregisterWorkspaceByName('workspaceFolder1');
+        extensionManager.addExtension(workspaceFolder1);
+        const ext = extensionManager.getByName('workspaceFolder1');
+        expect(ext).not.toBeUndefined();
+
+        extensionManager.deleteExtensionByFolder(workspaceFolder1);
         expect(extensionManager.getByName('workspaceFolder1')).toBeUndefined();
-        expect(jestInstance.deactivate).toHaveBeenCalled();
+        expect(ext.deactivate).toHaveBeenCalled();
       });
     });
 
-    describe('unregisterAllWorkspaces', () => {
-      it('should unregister all instances', () => {
+    describe('deleteAllExtensions', () => {
+      it('should delete all instances', () => {
         const [ws1, ws2] = initWorkspaces(['workspaceFolder1', 'workspaceFolder2']);
-        extensionManager.registerWorkspace(ws1);
-        extensionManager.registerWorkspace(ws2);
+        extensionManager.applySettings();
 
-        expect(extensionManager.getByName(ws1.name)).toBeDefined();
-        expect(extensionManager.getByName(ws2.name)).toBeDefined();
+        const ext1 = extensionManager.getByName(ws1.name);
+        const ext2 = extensionManager.getByName(ws2.name);
+        expect(ext1).toBeDefined();
+        expect(ext2).toBeDefined();
 
-        extensionManager.unregisterAllWorkspaces();
+        extensionManager.deleteAllExtensions();
 
         expect(extensionManager.getByName(ws1.name)).toBeUndefined();
         expect(extensionManager.getByName(ws2.name)).toBeUndefined();
-        expect(jestInstance.deactivate).toHaveBeenCalledTimes(2);
+        expect(ext1.deactivate).toHaveBeenCalledTimes(1);
+        expect(ext2.deactivate).toHaveBeenCalledTimes(1);
       });
     });
 
     describe('getByName()', () => {
       it('should return extension', () => {
-        extensionManager.registerWorkspace(workspaceFolder1);
-        expect(extensionManager.getByName('workspaceFolder1')).toBe(jestInstance);
+        extensionManager.addExtension(workspaceFolder1);
+        expect(jestInstances).toHaveLength(1);
+
+        expect(extensionManager.getByName('workspaceFolder1')).toBe(jestInstances[0]);
         expect(extensionManager.getByName('workspaceFolder2')).toBeUndefined();
+      });
+      it('can return virtual folder extension', () => {
+        const { ws2_v1 } = setupVirtualFolders(extensionManager);
+        expect(extensionManager.getByName(ws2_v1.name)).not.toBeUndefined();
       });
     });
 
     describe('getByDocUri()', () => {
+      const whateverUri: any = 'whatever';
       it('should return extension', async () => {
-        extensionManager.registerWorkspace(workspaceFolder1);
+        extensionManager.addExtension(workspaceFolder1);
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce({
           name: 'workspaceFolder1',
         });
-        expect(extensionManager.getByDocUri(null)).toBe(jestInstance);
+        const extList = extensionManager.getByDocUri(whateverUri);
+        expect(extList).toHaveLength(1);
+        expect(JestExt as jest.Mocked<any>).toHaveBeenCalledTimes(1);
       });
       it('should return undefined if no workspace found for uri', () => {
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(undefined);
-        expect(extensionManager.getByDocUri(null)).toBeUndefined();
+        expect(extensionManager.getByDocUri(null)).toHaveLength(0);
+      });
+      it('will return multiple extensions for venv', () => {
+        const ws2 = makeWorkspaceFolder('ws-2');
+        const v_1 = new VirtualWorkspaceFolder(ws2, 'ws-2-unit');
+        const v_2 = new VirtualWorkspaceFolder(ws2, 'ws-2-integration');
+
+        mockEnabledWorkspaceFolders.mockReturnValue([v_1, v_2]);
+        extensionManager.applySettings();
+
+        (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce({
+          name: ws2.name,
+        });
+        const extList = extensionManager.getByDocUri(whateverUri);
+        expect(extList).toHaveLength(2);
+        expect(extList.map((ext) => ext.name)).toEqual(
+          expect.arrayContaining([v_1.name, v_2.name])
+        );
       });
     });
 
     describe('selectExtension()', () => {
-      afterEach(() => {
-        (vscode.workspace as any).workspaceFolders = [makeWorkspaceFolder('workspaceFolder1')];
-      });
-
       it('should return extension at once if there is only one workspace folder', async () => {
-        extensionManager.registerWorkspace(workspaceFolder1);
-        expect(await extensionManager.selectExtension()).toBe(jestInstance);
+        extensionManager.addExtension(workspaceFolder1);
+        expect(await extensionManager.selectExtension()).toBe(jestInstances[0]);
       });
 
       it('should prompt for workspace if there are more then one enabled workspace folder', async () => {
         const [ws1, ws2] = initWorkspaces(['ws1', 'ws2', 'ws3'], ['ws1', 'ws2']);
-        extensionManager.registerWorkspace(ws1);
+        extensionManager.applySettings();
         (vscode.window.showQuickPick as any).mockReturnValue(ws1.name);
-        expect(await extensionManager.selectExtension()).toBe(jestInstance);
-        expect(vscode.window.showQuickPick).toHaveBeenCalledWith([ws1.name, ws2.name]);
+        expect(await extensionManager.selectExtension()).toBe(jestInstances[1]);
+        expect(vscode.window.showQuickPick).toHaveBeenCalledWith([ws1.name, ws2.name], {
+          canPickMany: false,
+        });
       });
 
       it('should return undefined if no workspace opened', async () => {
         initWorkspaces([]);
+        extensionManager.applySettings();
         expect(await extensionManager.selectExtension()).toBeUndefined();
         expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
       });
       it('should return undefined if no workspace selected', async () => {
-        const [ws1] = initWorkspaces(['ws1', 'ws2']);
-        extensionManager.registerWorkspace(ws1);
+        initWorkspaces(['ws1', 'ws2']);
+        extensionManager.applySettings();
         (vscode.window.showQuickPick as any).mockReturnValue(undefined);
         expect(await extensionManager.selectExtension()).toBeUndefined();
       });
 
-      it('should throw if no jest instance found for workspace', async () => {
-        extensionManager.getByName = jest.fn().mockReturnValue(undefined);
-        let error;
-        try {
-          await extensionManager.selectExtension();
-        } catch (e) {
-          error = e;
-        }
-        expect(error).toBeDefined();
+      it('could select from a list of extensions passed in', async () => {
+        const ext1 = makeJestExt(makeWorkspaceFolder('ext1'));
+        const ext2 = makeJestExt(makeWorkspaceFolder('ext2'));
+
+        (vscode.window.showQuickPick as any).mockReturnValue('ext1');
+        expect(await extensionManager.selectExtension([ext1, ext2])).toBe(ext1);
+        expect(vscode.window.showQuickPick).toHaveBeenCalledWith(['ext1', 'ext2'], {
+          canPickMany: false,
+        });
+      });
+      it('will show v-folders in the picker', async () => {
+        const ws1 = makeWorkspaceFolder('ws-1');
+        const ws2 = makeWorkspaceFolder('ws-2');
+        const v_1 = new VirtualWorkspaceFolder(ws2, 'ws-2-front');
+        const v_2 = new VirtualWorkspaceFolder(ws2, 'ws-2-back');
+        mockEnabledWorkspaceFolders.mockReturnValue([ws1, v_1, v_2]);
+        extensionManager.applySettings();
+
+        (vscode.window.showQuickPick as any).mockReturnValue(v_1.name);
+        expect(await extensionManager.selectExtension()).toBe(
+          jestInstances.find((ext) => ext.name === v_1.name)
+        );
+        expect(vscode.window.showQuickPick).toHaveBeenCalledWith([ws1.name, v_1.name, v_2.name], {
+          canPickMany: false,
+        });
+      });
+    });
+    describe('selectExtensions()', () => {
+      it('can select multiple extensions', async () => {
+        const ext1 = makeJestExt(makeWorkspaceFolder('ext1'));
+        const ext2 = makeJestExt(makeWorkspaceFolder('ext2'));
+        const ext3 = makeJestExt(makeWorkspaceFolder('ext3'));
+
+        (vscode.window.showQuickPick as any).mockReturnValue(['ext1', 'ext2']);
+        expect(await extensionManager.selectExtensions([ext1, ext2, ext3])).toEqual([ext1, ext2]);
+        expect(vscode.window.showQuickPick).toHaveBeenCalledWith(['ext1', 'ext2', 'ext3'], {
+          canPickMany: true,
+        });
       });
     });
 
@@ -333,8 +457,8 @@ describe('ExtensionManager', () => {
           const callback = jest.fn();
           const someObject = {};
 
-          const // recreate extensionManager with new workspaceFolders
-            extensionManager = createExtensionManager(['ws-1', 'ws-2']);
+          // recreate extensionManager with new workspaceFolders
+          extensionManager = createExtensionManager(['ws-1', 'ws-2']);
           jest.clearAllMocks();
 
           extensionManager.registerCommand(
@@ -353,45 +477,90 @@ describe('ExtensionManager', () => {
             )
           );
         });
-        it('can execute command for the selected workspace', async () => {
-          const callback = jest.fn();
-          extensionManager = createExtensionManager(['ws-1', 'ws-2']);
-          jest.clearAllMocks();
+        it.each`
+          selections          | calledTimes
+          ${undefined}        | ${0}
+          ${'ws-1'}           | ${1}
+          ${['ws-1']}         | ${1}
+          ${['ws-1', 'ws-2']} | ${2}
+        `(
+          'can execute command for a selected workspaces: $selections',
+          async ({ selections, calledTimes }) => {
+            const callback = jest.fn();
+            extensionManager = createExtensionManager(['ws-1', 'ws-2']);
+            jest.clearAllMocks();
 
-          (vscode.window.showQuickPick as jest.Mocked<any>).mockReturnValue(
-            vscode.workspace.workspaceFolders[1].name
-          );
+            (vscode.window.showQuickPick as jest.Mocked<any>).mockReturnValue(selections);
 
-          extensionManager.registerCommand({
-            type: 'select-workspace',
-            name: 'something',
-            callback,
+            extensionManager.registerCommand({
+              type: 'select-workspace',
+              name: 'something',
+              callback,
+            });
+            const registeredCallback = (vscode.commands.registerCommand as jest.Mocked<any>).mock
+              .calls[0][1];
+            await registeredCallback('arg1', 2);
+            expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledTimes(calledTimes);
+            if (typeof selections === 'string') {
+              expect(callback).toHaveBeenCalledWith(
+                extensionManager.getByName(selections),
+                'arg1',
+                2
+              );
+            } else if (Array.isArray(selections)) {
+              selections.forEach((ws) =>
+                expect(callback).toHaveBeenCalledWith(extensionManager.getByName(ws), 'arg1', 2)
+              );
+            } else {
+              expect(callback).not.toHaveBeenCalled();
+            }
+          }
+        );
+        describe('can execute command with a workspaces', () => {
+          it('when no virtual folder, the command will be executed with the workspace', async () => {
+            const callback = jest.fn();
+            const someObject = {};
+
+            // recreate extensionManager with new workspaceFolders
+            extensionManager = createExtensionManager(['ws-1', 'ws-2']);
+            jest.clearAllMocks();
+
+            extensionManager.registerCommand(
+              { type: 'workspace', name: 'something', callback },
+              someObject
+            );
+            const registeredCallback = (vscode.commands.registerCommand as jest.Mocked<any>).mock
+              .calls[0][1];
+            await registeredCallback({ name: 'ws-2' }, 'extra');
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledWith(extensionManager.getByName('ws-2'), 'extra');
           });
-          const registeredCallback = (vscode.commands.registerCommand as jest.Mocked<any>).mock
-            .calls[0][1];
-          await registeredCallback('arg1', 2);
-          expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
-          expect(callback).toHaveBeenCalledTimes(1);
-          expect(callback).toHaveBeenCalledWith(extensionManager.getByName('ws-2'), 'arg1', 2);
-        });
-        it('can execute command with a workspaces', async () => {
-          const callback = jest.fn();
-          const someObject = {};
+          it('if the workspace has virtual folders, a chooser will be prompted', async () => {
+            const { ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+            jest.clearAllMocks();
 
-          // recreate extensionManager with new workspaceFolders
-          extensionManager = createExtensionManager(['ws-1', 'ws-2']);
-          jest.clearAllMocks();
+            const callback = jest.fn();
+            const someObject = {};
 
-          extensionManager.registerCommand(
-            { type: 'workspace', name: 'something', callback },
-            someObject
-          );
-          const registeredCallback = (vscode.commands.registerCommand as jest.Mocked<any>).mock
-            .calls[0][1];
-          await registeredCallback({ name: 'ws-2' }, 'extra');
+            (vscode.window.showQuickPick as jest.Mocked<any>).mockReturnValue([ws2_v2.name]);
 
-          expect(callback).toHaveBeenCalledTimes(1);
-          expect(callback).toHaveBeenCalledWith(extensionManager.getByName('ws-2'), 'extra');
+            extensionManager.registerCommand(
+              { type: 'workspace', name: 'something', callback },
+              someObject
+            );
+            const registeredCallback = (vscode.commands.registerCommand as jest.Mocked<any>).mock
+              .calls[0][1];
+            await registeredCallback(ws2, 'extra');
+
+            expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
+            expect(vscode.window.showQuickPick).toHaveBeenCalledWith([ws2_v1.name, ws2_v2.name], {
+              canPickMany: false,
+            });
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledWith(extensionManager.getByName(ws2_v2.name), 'extra');
+          });
         });
       });
       describe.each`
@@ -402,9 +571,9 @@ describe('ExtensionManager', () => {
         const callback = jest.fn();
         const editor = makeEditor('ws-1');
         beforeEach(() => {
+          jest.clearAllMocks();
           // recreate extensionManager with new workspaceFolders
           extensionManager = createExtensionManager(['ws-1', 'ws-2']);
-          jest.clearAllMocks();
         });
         it('can generate command id by type', () => {
           extensionManager.registerCommand({ type, name: 'something', callback: jest.fn() });
@@ -444,6 +613,34 @@ describe('ExtensionManager', () => {
           registeredCallback(editor, {}, 'addtional argument');
           expect(callback).not.toHaveBeenCalled();
         });
+        it('will prompt a chooser if the active workspace has virtual folders', async () => {
+          const { ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+          jest.clearAllMocks();
+
+          const callback = jest.fn();
+          (vscode.window.showQuickPick as jest.Mocked<any>).mockReturnValue([ws2_v2.name]);
+
+          extensionManager.registerCommand({
+            type,
+            name: 'something',
+            callback,
+          });
+          const registeredCallback = (vscode.commands.registerTextEditorCommand as jest.Mocked<any>)
+            .mock.calls[0][1];
+          const editor = makeEditor(ws2.name);
+          await registeredCallback(editor, {}, 'addtional argument');
+
+          expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
+          expect(vscode.window.showQuickPick).toHaveBeenCalledWith([ws2_v1.name, ws2_v2.name], {
+            canPickMany: true,
+          });
+          expect(callback).toHaveBeenCalledTimes(1);
+          expect(callback).toHaveBeenCalledWith(
+            extensionManager.getByName(ws2_v2.name),
+            editor,
+            'addtional argument'
+          );
+        });
       });
     });
 
@@ -457,7 +654,7 @@ describe('ExtensionManager', () => {
             if (typeof value === 'boolean') {
               return value;
             }
-            return !scope || value.includes(scope?.fsPath);
+            return !scope || value.includes(scope?.uri.fsPath);
           }
         });
         return { affectsConfiguration };
@@ -473,7 +670,7 @@ describe('ExtensionManager', () => {
           eventValue          | EMCount | Ws1Count | Ws2Count
           ${true}             | ${1}    | ${1}     | ${1}
           ${false}            | ${0}    | ${0}     | ${0}
-          ${['ws-2']}         | ${0}    | ${0}     | ${1}
+          ${['ws-2']}         | ${1}    | ${0}     | ${1}
           ${['ws-1']}         | ${1}    | ${1}     | ${0}
           ${['ws-3']}         | ${0}    | ${0}     | ${0}
           ${['ws-1', 'ws-3']} | ${1}    | ${1}     | ${0}
@@ -511,7 +708,7 @@ describe('ExtensionManager', () => {
         });
         it('will register newly enabled workspace', () => {
           const [ws1, ws2] = vscode.workspace.workspaceFolders;
-          extensionManager.unregisterWorkspace(ws1);
+          extensionManager.deleteExtensionByFolder(ws1);
           expect(extensionManager.getByName(ws1.name)).toBeUndefined();
           expect(extensionManager.getByName(ws2.name)).not.toBeUndefined();
 
@@ -523,8 +720,74 @@ describe('ExtensionManager', () => {
 
           extensionManager.onDidChangeConfiguration(event);
           expect(applySettingsSpy).toHaveBeenCalledTimes(1);
-          expect(extensionManager.getByName(ws1.name)).not.toBeUndefined();
-          expect(extensionManager.getByName(ws2.name)).not.toBeUndefined();
+          expect(extensionManager.getByName(ws1.name)).toBeDefined();
+          expect(extensionManager.getByName(ws2.name)).toBeDefined();
+        });
+        describe('when workspace with virtual folders is changed', () => {
+          let v1, v2;
+          beforeEach(() => {
+            const [, ws2] = vscode.workspace.workspaceFolders;
+            v1 = new VirtualWorkspaceFolder(ws2, 'ws-2-front');
+            v2 = new VirtualWorkspaceFolder(ws2, 'ws-2-back');
+          });
+          it('when new v-folder is added, they should be registered and notified', () => {
+            const [ws1, ws2] = vscode.workspace.workspaceFolders;
+            mockEnabledWorkspaceFolders.mockReturnValue([ws1, v1]);
+            extensionManager.applySettings();
+            expect(extensionManager.getByName(v1.name)).toBeDefined();
+            expect(extensionManager.getByName(ws2.name)).toBeUndefined();
+
+            // adding v2 virtual folders in ws2
+            const event = mockEvent(true);
+            event.affectsConfiguration.mockImplementation((section: string, scope: any) => {
+              if (scope?.name === ws2.name && section === 'jest') {
+                return true;
+              }
+              return false;
+            });
+            mockEnabledWorkspaceFolders.mockReturnValue([ws1, v1, v2]);
+
+            applySettingsSpy.mockClear();
+            extensionManager.onDidChangeConfiguration(event);
+            expect(applySettingsSpy).toHaveBeenCalledTimes(1);
+            [ws1, v1, v2].forEach((ws) =>
+              expect(extensionManager.getByName(ws.name)).toBeDefined()
+            );
+
+            [v1, v2].forEach((folder) => {
+              const ext = extensionManager.getByName(folder.name);
+              expect(ext?.triggerUpdateSettings).toHaveBeenCalledTimes(1);
+            });
+            expect(ws1Ext.triggerUpdateSettings).not.toHaveBeenCalled();
+            expect(ws2Ext.triggerUpdateSettings).not.toHaveBeenCalled();
+          });
+          it('when venv is removed or disabled, they should be unregistered', () => {
+            const [ws1, ws2] = vscode.workspace.workspaceFolders;
+            mockEnabledWorkspaceFolders.mockReturnValue([ws1, v1, v2]);
+            extensionManager.applySettings();
+            expect(extensionManager.getByName(v1.name)).toBeDefined();
+            expect(extensionManager.getByName(v2.name)).toBeDefined();
+
+            // adding a new venv v2
+            const event = mockEvent(true);
+            event.affectsConfiguration.mockImplementation((section: string, scope: any) => {
+              if (scope?.name === ws2.name) {
+                if (section === 'jest.venv' || section === 'jest') {
+                  return true;
+                }
+              }
+              return false;
+            });
+            mockEnabledWorkspaceFolders.mockReturnValue([ws1, v2]);
+
+            applySettingsSpy.mockClear();
+            extensionManager.onDidChangeConfiguration(event);
+            expect(applySettingsSpy).toHaveBeenCalledTimes(1);
+            [ws1, v2].forEach((ws) => {
+              expect(extensionManager.getByName(ws.name)).toBeDefined();
+            });
+            expect(extensionManager.getByName(v1.name)).toBeUndefined();
+          });
         });
       });
     });
@@ -532,90 +795,168 @@ describe('ExtensionManager', () => {
     describe('onDidChangeWorkspaceFolders()', () => {
       it('will ignore folder change if IgnoreWorkspaceChanges is true', () => {
         context.workspaceState.get.mockReturnValue(true);
-        extensionManager.onDidChangeWorkspaceFolders({
-          added: [makeWorkspaceFolder('wokspaceFolderAdded')],
-          removed: [],
-        } as any);
+        extensionManager.onDidChangeWorkspaceFolders();
         expect(registerSpy).not.toHaveBeenCalled();
       });
-      it('should register all new folders', () => {
-        extensionManager.onDidChangeWorkspaceFolders({
-          added: [makeWorkspaceFolder('wokspaceFolderAdded')],
-          removed: [],
-        } as any);
-        expect(registerSpy).toHaveBeenCalledTimes(1);
+      it('should add/remove extensions for the added/removed folders', () => {
+        const f1 = makeWorkspaceFolder('added-1');
+        const f2 = makeWorkspaceFolder('added-2');
+
+        expect(extensionManager.getByName(workspaceFolder1.name)).toBeDefined();
+
+        // added 2 folders
+        (vscode.workspace as any).workspaceFolders = [workspaceFolder1, f1, f2];
+        // but only f1 is enabled
+        mockEnabledWorkspaceFolders.mockReturnValue([workspaceFolder1, f1]);
+
+        extensionManager.onDidChangeWorkspaceFolders();
+
+        expect(extensionManager.getByName(workspaceFolder1.name)).toBeDefined();
+        expect(extensionManager.getByName(f1.name)).toBeDefined();
+        expect(extensionManager.getByName(f2.name)).not.toBeDefined();
+
+        // removed f1
+        (vscode.workspace as any).workspaceFolders = [workspaceFolder1, f2];
+        mockEnabledWorkspaceFolders.mockReturnValue([workspaceFolder1]);
+
+        extensionManager.onDidChangeWorkspaceFolders();
+
+        expect(extensionManager.getByName(workspaceFolder1.name)).toBeDefined();
+        expect(extensionManager.getByName(f1.name)).not.toBeDefined();
+        expect(extensionManager.getByName(f2.name)).not.toBeDefined();
       });
 
-      it('should unregister all removed folders', () => {
-        const ws = makeWorkspaceFolder('wokspaceFolderToRemove');
-        extensionManager.registerWorkspace(ws);
-        extensionManager.onDidChangeWorkspaceFolders({
-          added: [],
-          removed: [ws],
-        } as any);
-        expect(unregisterSpy).toHaveBeenCalledTimes(1);
+      describe('when virtual folders are used', () => {
+        it('if a physical workspace folder is removed, it should unregister all virtual extensions under it', () => {
+          const { ws1, ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+
+          // verify these folder are registered
+          [ws1, ws2_v1, ws2_v2].forEach((folder) => {
+            expect(extensionManager.getByName(folder.name)).toBeDefined();
+          });
+          // ws2 is not registered because it used virtual folders
+          expect(extensionManager.getByName(ws2.name)).not.toBeDefined();
+
+          // now remove ws2, we should expect all virtual folders under it are unregistered
+          (vscode.workspace as any).workspaceFolders = [workspaceFolder1, ws1];
+          mockEnabledWorkspaceFolders.mockReturnValue([ws1]);
+
+          extensionManager.onDidChangeWorkspaceFolders();
+
+          [ws2, ws2_v1, ws2_v2].forEach((folder) => {
+            expect(extensionManager.getByName(folder.name)).not.toBeDefined();
+          });
+        });
+        it('can add or remove virtual folders', () => {
+          const { ws1, ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+
+          // adding a virtual folder ws2_v3
+          const ws2_v3 = new VirtualWorkspaceFolder(ws2.name, 'ws-2-v3');
+
+          mockEnabledWorkspaceFolders.mockReturnValue([ws1, ws2_v1, ws2_v2, ws2_v3]);
+          extensionManager.onDidChangeWorkspaceFolders();
+          expect(extensionManager.getByName(ws2_v3.name)).toBeDefined();
+          expect(extensionManager.getByName(ws2_v1.name)).toBeDefined();
+
+          // removing ws2_v1
+          mockEnabledWorkspaceFolders.mockReturnValue([ws1, ws2_v2, ws2_v3]);
+          extensionManager.onDidChangeWorkspaceFolders();
+          expect(extensionManager.getByName(ws2_v3.name)).toBeDefined();
+          expect(extensionManager.getByName(ws2_v1.name)).not.toBeDefined();
+        });
       });
     });
 
     describe('onDidCloseTextDocument()', () => {
       afterEach(() => {
-        jestInstance.onDidCloseTextDocument.mockClear();
+        jestInstances[0].onDidCloseTextDocument.mockClear();
       });
       it('should call extension method', () => {
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce({
           name: 'workspaceFolder1',
         });
         extensionManager.onDidCloseTextDocument({} as any);
-        expect(jestInstance.onDidCloseTextDocument).toHaveBeenCalled();
+        expect(jestInstances[0].onDidCloseTextDocument).toHaveBeenCalled();
       });
 
       it('should not call try to call extension method if no extension', () => {
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(undefined);
         extensionManager.onDidCloseTextDocument({} as any);
-        expect(jestInstance.onDidCloseTextDocument).not.toHaveBeenCalled();
+        expect(jestInstances[0].onDidCloseTextDocument).not.toHaveBeenCalled();
+      });
+      it('will notify all extensions under the same actual workspace folder', () => {
+        const { ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+
+        // close a document in ws2, we should expect all extensions under ws2 are notified
+        (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(ws2);
+        extensionManager.onDidCloseTextDocument({} as any);
+        expect(extensionManager.getByName(ws2_v1.name)?.onDidCloseTextDocument).toHaveBeenCalled();
+        expect(extensionManager.getByName(ws2_v2.name)?.onDidCloseTextDocument).toHaveBeenCalled();
       });
     });
 
     describe('onDidChangeActiveTextEditor()', () => {
       afterEach(() => {
-        jestInstance.onDidChangeActiveTextEditor.mockClear();
+        jestInstances[0].onDidChangeActiveTextEditor.mockClear();
       });
       it('should call extension method', () => {
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce({
           name: 'workspaceFolder1',
         });
         extensionManager.onDidChangeActiveTextEditor({ document: {} } as any);
-        expect(jestInstance.onDidChangeActiveTextEditor).toHaveBeenCalled();
+        expect(jestInstances[0].onDidChangeActiveTextEditor).toHaveBeenCalled();
       });
 
       it('should not call try to call extension method if no document', () => {
         extensionManager.onDidChangeActiveTextEditor({} as any);
-        expect(jestInstance.onDidChangeActiveTextEditor).not.toHaveBeenCalled();
+        expect(jestInstances[0].onDidChangeActiveTextEditor).not.toHaveBeenCalled();
       });
 
       it('should not call try to call extension method if no extension', () => {
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(undefined);
         extensionManager.onDidChangeActiveTextEditor({ document: {} } as any);
-        expect(jestInstance.onDidChangeActiveTextEditor).not.toHaveBeenCalled();
+        expect(jestInstances[0].onDidChangeActiveTextEditor).not.toHaveBeenCalled();
+      });
+      it('will notify all extensions under the same actual workspace folder', () => {
+        const { ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+
+        // close a document in ws2, we should expect all extensions under ws2 are notified
+        (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(ws2);
+        extensionManager.onDidChangeActiveTextEditor({ document: {} } as any);
+        expect(
+          extensionManager.getByName(ws2_v1.name)?.onDidChangeActiveTextEditor
+        ).toHaveBeenCalled();
+        expect(
+          extensionManager.getByName(ws2_v2.name)?.onDidChangeActiveTextEditor
+        ).toHaveBeenCalled();
       });
     });
 
     describe('onDidChangeTextDocument()', () => {
       afterEach(() => {
-        jestInstance.onDidChangeTextDocument.mockClear();
+        jestInstances[0].onDidChangeTextDocument.mockClear();
       });
       it('should call extension method', () => {
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce({
           name: 'workspaceFolder1',
         });
         extensionManager.onDidChangeTextDocument({ document: {} } as any);
-        expect(jestInstance.onDidChangeTextDocument).toHaveBeenCalled();
+        expect(jestInstances[0].onDidChangeTextDocument).toHaveBeenCalled();
       });
 
       it('should not call try to call extension method if no extension', () => {
         (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(undefined);
         extensionManager.onDidChangeTextDocument({ document: {} } as any);
-        expect(jestInstance.onDidChangeTextDocument).not.toHaveBeenCalled();
+        expect(jestInstances[0].onDidChangeTextDocument).not.toHaveBeenCalled();
+      });
+      it('will notify all extensions under the same actual workspace folder', () => {
+        const { ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+
+        // close a document in ws2, we should expect all extensions under ws2 are notified
+        (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(ws2);
+        extensionManager.onDidChangeTextDocument({ document: {} } as any);
+        expect(extensionManager.getByName(ws2_v1.name)?.onDidChangeTextDocument).toHaveBeenCalled();
+        expect(extensionManager.getByName(ws2_v2.name)?.onDidChangeTextDocument).toHaveBeenCalled();
       });
     });
 
@@ -691,6 +1032,16 @@ describe('ExtensionManager', () => {
         extensionManager.onWillSaveTextDocument(event);
         expect(ext1.onWillSaveTextDocument).toHaveBeenCalledTimes(1);
         expect(ext2.onWillSaveTextDocument).toHaveBeenCalledTimes(1);
+      });
+      it('will notify all extensions under the same actual workspace folder', () => {
+        const { ws2, ws2_v1, ws2_v2 } = setupVirtualFolders(extensionManager);
+
+        // close a document in ws2, we should expect all extensions under ws2 are notified
+        const event: any = { document: {} };
+        (vscode.workspace.getWorkspaceFolder as any).mockReturnValueOnce(ws2);
+        extensionManager.onWillSaveTextDocument(event);
+        expect(extensionManager.getByName(ws2_v1.name)?.onWillSaveTextDocument).toHaveBeenCalled();
+        expect(extensionManager.getByName(ws2_v2.name)?.onWillSaveTextDocument).toHaveBeenCalled();
       });
     });
     describe('register', () => {
@@ -858,7 +1209,10 @@ describe('ExtensionManager', () => {
                 expect.anything()
               );
             } else {
-              expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+              expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
+                'vscode.open',
+                expect.anything()
+              );
             }
           } else {
             expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();

--- a/tests/setup-wizard/start-wizard.test.ts
+++ b/tests/setup-wizard/start-wizard.test.ts
@@ -1,5 +1,6 @@
 jest.unmock('../../src/setup-wizard/start-wizard');
 jest.unmock('./test-helper');
+jest.unmock('../test-helper');
 import * as vscode from 'vscode';
 
 import {
@@ -10,7 +11,8 @@ import {
 } from '../../src/setup-wizard/start-wizard';
 import { showActionMenu } from '../../src/setup-wizard/wizard-helper';
 import * as tasks from '../../src/setup-wizard/tasks';
-import { mockWizardHelper, throwError, workspaceFolder } from './test-helper';
+import { mockWizardHelper, throwError } from './test-helper';
+import { makeWorkspaceFolder } from '../test-helper';
 import * as helper from '../../src/setup-wizard/wizard-helper';
 
 const mockTasks = tasks as jest.Mocked<any>;
@@ -64,7 +66,7 @@ describe('startWizard', () => {
       async ({ taskResult, menuCallCount, wizardResult }) => {
         expect.hasAssertions();
         console.error = jest.fn();
-        (vscode.workspace as any).workspaceFolders = [workspaceFolder('single-root')];
+        (vscode.workspace as any).workspaceFolders = [makeWorkspaceFolder('single-root')];
         mockShowActionMenu(menuId, StartWizardActionId.exit);
         const task = WizardTasks[taskId].task;
         task.mockImplementation(() => {
@@ -90,7 +92,7 @@ describe('startWizard', () => {
     `('invoke directly: $taskResult => $wizardResult', async ({ taskResult, wizardResult }) => {
       expect.hasAssertions();
       console.error = jest.fn();
-      const workspace = workspaceFolder('w-1');
+      const workspace = makeWorkspaceFolder('w-1');
       const task = WizardTasks[taskId].task;
       task.mockImplementation(() => {
         if (typeof taskResult === 'function') {
@@ -117,7 +119,7 @@ describe('startWizard', () => {
   });
   it('has a verbose mode', async () => {
     expect.hasAssertions();
-    (vscode.workspace as any).workspaceFolders = [workspaceFolder('single-root')];
+    (vscode.workspace as any).workspaceFolders = [makeWorkspaceFolder('single-root')];
     const mockLog = jest.fn();
     console.log = mockLog;
 

--- a/tests/setup-wizard/tasks/setup-jest-cmdline.test.ts
+++ b/tests/setup-wizard/tasks/setup-jest-cmdline.test.ts
@@ -1,5 +1,6 @@
 jest.unmock('../../../src/setup-wizard/tasks/setup-jest-cmdline');
 jest.unmock('../test-helper');
+jest.unmock('../../test-helper');
 jest.unmock('./task-test-helper');
 
 import * as vscode from 'vscode';
@@ -73,9 +74,9 @@ describe('wizard-tasks', () => {
         await setupJestCmdLine(c);
 
         if (wsInContext) {
-          expect(mockHelper.selectWorkspace).not.toHaveBeenCalled();
+          expect(mockHelper.selectWorkspaceFolder).not.toHaveBeenCalled();
         } else {
-          expect(mockHelper.selectWorkspace).toHaveBeenCalled();
+          expect(mockHelper.selectWorkspaceFolder).toHaveBeenCalled();
         }
         if (willAbort) {
           expect(mockHelper.showActionMenu).not.toHaveBeenCalled();
@@ -147,11 +148,15 @@ describe('wizard-tasks', () => {
 
           expect(wizardSettings[setting]).toEqual(newValue);
 
-          expect(mockSaveConfig).toHaveBeenCalledTimes(2);
-          expect(mockSaveConfig).toHaveBeenCalledWith({
-            name: `jest.${setting}`,
-            value: newValue,
-          });
+          expect(mockSaveConfig).toHaveBeenCalledTimes(1);
+          expect(mockSaveConfig.mock.calls[0]).toEqual(
+            expect.arrayContaining([
+              {
+                name: `jest.${setting}`,
+                value: newValue,
+              },
+            ])
+          );
         });
       });
     });

--- a/tests/setup-wizard/tasks/task-test-helper.ts
+++ b/tests/setup-wizard/tasks/task-test-helper.ts
@@ -1,10 +1,10 @@
-import { workspaceFolder } from '../test-helper';
+import { makeWorkspaceFolder } from '../../test-helper';
 import * as path from 'path';
 
 export const createWizardContext = (debugConfigProvider: any, wsName?: string): any => ({
   debugConfigProvider,
   wsManager: {
-    getValidWorkspaces: jest.fn(),
+    getValidWorkspaceFolders: jest.fn(),
     getFoldersFromFilesystem: jest.fn(),
   },
   vscodeContext: {
@@ -17,7 +17,7 @@ export const createWizardContext = (debugConfigProvider: any, wsName?: string): 
       update: jest.fn(),
     },
   },
-  workspace: wsName ? workspaceFolder(wsName) : undefined,
+  workspace: wsName ? makeWorkspaceFolder(wsName) : undefined,
   message: jest.fn(),
 });
 

--- a/tests/setup-wizard/test-helper.ts
+++ b/tests/setup-wizard/test-helper.ts
@@ -34,7 +34,7 @@ export const mockWizardHelper = (mockHelper: jest.Mocked<any>): any => {
     }));
   };
   const mockSelectWorkspace = (ws?: string) => {
-    mockHelper.selectWorkspace.mockImplementation(() => Promise.resolve(ws));
+    mockHelper.selectWorkspaceFolder.mockImplementation(() => Promise.resolve(ws));
   };
   return {
     mockShowActionMenu,
@@ -47,8 +47,3 @@ export const mockWizardHelper = (mockHelper: jest.Mocked<any>): any => {
 export const throwError = (msg: string): void => {
   throw new Error(msg);
 };
-
-export const workspaceFolder = (name: string): any => ({
-  name,
-  uri: { fsPath: name, path: name },
-});

--- a/tests/setup-wizard/wizard-helper.test.ts
+++ b/tests/setup-wizard/wizard-helper.test.ts
@@ -730,6 +730,23 @@ describe('createSaveConfig', () => {
       vscode.ConfigurationTarget.Workspace
     );
   });
+  it('will svae to actual workspace folder for vertual workspace folder', async () => {
+    expect.hasAssertions();
+    mockUpdate.mockReturnValue(Promise.resolve());
+    const ws = makeWorkspaceFolder('ws');
+    context.workspace = new VirtualWorkspaceFolder(ws, 'virtual');
+    const saveConfig = createSaveConfig(context);
+    const entry = { name: 'jest.virtualFolders', value: '[]' };
+    await saveConfig(entry);
+
+    expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith(undefined, ws.uri);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      entry.name,
+      entry.value,
+      vscode.ConfigurationTarget.WorkspaceFolder
+    );
+  });
   it('when save failed, throws error', async () => {
     expect.hasAssertions();
     mockUpdate

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -229,7 +229,6 @@ expect.extend({
 export const makeWorkspaceFolder = (name: string): any => ({
   uri: makeUri(name),
   name,
-  path: name,
 });
 export const makeUri = (...parts: string[]): any => ({
   fsPath: parts.join(path.sep),

--- a/tests/test-provider/test-item-data.test.ts
+++ b/tests/test-provider/test-item-data.test.ts
@@ -179,6 +179,11 @@ describe('test-item-data', () => {
   });
   describe('discover children', () => {
     describe('WorkspaceRoot', () => {
+      it('has no parent item and the id should contain the workspace name', () => {
+        const wsRoot = new WorkspaceRoot(context);
+        expect(wsRoot.item.parent).toBeUndefined();
+        expect(wsRoot.item.id).toEqual(expect.stringContaining(`:${context.ext.workspace.name}`));
+      });
       it('create test document tree for testFiles list', () => {
         const testFiles = [
           '/ws-1/src/a.test.ts',

--- a/tests/test-provider/test-item-data.test.ts
+++ b/tests/test-provider/test-item-data.test.ts
@@ -9,6 +9,7 @@ jest.unmock('../../src/errors');
 
 import { JestTestRun } from '../../src/test-provider/test-provider-helper';
 import { tiContextManager } from '../../src/test-provider/test-item-context-manager';
+import { toAbsoluteRootPath } from '../../src/helpers';
 
 jest.mock('path', () => {
   let sep = '/';
@@ -173,6 +174,8 @@ describe('test-item-data', () => {
     (tiContextManager.setItemContext as jest.Mocked<any>).mockClear();
 
     (vscode.Location as jest.Mocked<any>).mockReturnValue({});
+
+    (toAbsoluteRootPath as jest.Mocked<any>).mockImplementation((p) => p.uri.fsPath);
   });
   describe('discover children', () => {
     describe('WorkspaceRoot', () => {

--- a/tests/virtual-workspace-folder.test.ts
+++ b/tests/virtual-workspace-folder.test.ts
@@ -9,199 +9,203 @@ import {
   VirtualFolderBasedCache,
 } from '../src/virtual-workspace-folder';
 import { makeWorkspaceFolder, makeUri } from './test-helper';
+import { toAbsoluteRootPath } from '../src/helpers';
 
-describe('VirtualWorkspaceFolder', () => {
-  const workspaceFolder = makeWorkspaceFolder(path.join(__dirname, 'my-workspace'));
-  const vFolderName = 'v1';
-  const vFolderRootPath = path.join('packages', 'v1'); // a relative path
-  let virtualFolder;
+describe('virtual-workspace-folder', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    vscode.Uri.joinPath = jest
+    (toAbsoluteRootPath as jest.Mocked<any>) = jest
       .fn()
-      .mockImplementation((uri, p) => ({ fsPath: path.join(uri.fsPath, p) }));
+      .mockImplementation((folder, p) => path.join(folder.uri.fsPath, p));
     vscode.Uri.file = jest.fn().mockImplementation((f) => ({ fsPath: f }));
-    virtualFolder = new VirtualWorkspaceFolder(workspaceFolder, vFolderName, vFolderRootPath);
   });
-
-  it('should have the correct name', () => {
-    expect(virtualFolder.name).toEqual(vFolderName);
-  });
-
-  it('should have the correct uri that includes rootPath', () => {
-    expect(virtualFolder.uri.fsPath).toEqual(
-      path.join(workspaceFolder.uri.fsPath, vFolderRootPath)
-    );
-  });
-
-  it('can take both absolute or relative rootPath', () => {
-    //make an absolute path
-    const rootPath = path.join(workspaceFolder.uri.fsPath, 'packages', 'v1');
-    const folder2 = new VirtualWorkspaceFolder(workspaceFolder, vFolderName, rootPath);
-    expect(folder2.uri.fsPath).toEqual(virtualFolder.uri.fsPath);
-  });
-  it('if no rootPath is given, the uri is the same as the actual workspace folder', () => {
-    const folder2 = new VirtualWorkspaceFolder(workspaceFolder, vFolderName);
-    expect(folder2.uri.fsPath).toEqual(workspaceFolder.uri.fsPath);
-  });
-  it('should have the same index as the actual workspace folder', () => {
-    workspaceFolder.index = 1;
-    expect(virtualFolder.index).toEqual(workspaceFolder.index);
-  });
-
-  describe('should correctly determine if a uri is in the workspace', () => {
-    it.each`
-      case | pathComps                                | expected
-      ${1} | ${['packages', 'v1', 'src', 'index.ts']} | ${true}
-      ${2} | ${['packages', 'v2', 'src', 'index.ts']} | ${false}
-      ${3} | ${['src', 'index.ts']}                   | ${false}
-    `('case $case: can determine if a uri is in the workspace', ({ pathComps, expected }) => {
-      const uri = makeUri(workspaceFolder.uri.fsPath, ...pathComps);
-      expect(virtualFolder.isInWorkspaceFolder(uri)).toBe(expected);
-    });
-  });
-  it('isVirtualWorkspaceFolder can determine if a workspace folder is virtual', () => {
-    expect(isVirtualWorkspaceFolder(virtualFolder)).toBe(true);
-    expect(isVirtualWorkspaceFolder(workspaceFolder)).toBe(false);
-  });
-});
-
-const makeCacheItem = (workspaceFolder: vscode.WorkspaceFolder): any => ({ workspaceFolder });
-type CacheItem = ReturnType<typeof makeCacheItem>;
-
-describe('VirtualFolderBasedCache', () => {
-  let cache: VirtualFolderBasedCache<CacheItem>;
-
-  beforeEach(() => {
-    cache = new VirtualFolderBasedCache();
-  });
-
-  it('can add, get and delete items by folder name', () => {
-    const item = makeCacheItem(makeWorkspaceFolder('folder1'));
-    cache.addItem(item);
-    expect(cache.getItemByFolderName('folder1')).toBe(item);
-    expect(cache.size).toBe(1);
-
-    cache.deleteItemByFolder(item.workspaceFolder);
-    expect(cache.size).toBe(0);
-    expect(cache.getItemByFolderName('folder1')).toBeUndefined();
-    expect(cache.getItemsByActualFolderName('folder1')).toBeUndefined();
-  });
-  it('adding existing item will replace the old one', () => {
-    const item = makeCacheItem(makeWorkspaceFolder('folder1'));
-    cache.addItem(item);
-    expect(cache.getItemByFolderName('folder1')).toBe(item);
-    expect(cache.size).toBe(1);
-
-    const item2 = makeCacheItem(makeWorkspaceFolder('folder1'));
-    cache.addItem(item2);
-    expect(cache.getItemByFolderName('folder1')).toBe(item2);
-    expect(cache.size).toBe(1);
-  });
-
-  describe('with virtual folders', () => {
-    let item1, item2, item3;
+  describe('VirtualWorkspaceFolder', () => {
+    const workspaceFolder = makeWorkspaceFolder(path.join(__dirname, 'my-workspace'));
+    const vFolderName = 'v1';
+    const vFolderRootPath = path.join('packages', 'v1'); // a relative path
+    let virtualFolder;
     beforeEach(() => {
-      vscode.Uri.file = jest.fn().mockImplementation((f) => ({ fsPath: f }));
-      vscode.Uri.joinPath = jest
-        .fn()
-        .mockImplementation((uri, ...parts) => makeUri(uri.fsPath, ...parts));
-
-      item1 = makeCacheItem(makeWorkspaceFolder('folder1'));
-      item2 = makeCacheItem(
-        new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder2', 'folder2')
-      );
-      item3 = makeCacheItem(
-        new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder3', 'folder3')
-      );
+      virtualFolder = new VirtualWorkspaceFolder(workspaceFolder, vFolderName, vFolderRootPath);
     });
 
-    it('can retrieve items by actual folder name', () => {
+    it('should have the correct name', () => {
+      expect(virtualFolder.name).toEqual(vFolderName);
+    });
+
+    it('should returns the same uri as the actual folder', () => {
+      expect(virtualFolder.uri).toEqual(workspaceFolder.uri);
+    });
+
+    it('can take both absolute or relative rootPath', () => {
+      //make an absolute path
+      const rootPath = path.join(workspaceFolder.uri.fsPath, 'packages', 'v1');
+      const folder2 = new VirtualWorkspaceFolder(workspaceFolder, vFolderName, rootPath);
+      expect(folder2.uri.fsPath).toEqual(virtualFolder.uri.fsPath);
+      expect(toAbsoluteRootPath).toHaveBeenCalled();
+    });
+    it('if no rootPath is given, the uri is the same as the actual workspace folder', () => {
+      const folder2 = new VirtualWorkspaceFolder(workspaceFolder, vFolderName);
+      expect(folder2.uri.fsPath).toEqual(workspaceFolder.uri.fsPath);
+    });
+    it('should have the same index as the actual workspace folder', () => {
+      workspaceFolder.index = 1;
+      expect(virtualFolder.index).toEqual(workspaceFolder.index);
+    });
+
+    describe('should correctly determine if a uri is in the workspace', () => {
+      it.each`
+        case | pathComps                                | expected
+        ${1} | ${['packages', 'v1', 'src', 'index.ts']} | ${true}
+        ${2} | ${['packages', 'v2', 'src', 'index.ts']} | ${false}
+        ${3} | ${['src', 'index.ts']}                   | ${false}
+      `('case $case: can determine if a uri is in the workspace', ({ pathComps, expected }) => {
+        const uri = makeUri(workspaceFolder.uri.fsPath, ...pathComps);
+        expect(virtualFolder.isInWorkspaceFolder(uri)).toBe(expected);
+      });
+    });
+    it('isVirtualWorkspaceFolder can determine if a workspace folder is virtual', () => {
+      expect(isVirtualWorkspaceFolder(virtualFolder)).toBe(true);
+      expect(isVirtualWorkspaceFolder(workspaceFolder)).toBe(false);
+    });
+  });
+
+  const makeCacheItem = (workspaceFolder: vscode.WorkspaceFolder): any => ({ workspaceFolder });
+  type CacheItem = ReturnType<typeof makeCacheItem>;
+
+  describe('VirtualFolderBasedCache', () => {
+    let cache: VirtualFolderBasedCache<CacheItem>;
+
+    beforeEach(() => {
+      cache = new VirtualFolderBasedCache();
+    });
+
+    it('can add, get and delete items by folder name', () => {
+      const item = makeCacheItem(makeWorkspaceFolder('folder1'));
+      cache.addItem(item);
+      expect(cache.getItemByFolderName('folder1')).toBe(item);
+      expect(cache.size).toBe(1);
+
+      cache.deleteItemByFolder(item.workspaceFolder);
+      expect(cache.size).toBe(0);
+      expect(cache.getItemByFolderName('folder1')).toBeUndefined();
+      expect(cache.getItemsByActualFolderName('folder1')).toBeUndefined();
+    });
+    it('adding existing item will replace the old one', () => {
+      const item = makeCacheItem(makeWorkspaceFolder('folder1'));
+      cache.addItem(item);
+      expect(cache.getItemByFolderName('folder1')).toBe(item);
+      expect(cache.size).toBe(1);
+
+      const item2 = makeCacheItem(makeWorkspaceFolder('folder1'));
+      cache.addItem(item2);
+      expect(cache.getItemByFolderName('folder1')).toBe(item2);
+      expect(cache.size).toBe(1);
+    });
+
+    describe('with virtual folders', () => {
+      let item1, item2, item3;
+      beforeEach(() => {
+        vscode.Uri.file = jest.fn().mockImplementation((f) => ({ fsPath: f }));
+        vscode.Uri.joinPath = jest
+          .fn()
+          .mockImplementation((uri, ...parts) => makeUri(uri.fsPath, ...parts));
+
+        item1 = makeCacheItem(makeWorkspaceFolder('folder1'));
+        item2 = makeCacheItem(
+          new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder2', 'folder2')
+        );
+        item3 = makeCacheItem(
+          new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder3', 'folder3')
+        );
+      });
+
+      it('can retrieve items by actual folder name', () => {
+        cache.addItem(item1);
+        cache.addItem(item2);
+        cache.addItem(item3);
+        expect(cache.size).toBe(3);
+
+        expect(cache.getItemsByActualFolderName('folder1')).toEqual([item1, item2, item3]);
+        expect(cache.getItemByFolderName('folder1')).toBe(item1);
+        expect(cache.getItemByFolderName('folder2')).toBe(item2);
+        expect(cache.getItemByFolderName('folder3')).toBe(item3);
+      });
+      it('can retrieve items by actual folder name, even if the actualFolder is not in cache', () => {
+        cache.addItem(item2);
+        cache.addItem(item3);
+        expect(cache.size).toBe(2);
+
+        expect(cache.getItemsByActualFolderName('folder1')).toEqual([item2, item3]);
+        expect(cache.getItemByFolderName('folder1')).toBeUndefined();
+        expect(cache.getItemByFolderName('folder2')).toBe(item2);
+        expect(cache.getItemByFolderName('folder3')).toBe(item3);
+      });
+
+      it('deletiing the virtual folder item will also remove the byActualFolderName entry', () => {
+        cache.addItem(item2);
+        cache.addItem(item3);
+        expect(cache.size).toBe(2);
+
+        expect(cache.getItemsByActualFolderName('folder1')).toEqual([item2, item3]);
+        cache.deleteItemByFolder(item2.workspaceFolder);
+        expect(cache.getItemsByActualFolderName('folder1')).toEqual([item3]);
+        expect(cache.getItemByFolderName('folder2')).toBeUndefined();
+      });
+      it('can delete items by atualFolder', () => {
+        cache.addItem(item2);
+        cache.addItem(item3);
+        expect(cache.getItemByFolderName('folder2')).toBe(item2);
+        expect(cache.getItemByFolderName('folder3')).toBe(item3);
+        expect(cache.size).toBe(2);
+
+        cache.deleteItemByFolder(item1.workspaceFolder);
+        expect(cache.getItemByFolderName('folder2')).toBeUndefined();
+        expect(cache.getItemByFolderName('folder3')).toBeUndefined();
+        expect(cache.size).toBe(0);
+      });
+      describe('findRelatedItems', () => {
+        let item4;
+        beforeEach(() => {
+          item4 = makeCacheItem(makeWorkspaceFolder('folder4'));
+        });
+        it.each`
+          case | uriComps                                     | getWorkspaceFolder             | expectedItems
+          ${1} | ${['dummy']}                                 | ${() => undefined}             | ${[]}
+          ${2} | ${['folder1']}                               | ${() => item1.workspaceFolder} | ${[]}
+          ${3} | ${['folder1', 'something']}                  | ${() => item1.workspaceFolder} | ${[]}
+          ${4} | ${['folder1', 'folder2', 'index.ts']}        | ${() => item1.workspaceFolder} | ${() => [item2]}
+          ${5} | ${['folder1', 'folder3', 'src', 'index.ts']} | ${() => item1.workspaceFolder} | ${() => [item3]}
+          ${6} | ${['folder4', 'src', 'index.ts']}            | ${() => item4.workspaceFolder} | ${() => [item4]}
+        `(
+          'case $case: can find related items for a given uri',
+          ({ uriComps, getWorkspaceFolder, expectedItems }) => {
+            cache.addItem(item2);
+            cache.addItem(item3);
+            cache.addItem(item4);
+            const uri = makeUri(...uriComps);
+            vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValue(getWorkspaceFolder());
+            expect(cache.findRelatedItems(uri)).toEqual(
+              typeof expectedItems === 'function' ? expectedItems() : expectedItems
+            );
+          }
+        );
+      });
+    });
+
+    it('can reset the cache', () => {
+      const item = makeCacheItem(makeWorkspaceFolder('folder1'));
+      cache.addItem(item);
+      cache.reset();
+      expect(cache.size).toBe(0);
+    });
+    it('can return all cached items', () => {
+      const item1 = makeCacheItem(makeWorkspaceFolder('folder1'));
+      const item2 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder2'));
+      const item3 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder3'));
       cache.addItem(item1);
       cache.addItem(item2);
       cache.addItem(item3);
-      expect(cache.size).toBe(3);
-
-      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item1, item2, item3]);
-      expect(cache.getItemByFolderName('folder1')).toBe(item1);
-      expect(cache.getItemByFolderName('folder2')).toBe(item2);
-      expect(cache.getItemByFolderName('folder3')).toBe(item3);
+      expect(cache.getAllItems()).toEqual([item1, item2, item3]);
     });
-    it('can retrieve items by actual folder name, even if the actualFolder is not in cache', () => {
-      cache.addItem(item2);
-      cache.addItem(item3);
-      expect(cache.size).toBe(2);
-
-      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item2, item3]);
-      expect(cache.getItemByFolderName('folder1')).toBeUndefined();
-      expect(cache.getItemByFolderName('folder2')).toBe(item2);
-      expect(cache.getItemByFolderName('folder3')).toBe(item3);
-    });
-
-    it('deletiing the virtual folder item will also remove the byActualFolderName entry', () => {
-      cache.addItem(item2);
-      cache.addItem(item3);
-      expect(cache.size).toBe(2);
-
-      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item2, item3]);
-      cache.deleteItemByFolder(item2.workspaceFolder);
-      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item3]);
-      expect(cache.getItemByFolderName('folder2')).toBeUndefined();
-    });
-    it('can delete items by atualFolder', () => {
-      cache.addItem(item2);
-      cache.addItem(item3);
-      expect(cache.getItemByFolderName('folder2')).toBe(item2);
-      expect(cache.getItemByFolderName('folder3')).toBe(item3);
-      expect(cache.size).toBe(2);
-
-      cache.deleteItemByFolder(item1.workspaceFolder);
-      expect(cache.getItemByFolderName('folder2')).toBeUndefined();
-      expect(cache.getItemByFolderName('folder3')).toBeUndefined();
-      expect(cache.size).toBe(0);
-    });
-    describe('findRelatedItems', () => {
-      let item4;
-      beforeEach(() => {
-        item4 = makeCacheItem(makeWorkspaceFolder('folder4'));
-      });
-      it.each`
-        case | uriComps                                     | getWorkspaceFolder             | expectedItems
-        ${1} | ${['dummy']}                                 | ${() => undefined}             | ${[]}
-        ${2} | ${['folder1']}                               | ${() => item1.workspaceFolder} | ${[]}
-        ${3} | ${['folder1', 'something']}                  | ${() => item1.workspaceFolder} | ${[]}
-        ${4} | ${['folder1', 'folder2', 'index.ts']}        | ${() => item1.workspaceFolder} | ${() => [item2]}
-        ${5} | ${['folder1', 'folder3', 'src', 'index.ts']} | ${() => item1.workspaceFolder} | ${() => [item3]}
-        ${6} | ${['folder4', 'src', 'index.ts']}            | ${() => item4.workspaceFolder} | ${() => [item4]}
-      `(
-        'case $case: can find related items for a given uri',
-        ({ uriComps, getWorkspaceFolder, expectedItems }) => {
-          cache.addItem(item2);
-          cache.addItem(item3);
-          cache.addItem(item4);
-          const uri = makeUri(...uriComps);
-          vscode.workspace.getWorkspaceFolder = jest.fn().mockReturnValue(getWorkspaceFolder());
-          expect(cache.findRelatedItems(uri)).toEqual(
-            typeof expectedItems === 'function' ? expectedItems() : expectedItems
-          );
-        }
-      );
-    });
-  });
-
-  it('can reset the cache', () => {
-    const item = makeCacheItem(makeWorkspaceFolder('folder1'));
-    cache.addItem(item);
-    cache.reset();
-    expect(cache.size).toBe(0);
-  });
-  it('can return all cached items', () => {
-    const item1 = makeCacheItem(makeWorkspaceFolder('folder1'));
-    const item2 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder2'));
-    const item3 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder3'));
-    cache.addItem(item1);
-    cache.addItem(item2);
-    cache.addItem(item3);
-    expect(cache.getAllItems()).toEqual([item1, item2, item3]);
   });
 });

--- a/tests/virtual-workspace-folder.test.ts
+++ b/tests/virtual-workspace-folder.test.ts
@@ -1,0 +1,171 @@
+jest.unmock('../src/virtual-workspace-folder');
+jest.unmock('./test-helper');
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import {
+  VirtualWorkspaceFolder,
+  isVirtualWorkspaceFolder,
+  VirtualFolderBasedCache,
+} from '../src/virtual-workspace-folder';
+import { makeWorkspaceFolder, makeUri } from './test-helper';
+
+describe('VirtualWorkspaceFolder', () => {
+  const workspaceFolder = makeWorkspaceFolder(path.join(__dirname, 'my-workspace'));
+  const vFolderName = 'v1';
+  const vFolderRootPath = path.join('packages', 'v1'); // a relative path
+  let virtualFolder;
+  beforeEach(() => {
+    jest.resetAllMocks();
+    vscode.Uri.joinPath = jest
+      .fn()
+      .mockImplementation((uri, p) => ({ fsPath: path.join(uri.fsPath, p) }));
+    vscode.Uri.file = jest.fn().mockImplementation((f) => ({ fsPath: f }));
+    virtualFolder = new VirtualWorkspaceFolder(workspaceFolder, vFolderName, vFolderRootPath);
+  });
+
+  it('should have the correct name', () => {
+    expect(virtualFolder.name).toEqual(vFolderName);
+  });
+
+  it('should have the correct uri', () => {
+    expect(virtualFolder.uri.fsPath).toEqual(
+      path.join(workspaceFolder.uri.fsPath, vFolderRootPath)
+    );
+  });
+
+  it('can take both absolute or relative rootPath', () => {
+    //make an absolute path
+    const rootPath = path.join(workspaceFolder.uri.fsPath, 'packages', 'v1');
+    const folder2 = new VirtualWorkspaceFolder(workspaceFolder, vFolderName, rootPath);
+    expect(folder2.uri.fsPath).toEqual(virtualFolder.uri.fsPath);
+  });
+  it('if no rootPath is given, the uri is the same as the actual workspace folder', () => {
+    const folder2 = new VirtualWorkspaceFolder(workspaceFolder, vFolderName);
+    expect(folder2.uri.fsPath).toEqual(workspaceFolder.uri.fsPath);
+  });
+  it('should have the same index as the actual workspace folder', () => {
+    workspaceFolder.index = 1;
+    expect(virtualFolder.index).toEqual(workspaceFolder.index);
+  });
+
+  describe('should correctly determine if a uri is in the workspace', () => {
+    it.each`
+      case | pathComps                                | expected
+      ${1} | ${['packages', 'v1', 'src', 'index.ts']} | ${true}
+      ${2} | ${['packages', 'v2', 'src', 'index.ts']} | ${false}
+      ${3} | ${['src', 'index.ts']}                   | ${false}
+    `('case $case: can determine if a uri is in the workspace', ({ pathComps, expected }) => {
+      const uri = makeUri(workspaceFolder.uri.fsPath, ...pathComps);
+      expect(virtualFolder.isInWorkspace(uri)).toBe(expected);
+    });
+  });
+  it('isVirtualWorkspaceFolder can determine if a workspace folder is virtual', () => {
+    expect(isVirtualWorkspaceFolder(virtualFolder)).toBe(true);
+    expect(isVirtualWorkspaceFolder(workspaceFolder)).toBe(false);
+  });
+});
+
+const makeCacheItem = (workspaceFolder: vscode.WorkspaceFolder): any => ({ workspaceFolder });
+type CacheItem = ReturnType<typeof makeCacheItem>;
+
+describe('VirtualFolderBasedCache', () => {
+  let cache: VirtualFolderBasedCache<CacheItem>;
+
+  beforeEach(() => {
+    cache = new VirtualFolderBasedCache();
+  });
+
+  it('can add, get and delete items by folder name', () => {
+    const item = makeCacheItem(makeWorkspaceFolder('folder1'));
+    cache.addItem(item);
+    expect(cache.getItemByFolderName('folder1')).toBe(item);
+    expect(cache.size).toBe(1);
+
+    cache.deleteItemByFolder(item.workspaceFolder);
+    expect(cache.size).toBe(0);
+    expect(cache.getItemByFolderName('folder1')).toBeUndefined();
+    expect(cache.getItemsByActualFolderName('folder1')).toBeUndefined();
+  });
+  it('adding existing item will replace the old one', () => {
+    const item = makeCacheItem(makeWorkspaceFolder('folder1'));
+    cache.addItem(item);
+    expect(cache.getItemByFolderName('folder1')).toBe(item);
+    expect(cache.size).toBe(1);
+
+    const item2 = makeCacheItem(makeWorkspaceFolder('folder1'));
+    cache.addItem(item2);
+    expect(cache.getItemByFolderName('folder1')).toBe(item2);
+    expect(cache.size).toBe(1);
+  });
+
+  describe('with virtual folders', () => {
+    let item1, item2, item3;
+    beforeEach(() => {
+      item1 = makeCacheItem(makeWorkspaceFolder('folder1'));
+      item2 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder2'));
+      item3 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder3'));
+    });
+
+    it('can retrieve items by actual folder name', () => {
+      cache.addItem(item1);
+      cache.addItem(item2);
+      cache.addItem(item3);
+      expect(cache.size).toBe(3);
+
+      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item1, item2, item3]);
+      expect(cache.getItemByFolderName('folder1')).toBe(item1);
+      expect(cache.getItemByFolderName('folder2')).toBe(item2);
+      expect(cache.getItemByFolderName('folder3')).toBe(item3);
+    });
+    it('can retrieve items by actual folder name, even if the actualFolder is not in cache', () => {
+      cache.addItem(item2);
+      cache.addItem(item3);
+      expect(cache.size).toBe(2);
+
+      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item2, item3]);
+      expect(cache.getItemByFolderName('folder1')).toBeUndefined();
+      expect(cache.getItemByFolderName('folder2')).toBe(item2);
+      expect(cache.getItemByFolderName('folder3')).toBe(item3);
+    });
+
+    it('deletiing the virtual folder item will also remove the byActualFolderName entry', () => {
+      cache.addItem(item2);
+      cache.addItem(item3);
+      expect(cache.size).toBe(2);
+
+      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item2, item3]);
+      cache.deleteItemByFolder(item2.workspaceFolder);
+      expect(cache.getItemsByActualFolderName('folder1')).toEqual([item3]);
+      expect(cache.getItemByFolderName('folder2')).toBeUndefined();
+    });
+    it('can delete items by atualFolder', () => {
+      cache.addItem(item2);
+      cache.addItem(item3);
+      expect(cache.getItemByFolderName('folder2')).toBe(item2);
+      expect(cache.getItemByFolderName('folder3')).toBe(item3);
+      expect(cache.size).toBe(2);
+
+      cache.deleteItemByFolder(item1.workspaceFolder);
+      expect(cache.getItemByFolderName('folder2')).toBeUndefined();
+      expect(cache.getItemByFolderName('folder3')).toBeUndefined();
+      expect(cache.size).toBe(0);
+    });
+  });
+
+  it('can reset the cache', () => {
+    const item = makeCacheItem(makeWorkspaceFolder('folder1'));
+    cache.addItem(item);
+    cache.reset();
+    expect(cache.size).toBe(0);
+  });
+  it('can return all cached items', () => {
+    const item1 = makeCacheItem(makeWorkspaceFolder('folder1'));
+    const item2 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder2'));
+    const item3 = makeCacheItem(new VirtualWorkspaceFolder(item1.workspaceFolder, 'folder3'));
+    cache.addItem(item1);
+    cache.addItem(item2);
+    cache.addItem(item3);
+    expect(cache.getAllItems()).toEqual([item1, item2, item3]);
+  });
+});

--- a/tests/virtual-workspace-folder.test.ts
+++ b/tests/virtual-workspace-folder.test.ts
@@ -57,7 +57,7 @@ describe('VirtualWorkspaceFolder', () => {
       ${3} | ${['src', 'index.ts']}                   | ${false}
     `('case $case: can determine if a uri is in the workspace', ({ pathComps, expected }) => {
       const uri = makeUri(workspaceFolder.uri.fsPath, ...pathComps);
-      expect(virtualFolder.isInWorkspace(uri)).toBe(expected);
+      expect(virtualFolder.isInWorkspaceFolder(uri)).toBe(expected);
     });
   });
   it('isVirtualWorkspaceFolder can determine if a workspace folder is virtual', () => {


### PR DESCRIPTION
We have come a full circle on this issue - supporting multiple jest configs for a given workspace. This is common for monorepo projects and projects with multiple test environments, such as unit and integration tests. We implemented monorepo support with vscode multi-root workspaces a few years ago. However, this fell short of addressing multi-test-environment that share the same code base (folder).

This PR addresses this gap by introducing the concept of **virtual folders**. A virtual folder defines a jest runtime environment, customizable with all resource level settings, such as `jestCommanLine`, `rootPath`. Multiple virtual folders can reside in any given vscode workspace folder via `jest.virtualFolders`. See details documented in the README.md file.

The code change outline:
-  expand the `JestExt` to be workspace "agnostic", i.e. it can work with either the actual vscode.WorkspaceFolder or virtualFolder. 
- update `workspace-manager`, `extension-manager`, `StatusBar`, `CoverageCodeLensProvider` etc to work with virtual folders.
- update `DebugConfigurationProvider` to append the folder name to the generated configuration names.
- adjust the setup wizard to work with virtual folders. (except the monorepo setup, which will ignore virtual folders)
- a few refactoring and code organization change.
- tests adjustment accordingly.

---

resolve #870
resolve #428
