### PR TITLE
Fix multi-variable substitution

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -109,20 +109,10 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       if (typeof arg !== 'string') {
         return arg;
       }
-      switch (true) {
-        case testFileRegex.test(arg): {
-          return arg.replace(testFileRegex, toFilePath(this.fileNameToRun));
-        }
-        case testFilePatternRegex.test(arg): {
-          return arg.replace(testFilePatternRegex, escapeRegExp(this.fileNameToRun));
-        }
-        case testNamePatternRegex.test(arg): {
-          return arg.replace(testNamePatternRegex, this.testToRun);
-        }
-
-        default:
-          return arg;
-      }
+      return arg
+        .replace(testFileRegex, toFilePath(this.fileNameToRun))
+        .replace(testFilePatternRegex, escapeRegExp(this.fileNameToRun))
+        .replace(testNamePatternRegex, this.testToRun);
     });
     debugConfiguration.args = args;
 

--- a/tests/DebugConfigurationProvider.test.ts
+++ b/tests/DebugConfigurationProvider.test.ts
@@ -128,6 +128,26 @@ describe('DebugConfigurationProvider', () => {
       expect(configuration).toBeDefined();
       expect(configuration.args).toEqual(expected);
     });
+    it('will translate multiple variables in a single arg', () => {
+      (toFilePath as unknown as jest.Mock<{}>).mockReturnValueOnce(fileName);
+      (escapeRegExp as unknown as jest.Mock<{}>).mockReturnValueOnce(fileNamePattern);
+
+      let configuration: any = {
+        name: 'vscode-jest-tests.v2',
+        args: ['--testNamePattern "${jest.testNamePattern}" --runTestsByPath "${jest.testFile}"'],
+      };
+
+      const sut = new DebugConfigurationProvider();
+      const ws = makeWorkspaceFolder('whatever');
+      sut.prepareTestRun(fileName, testName, ws);
+
+      configuration = sut.resolveDebugConfiguration(undefined, configuration);
+
+      expect(configuration).toBeDefined();
+      expect(configuration.args).toEqual([
+        `--testNamePattern "${testName}" --runTestsByPath "${fileName}"`,
+      ]);
+    });
   });
   describe('can generate debug config with jestCommandLine and rootPath', () => {
     const canRunTest = (isWin32: boolean) =>


### PR DESCRIPTION
# Summary

Fixes variable substitution in launch.json debug configurations when an `arg` contains more than one variable

More details in https://github.com/jest-community/vscode-jest/issues/1039

### Previous

`/Users/foo/bar/node_modules/.bin/sst bind 'jest --testNamePattern="${jest.testNamePattern}" --config jest.config.ts --runInBand --watchAll=false  "/Users/foo/bar/path/test/createOrUpdateLineageIntegration.integration.test.ts"'`

### Now

`/Users/foo/bar/node_modules/.bin/sst bind 'jest --testNamePattern="creating an integration returns 200" --config jest.config.ts --runInBand --watchAll=false  "/Users/foo/bar/path/test/createOrUpdateLineageIntegration.integration.test.ts"'`

# Test

I added a unit test, verified it was failing without this change, and that it passes with this change. 

I also followed the [eat your own dog food](https://github.com/jest-community/vscode-jest/blob/master/CONTRIBUTING.md#testing-and-debugging) steps in the CONTRIBUTING readme, and verified things work in our repository with this change + changing the settings.json `"jest.jestCommandLine"` value to

`"jest.jestCommandLine": "wrap () { NODE_OPTIONS=--experimental-vm-modules yarn sst bind  \"jest --config=jest.config.ts $*\";}; wrap ",`

to make sure the additional flags the plugin appends are substituted within `"jest ..."`
  

