### PR TITLE
feat: add support for pnpm round 2

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -181,9 +181,9 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       program: undefined,
     };
 
-    if (cmd === 'npm') {
+    if (cmd === 'npm' || cmd === 'pnpm') {
       const extraArgs = args.includes('--') ? [] : ['--'];
-      return { runtimeExecutable: 'npm', args: extraArgs, ...commonConfig };
+      return { runtimeExecutable: cmd, args: extraArgs, ...commonConfig };
     }
     if (cmd === 'yarn') {
       return { runtimeExecutable: 'yarn', args: [], ...commonConfig };

--- a/tests/DebugConfigurationProvider.test.ts
+++ b/tests/DebugConfigurationProvider.test.ts
@@ -290,33 +290,38 @@ describe('DebugConfigurationProvider', () => {
         ${'yarn'} | ${['test', '--config', 'test-jest.json']}       | ${false}
         ${'npm'}  | ${['run', 'test']}                              | ${true}
         ${'npm'}  | ${['test', '--', '--config', 'test-jest.json']} | ${false}
-      `('can merge yarn or npm command line: $cmd $cArgs', ({ cmd, cArgs, appendExtraArg }) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { args, program, windows, ...restConfig } = config;
-        const sut = new DebugConfigurationProvider();
-        const spy = jest.spyOn(sut, 'provideDebugConfigurations');
-        spy.mockImplementation(() => [config]);
+        ${'pnpm'} | ${['run', 'test']}                              | ${true}
+        ${'pnpm'} | ${['test', '--', '--config', 'test-jest.json']} | ${false}
+      `(
+        'can merge yarn or npm or pnpmcommand line: $cmd $cArgs',
+        ({ cmd, cArgs, appendExtraArg }) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { args, program, windows, ...restConfig } = config;
+          const sut = new DebugConfigurationProvider();
+          const spy = jest.spyOn(sut, 'provideDebugConfigurations');
+          spy.mockImplementation(() => [config]);
 
-        const cmdLine = [cmd, ...cArgs].join(' ');
-        const {
-          args: newArgs,
-          program: newProgram,
-          runtimeExecutable,
-          ...restNewConfig
-        } = sut.withCommandLine(workspace, cmdLine);
-        expect(newArgs).toContain('--runInBand');
-        expect(runtimeExecutable).toEqual(cmd);
-        expect(newProgram).toBeUndefined();
+          const cmdLine = [cmd, ...cArgs].join(' ');
+          const {
+            args: newArgs,
+            program: newProgram,
+            runtimeExecutable,
+            ...restNewConfig
+          } = sut.withCommandLine(workspace, cmdLine);
+          expect(newArgs).toContain('--runInBand');
+          expect(runtimeExecutable).toEqual(cmd);
+          expect(newProgram).toBeUndefined();
 
-        const expectArgs = [...cArgs];
-        if (appendExtraArg) {
-          expectArgs.push('--');
+          const expectArgs = [...cArgs];
+          if (appendExtraArg) {
+            expectArgs.push('--');
+          }
+          expectArgs.push(...args);
+
+          expect(newArgs).toEqual(expectArgs);
+          expect(restNewConfig).toEqual(restConfig);
         }
-        expectArgs.push(...args);
-
-        expect(newArgs).toEqual(expectArgs);
-        expect(restNewConfig).toEqual(restConfig);
-      });
+      );
 
       it('platform specific sections are removed.', () => {
         const sut = new DebugConfigurationProvider();

--- a/tests/DebugConfigurationProvider.test.ts
+++ b/tests/DebugConfigurationProvider.test.ts
@@ -293,7 +293,7 @@ describe('DebugConfigurationProvider', () => {
         ${'pnpm'} | ${['run', 'test']}                              | ${true}
         ${'pnpm'} | ${['test', '--', '--config', 'test-jest.json']} | ${false}
       `(
-        'can merge yarn or npm or pnpmcommand line: $cmd $cArgs',
+        'can merge yarn or npm or pnpm command line: $cmd $cArgs',
         ({ cmd, cArgs, appendExtraArg }) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { args, program, windows, ...restConfig } = config;


### PR DESCRIPTION
Credit to original PR https://github.com/jest-community/vscode-jest/pull/1033. This includes unit tests. 

- Followed instructions for `code --extensionDevelopmentPath=your-local-vscode-jest` and seemed to work fine 🤞🏼 
- `yarn test` passed
- `yarn vscode:prepublish` seemed to work

Closes [#974](https://github.com/jest-community/vscode-jest/issues/974)