### PR TITLE
fix dashed-arg and prepare for v6.0.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.68.1"
@@ -525,7 +525,7 @@
   "dependencies": {
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-source-maps": "^4.0.1",
-    "jest-editor-support": "^31.1.0"
+    "jest-editor-support": "^31.1.1"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,10 +2344,10 @@ jest-each@^29.3.1:
     jest-util "^29.3.1"
     pretty-format "^29.3.1"
 
-jest-editor-support@^31.1.0:
-  version "31.1.0"
-  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-31.1.0.tgz#087a8954d465288f3c544c75feb223f4bc31cea5"
-  integrity sha512-CGDZh5gO4NRthr6ocmD13pkuSDqZ03Cq+f6UuvwELoNN7p7rkZrEwjPZ/ysMDWoEzRtlTFZ+7sYmfE4kuyhIhQ==
+jest-editor-support@^31.1.1:
+  version "31.1.1"
+  resolved "https://registry.yarnpkg.com/jest-editor-support/-/jest-editor-support-31.1.1.tgz#46fa8280e6484a2695a6c7c882852e3821100181"
+  integrity sha512-bCKpKWAMLhjK7QDX9geBDzfyvZacl937hnT3Z+yfERBx8bB7yZg2uhvCBErqO51Ie+wgg42Ffo8rn+Nhdr2hHQ==
   dependencies:
     "@babel/parser" "^7.20.7"
     "@babel/runtime" "^7.20.7"


### PR DESCRIPTION
Pick up the dashed-args fix (see #1034) from [jest-editor-support@v31.1.1](https://github.com/jest-community/jest-editor-support/releases/tag/v31.1.1); and update package version to 6.0.1