### PR TITLE
feat: add clearTestResults option

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Users can use the following settings to tailor the extension for their environme
 |disabledWorkspaceFolders 💼|Disabled workspace folders names in multi-root environment|[]|`"jest.disabledWorkspaceFolders": ["package-a", "package-b"]`|
 |[autoRevealOutput](#autoRevealOutput)|Determine when to show test output|"on-run"|`"jest.autoRevealOutput": "on-exec-error"`|
 |autoClearTerminal|Clear the terminal output at the start of any new test run.|false|`"jest.autoClearTerminal": true`| >= v6.0.0 |
+|clearTestResults|Clear previous test results at the start of any new test run.|false|`"jest.clearTestResults": true`| >= v6.0.2 |
 
 #### Details
 ##### jestCommandLine

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
           "type": "string",
           "scope": "resource"
         },
+        "jest.clearTestResults": {
+          "type": "boolean",
+          "description": "Clear previous test results at the start of any new test run.",
+          "default": false
+        },
         "jest.autoClearTerminal": {
           "description": "Clear the terminal output at the start of any new test run.",
           "type": "boolean",

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -125,6 +125,7 @@ export const getExtensionResourceSettings = (
     monitorLongRun: getSetting<MonitorLongRun>('monitorLongRun') ?? undefined,
     autoRun: new AutoRun(getSetting<JestExtAutoRunSetting | null>('autoRun')),
     autoRevealOutput: getSetting<AutoRevealOutputType>('autoRevealOutput') ?? 'on-run',
+    clearTestResults: getSetting<boolean>('clearTestResults') ?? false,
     parserPluginOptions: getSetting<JESParserPluginOptions>('parserPluginOptions'),
     enable: getSetting<boolean>('enable'),
     useDashedArgs: getSetting<boolean>('useDashedArgs') ?? false,

--- a/src/Settings/index.ts
+++ b/src/Settings/index.ts
@@ -53,6 +53,7 @@ export interface PluginResourceSettings {
   shell: RunShell;
   monitorLongRun?: MonitorLongRun;
   autoRevealOutput: AutoRevealOutputType;
+  clearTestResults: boolean;
   parserPluginOptions?: JESParserPluginOptions;
   enable?: boolean;
   useDashedArgs?: boolean;

--- a/src/test-provider/test-provider.ts
+++ b/src/test-provider/test-provider.ts
@@ -147,6 +147,11 @@ export class JestTestProvider {
       this.log('error', message, request);
       return Promise.reject(message);
     }
+
+    if (this.context.ext.settings.clearTestResults) {
+      vscode.commands.executeCommand('testing.clearTestResults');
+    }
+
     const run = this.context.createTestRun(request, { name: this.controller.id });
     const tests = (request.include ?? this.getAllItems()).filter(
       (t) => !request.exclude?.includes(t)

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -165,6 +165,7 @@ describe('getExtensionResourceSettings()', () => {
     expect(getExtensionResourceSettings(folder)).toEqual({
       coverageFormatter: 'DefaultFormatter',
       jestCommandLine: undefined,
+      clearTestResults: false,
       rootPath: 'workspaceFolder1',
       showCoverageOnLoad: false,
       debugMode: false,


### PR DESCRIPTION
Adds option to clear test results on new test run as discussed in https://github.com/jest-community/vscode-jest/issues/1060

- README.MD updated
- unit test updated
- please note: I did not increase version in package.json - I don't know the release process, if you have it automatic in merge etc. (this also means in README.MD I guess the supported version of this new setting)