### PR TITLE
fix TestNamePattern issue

### DIFF
--- a/src/JestExt/types.ts
+++ b/src/JestExt/types.ts
@@ -7,6 +7,7 @@ import { ProcessSession } from './process-session';
 import { JestProcessInfo } from '../JestProcessManagement';
 import { JestOutputTerminal } from './output-terminal';
 import { TestIdentifier } from '../TestResults';
+import { TestNamePattern } from '../types';
 
 export enum WatchMode {
   None = 'none',
@@ -56,5 +57,5 @@ export type JestExtProcessContext = Readonly<JestExtProcessContextRaw>;
 export type DebugTestIdentifier = string | TestIdentifier;
 export type DebugFunction = (
   document: vscode.TextDocument | string,
-  ...ids: DebugTestIdentifier[]
+  testNamePattern?: TestNamePattern
 ) => Promise<void>;

--- a/src/JestProcessManagement/types.ts
+++ b/src/JestProcessManagement/types.ts
@@ -3,6 +3,7 @@ import { RunnerEvent } from 'jest-editor-support';
 import { JestTestProcessType } from '../Settings';
 import { JestProcess } from './JestProcess';
 import { JestTestRun } from '../test-provider/jest-test-run';
+import { TestNamePattern } from '../types';
 
 export interface JestProcessListener {
   onEvent: (process: JestProcess, event: RunnerEvent, ...args: unknown[]) => unknown;
@@ -71,7 +72,7 @@ export type JestProcessRequestSimple =
   | {
       type: Extract<JestTestProcessType, 'by-file-test'>;
       testFileName: string;
-      testNamePattern: string;
+      testNamePattern: TestNamePattern;
       updateSnapshot?: boolean;
     }
   | {
@@ -82,7 +83,7 @@ export type JestProcessRequestSimple =
   | {
       type: Extract<JestTestProcessType, 'by-file-test-pattern'>;
       testFileNamePattern: string;
-      testNamePattern: string;
+      testNamePattern: TestNamePattern;
       updateSnapshot?: boolean;
     }
   | {

--- a/src/TestResults/snapshot-provider.ts
+++ b/src/TestResults/snapshot-provider.ts
@@ -50,7 +50,7 @@ export class SnapshotProvider {
   public async previewSnapshot(testPath: string, testFullName: string): Promise<void> {
     const content = await this.snapshotSupport.getSnapshotContent(
       testPath,
-      new RegExp(`^${escapeRegExp(testFullName)} [0-9]+$`)
+      new RegExp(`^${escapeRegExp({ value: testFullName, exactMatch: false })} [0-9]+$`)
     );
     const noSnapshotFound = (): void => {
       vscode.window.showErrorMessage('no snapshot is found, please run test to generate first');

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,7 +5,7 @@ import { join, resolve, normalize, isAbsolute } from 'path';
 import { ExtensionContext } from 'vscode';
 
 import { TestIdentifier } from './TestResults';
-import { TestStats } from './types';
+import { StringPattern, TestStats } from './types';
 import { LoginShell } from 'jest-editor-support';
 import { WorkspaceManager } from './workspace-manager';
 
@@ -125,10 +125,22 @@ export const getDefaultJestCommand = (rootPath = ''): string | undefined => {
 };
 
 /**
- *  Taken From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+ * Escapes special characters in a string to be used as a regular expression pattern.
+ * @param str - The string to escape.
+ * @returns The escaped string.
+ *
+ * Note: the conversion algorithm is taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
  */
-export function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+export function escapeRegExp(str: string | StringPattern): string {
+  const sp: StringPattern = typeof str === 'string' ? { value: str } : str;
+  if (sp.isRegExp) {
+    return sp.value;
+  }
+  const escaped = sp.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+  if (sp.exactMatch) {
+    return escaped + '$';
+  }
+  return escaped;
 }
 
 /**

--- a/src/test-provider/types.ts
+++ b/src/test-provider/types.ts
@@ -4,6 +4,7 @@ import { TestResultProvider } from '../TestResults';
 import { WorkspaceRoot, FolderData, TestData, TestDocumentRoot } from './test-item-data';
 import { JestTestProviderContext } from './test-provider-context';
 import { JestTestRun } from './jest-test-run';
+import { TestNamePattern } from '../types';
 
 export type TestItemDataType = WorkspaceRoot | FolderData | TestDocumentRoot | TestData;
 
@@ -24,7 +25,7 @@ export interface TestItemData {
 }
 
 export interface Debuggable {
-  getDebugInfo: () => { fileName: string; testNamePattern?: string };
+  getDebugInfo: () => { fileName: string; testNamePattern?: TestNamePattern };
 }
 
 export enum TestTagId {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,3 +15,11 @@ export interface TestExplorerRunRequest {
   request: vscode.TestRunRequest;
   token: vscode.CancellationToken;
 }
+
+export interface StringPattern {
+  value: string;
+  exactMatch?: boolean;
+  isRegExp?: boolean;
+}
+
+export type TestNamePattern = StringPattern | string;

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -148,11 +148,15 @@ describe('ModuleHelpers', () => {
 
 describe('escapeRegExp', () => {
   it.each`
-    str                    | expected
-    ${'no special char'}   | ${'no special char'}
-    ${'with (a)'}          | ${'with \\(a\\)'}
-    ${'with {} and $sign'} | ${'with \\{\\} and \\$sign'}
-    ${'with []'}           | ${'with \\[\\]'}
+    str                                        | expected
+    ${'no special char'}                       | ${'no special char'}
+    ${'with (a)'}                              | ${'with \\(a\\)'}
+    ${'with {} and $sign'}                     | ${'with \\{\\} and \\$sign'}
+    ${'with []'}                               | ${'with \\[\\]'}
+    ${{ value: 'with []', exactMatch: true }}  | ${'with \\[\\]$'}
+    ${{ value: 'with []', exactMatch: false }} | ${'with \\[\\]'}
+    ${{ value: 'with []', isRegExp: true }}    | ${'with []'}
+    ${{ value: 'with []', isRegExp: false }}   | ${'with \\[\\]'}
   `('escapeRegExp: $str', ({ str, expected }) => {
     expect(escapeRegExp(str)).toEqual(expected);
   });


### PR DESCRIPTION
## Summary

Fix TestNamePattern matching more tests issue: Adding "$" at the end of regex for test blocks run. Note this doesn't apply to describe blocks, which have to remain "open" so jest can match all the test items within.

## Related Issues
resolve #1042
resolve #1084