### PR TITLE
fix "each" block test run issues

### DIFF
--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -64,6 +64,8 @@ abstract class TestItemDataBase implements TestItemData, JestRunnable, WithUri {
     if (!this.isTestNameResolved()) {
       const parent = this.item.parent && this.context.getData(this.item.parent);
       if (parent) {
+        run.end({ reason: 'unresolved parameterized test' });
+        run.updateRequest(new vscode.TestRunRequest([parent.item]));
         return parent.scheduleTest(run, itemCommand);
       }
       this.context.output.write(`running an unresolved parameterized test might fail`, 'warn');

--- a/src/test-provider/test-provider-context.ts
+++ b/src/test-provider/test-provider-context.ts
@@ -84,13 +84,7 @@ export class JestTestProviderContext {
 
   createTestRun = (request: vscode.TestRunRequest, options?: JestTestRunOptions): JestTestRun => {
     const name = options?.name ?? `testRun-${SEQ++}`;
-    const createRun = (name: string) => {
-      const vscodeRun = this.controller.createTestRun(request, name);
-      vscodeRun.appendOutput(`\r\nTestRun "${name}" started\r\n`);
-      return vscodeRun;
-    };
-
-    return new JestTestRun(name, this, createRun);
+    return new JestTestRun(name, this, request, this.controller.createTestRun);
   };
 
   // tags

--- a/tests/manual-mocks.ts
+++ b/tests/manual-mocks.ts
@@ -24,6 +24,7 @@ jest.mock('../src/test-provider/jest-test-run', () => {
         write: jest.fn(),
         addProcess: jest.fn(),
         isClosed: jest.fn(() => false),
+        updateRequest: jest.fn(),
       };
     }),
   };

--- a/tests/test-provider/test-item-data.test.ts
+++ b/tests/test-provider/test-item-data.test.ts
@@ -786,12 +786,13 @@ describe('test-item-data', () => {
         expect(process.userData.testItem).toBe(folderData.item);
       });
       describe('if test name is not resolved', () => {
-        it('if there is a parent block => will execute it instead', () => {
+        it('will find the parent block that is resolved to execute instead', () => {
           const { doc } = createAllTestItems();
           const descNode: any = {
             fullName: 'a $describe',
             attrs: { nonLiteralName: true },
-            data: {},
+            childContainers: [],
+            childData: [],
           };
           const testNode: any = { fullName: 'a test', attrs: { isGroup: 'yes' }, data: {} };
           const descItem = new TestData(context, doc.uri, descNode, doc.item);
@@ -799,8 +800,13 @@ describe('test-item-data', () => {
           const jestRun = createTestRun();
 
           testItem.scheduleTest(jestRun);
+
           expect(process.userData.run).toBe(jestRun);
           expect(process.userData.testItem.id).toBe(doc.item.id);
+
+          expect(jestRun.end).toHaveBeenCalledTimes(2);
+          expect(jestRun.updateRequest).toHaveBeenCalledTimes(2);
+          expect(vscode.TestRunRequest).toHaveBeenLastCalledWith([doc.item]);
         });
         it('if failed to get parent block, will attempt to run the test anyway', () => {
           const { doc } = createAllTestItems();

--- a/tests/test-provider/test-provider-context.test.ts
+++ b/tests/test-provider/test-provider-context.test.ts
@@ -28,13 +28,13 @@ describe('JestTestProviderContext', () => {
     const jestRun = context.createTestRun(request, { name: 'test-run' });
 
     expect(jestRun).toBe(mockJestRun);
-    expect(JestTestRun).toHaveBeenCalledWith('test-run', context, expect.anything());
+    expect(JestTestRun).toHaveBeenCalledWith('test-run', context, request, expect.anything());
     // no vscode run should be created yet
     expect(mockController.createTestRun).not.toHaveBeenCalled();
 
     // vscode run will be created through the factory function
-    const factory = (JestTestRun as jest.Mocked<any>).mock.calls[0][2];
-    const run = factory('new-test-run');
+    const factory = (JestTestRun as jest.Mocked<any>).mock.calls[0][3];
+    const run = factory(request, 'new-test-run');
 
     expect(mockController.createTestRun).toHaveBeenCalledWith(request, 'new-test-run');
     expect(run).toBe(mockRun);

--- a/tests/test-provider/test-provider.test.ts
+++ b/tests/test-provider/test-provider.test.ts
@@ -115,7 +115,7 @@ describe('JestTestProvider', () => {
 
   describe('can discover tests', () => {
     it('test mockedJestTestRun', () => {
-      const jestRun = new JestTestRun('jest-run', {} as any, (() => {}) as any);
+      const jestRun = new JestTestRun('jest-run', {} as any, {} as any, (() => {}) as any);
       expect(jestRun.name).toBe('jest-run');
     });
     it('should only discover items with canResolveChildren = true', () => {


### PR DESCRIPTION
## Summary

Mainly fix the JestTestRun for the following two scenarios:

1. when running an unresolved test name block, such as `jest.each` or name as a non-literal string, the tests do not show status after the run.
2. when select "run all tests" for resolved ".each" blocks, the later runs override the earlier, leaving some test blocks marked as "skipped".