### PR TITLE
more fault tolerant for shell setting

### DIFF
--- a/src/JestExt/run-shell.ts
+++ b/src/JestExt/run-shell.ts
@@ -41,7 +41,7 @@ export class RunShell {
         this.nonLoginShell = setting;
         this.loginShell = this.getLoginShell(setting);
       } else {
-        if (setting.args.length > 0) {
+        if (setting.args?.length > 0) {
           this._useLoginShell = true;
           this.nonLoginShell = undefined;
           this.loginShell = setting;

--- a/tests/JestExt/run-shell.test.ts
+++ b/tests/JestExt/run-shell.test.ts
@@ -17,7 +17,7 @@ describe('RunnerShell', () => {
     console.error = jest.fn();
     console.warn = jest.fn();
   });
-  beforeEach(() => {});
+  beforeEach(() => { });
 
   describe('can initialize from a shell setting', () => {
     it.each`
@@ -30,6 +30,7 @@ describe('RunnerShell', () => {
       ${6} | ${'darwin'} | ${{ path: 'bash', args: ['--login'] }} | ${{ path: 'bash', args: ['--login'] }} | ${true}       | ${undefined}
       ${7} | ${'linux'}  | ${undefined}                           | ${LoginShells.sh}                      | ${false}      | ${undefined}
       ${8} | ${'linux'}  | ${'whatever'}                          | ${undefined}                           | ${'never'}    | ${undefined}
+      ${9} | ${'darwin'} | ${{ path: '/bin/zsh' }}                | ${LoginShells.zsh}                     | ${false}      | ${'/bin/zsh'}
     `('case $case', ({ platform, setting, loginShell, settingOverride, useLoginShell }) => {
       jest.clearAllMocks();
       mockPlatform.mockReturnValue(platform);

--- a/tests/JestExt/run-shell.test.ts
+++ b/tests/JestExt/run-shell.test.ts
@@ -17,7 +17,7 @@ describe('RunnerShell', () => {
     console.error = jest.fn();
     console.warn = jest.fn();
   });
-  beforeEach(() => { });
+  beforeEach(() => {});
 
   describe('can initialize from a shell setting', () => {
     it.each`


### PR DESCRIPTION
Make `"jest.shell"` setting init more fault-tolerant. 

Resolve #1099 