### PR TITLE
Minor docs updates for the migration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,22 +444,23 @@ The extension also features built-in conflict detection and quick fixes to assis
     "clearOnRun": "terminal"
   }
   ```
-  
-**Migration Guide**
-<a id="outputconfig-migration"></a>
 
-Migrating to the new `"jest.outputConfig"` can require some manual adjustments, especially if you're working in a multi-root workspace. Here are some guidelines to help with the transition:
-
-1. **Workspace Level vs Workspace-Folder Level**: The new `"jest.outputConfig"` is a workspace-level setting, unlike legacy settings like `"jest.autoClearTerminal"` and `"jest.autoRevealOutput"`, which are workspace-folder level settings.
-
-2. **Backward Compatibility**: If no `"jest.outputConfig"` is defined in your settings.json, the extension will attempt to generate a backward-compatible outputConfig in memory. This uses the `"testing.openTesting"` setting and any legacy settings (`"jest.autoClearTerminal"`, `"jest.autoRevealOutput"`) you might have. Note that this might only work for single-root workspaces.
-
-3. **Migration Steps**:
-   - Use the `"Jest: Save Current Output Config"` command from the command palette to update your settings.json.
-   - (optional) Fix warning: The save does not include `"testing.openTesting"`, so you might see the conflict warning message. You can either use the "Quick Fix" action or adjust the `settings.json` manually (see [handling conflict](#outputconfig-conflict)).
-   - Finally, remove any deprecated settings.
-
-By following these guidelines, you should be able to smoothly transition to using `"jest.outputConfig"`.
+> [!NOTE] 
+> **Migration Guide**
+> <a id="outputconfig-migration"></a>
+>
+> Migrating to the new `"jest.outputConfig"` can require some manual adjustments, especially if you're working in a multi-root workspace. Here are some guidelines to help with the transition:
+> 
+> 1. **Workspace Level vs Workspace-Folder Level**: The new `"jest.outputConfig"` is a workspace-level setting, unlike legacy settings like `"jest.autoClearTerminal"` and `"jest.autoRevealOutput"`, which are workspace-folder level settings.
+> 
+> 2. **Backward Compatibility**: If no `"jest.outputConfig"` is defined in your settings.json, the extension will attempt to generate a backward-compatible outputConfig in memory. This uses the `"testing.openTesting"` setting and any legacy settings (`"jest.autoClearTerminal"`, `"jest.autoRevealOutput"`) you might have. Note that this might only work for single-root workspaces.
+> 
+> 3. **Migration Steps**:
+>    - Use the `"Jest: Save Current Output Config"` command from the command palette to update your settings.json.
+>    - (optional) Fix warning: The save does not include `"testing.openTesting"`, so you might see the conflict warning message. You can either use the "Quick Fix" action or adjust the `settings.json` manually (see [handling conflict](#outputconfig-conflict)).
+>   - Finally, remove any deprecated settings.
+> 
+> By following these guidelines, you should be able to smoothly transition to using `"jest.outputConfig"`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ The extension also features built-in conflict detection and quick fixes to assis
     "clearOnRun": "terminal"
   }
   ```
- ``
+  
 **Migration Guide**
 <a id="outputconfig-migration"></a>
 

--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ Default is `"jest.monitorLongRun":60000` (1 minute)
 
 #### autoRevealOutput
  <div style="background-color: yellow; color: black; padding: 10px; border-radius: 5px;">
-  As of v6.1.0, this setting has been folded into <a href="#runmode">runMode</a>. For transition details, please refer to the <a href="#runmode-migration">runMode migration</a>.
+  As of v6.1.0, this setting has been folded into <a href="#outputconfig">outputConfig</a>. For transition details, please refer to the <a href="#outputconfig-migration">outputConfig migration</a>.
 </div>
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ The extension also features built-in conflict detection and quick fixes to assis
     "clearOnRun": "terminal"
   }
   ```
- 
+ ``
 **Migration Guide**
 <a id="outputconfig-migration"></a>
 
@@ -563,9 +563,9 @@ Starting from v6.1.0, if no runMode is defined in settings.json, the extension w
 ---
 
 #### autoRun
- <div style="background-color: yellow; color: black; padding: 10px; border-radius: 5px;">
-  Note: As of v6.1.0, autoRun will be replaced by <a href="#runmode">runMode</a>. For transition details, please refer to the <a href="#runmode-migration">runMode migration</a>.
-</div>
+
+> [!WARNING]
+>  As of v6.1.0, autoRun will be replaced by <a href="#runmode">runMode</a>. For transition details, please refer to the <a href="#runmode-migration">runMode migration</a>.
 
 AutoRun controls when tests should be executed automatically.
 
@@ -651,9 +651,8 @@ There are 2 ways to change autoRun:
 
 #### testExplorer
 
- <div style="background-color: yellow; color: black; padding: 10px; border-radius: 5px;">
-  As of v6.1.0, this setting has been folded into <a href="#runmode">runMode</a>. For transition details, please refer to the <a href="#runmode-migration">runMode migration</a>.
-</div>
+> [!WARNING]
+>   As of v6.1.0, this setting has been folded into <a href="#runmode">runMode</a>. For transition details, please refer to the <a href="#runmode-migration">runMode migration</a>.
 
   ```ts
   testExplorer = {showInlineError?: boolean}
@@ -697,9 +696,9 @@ Default is `"jest.monitorLongRun":60000` (1 minute)
 ---
 
 #### autoRevealOutput
- <div style="background-color: yellow; color: black; padding: 10px; border-radius: 5px;">
-  As of v6.1.0, this setting has been folded into <a href="#outputconfig">outputConfig</a>. For transition details, please refer to the <a href="#outputconfig-migration">outputConfig migration</a>.
-</div>
+
+> [!WARNING]
+>  As of v6.1.0, this setting has been folded into <a href="#outputconfig">outputConfig</a>. For transition details, please refer to the <a href="#outputconfig-migration">outputConfig migration</a>.
 
 ```ts
 autoRevealOutput = "on-run" | "on-exec-error" | "off"

--- a/README.md
+++ b/README.md
@@ -446,8 +446,8 @@ The extension also features built-in conflict detection and quick fixes to assis
   ```
 
 > [!NOTE] 
-> **Migration Guide**
 > <a id="outputconfig-migration"></a>
+> **Migration Guide**
 >
 > Migrating to the new `"jest.outputConfig"` can require some manual adjustments, especially if you're working in a multi-root workspace. Here are some guidelines to help with the transition:
 > 


### PR DESCRIPTION
The main change is to updating the migration for `autoRevealOutput` to point to `outputConfig` instead of `runMode`.

I also updated the formatting to use [alerts syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts). If you don't like it, I'm happy to update the PR. 

