### PR TITLE
Fixed missing test error auto focusing for watch mode run

### DIFF
--- a/release-notes/release-note-v6.md
+++ b/release-notes/release-note-v6.md
@@ -50,7 +50,8 @@ This release is a patch release with the following changes:
 
 **Bug Fixes**
 - Fixed an outputConfig initialization bug that did not honor "testing.openTesting": "openOnTestFailure" setting correctly. ([#1119](https://github.com/jest-community/vscode-jest/pull/1119) - @connectdotz)
- 
+- Fixed missing test error auto focusing for watch mode run. ([#1120](https://github.com/jest-community/vscode-jest/pull/1120) - @connectdotz) 
+  
 **New Command**
 - Added a new command `"Jest: Disable Auto Focus Test Output"` to easily disable TEST RESULTS panel auto focus. It will set the output to the "neutral" mode, i.e., no auto focusing. ([#1119](https://github.com/jest-community/vscode-jest/pull/1119) - @connectdotz)
 

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -204,6 +204,12 @@ export class JestExt {
         case 'end': {
           const state = event.error ? 'exec-error' : 'done';
           this.updateStatusBar({ state });
+
+          // testError should be persistent per run-cycle. Not clear up this flag at end end of the cycle
+          // could cause the processes with multiple run cycles, such as watch mode, to failed to act properly.
+          if (event.process.userData?.testError) {
+            event.process.userData.testError = undefined;
+          }
           break;
         }
         case 'exit':


### PR DESCRIPTION
The `process.userData.testError` flag should be reset at the end of the run-cycle; otherwise, for watch mode that uses the same process, it will not change focus after the first error test run.