### PR TITLE
improve default test results focus behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,8 +10,7 @@
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
   // jest
-  "jest.runMode":"on-demand",
-  // "testing.openTesting": "neverOpen",
+  
   // eslint
   "tslint.enable": false,
   "eslint.enable": true,

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Upon upgrading to v6.2, some users, frequently with auto run modes (e.g., 'watch
 > [!NOTE] 
 > 
 > **update**
-> In version 6.2.3, we've resolved this issue by modifying the default auto-focus behavior so the 'TEST RESULTS' panel will not automatically grab focus in auto-run modes, particularly when `"testing.openTesting"` or `"jest.outputConfig"` settings are not specified. This change should completely eliminate this issue.
+> In version 6.2.3, we've resolved this issue by modifying the default auto-focus behavior so the 'TEST RESULTS' panel will not automatically grab focus in auto-run modes, particularly when `"testing.openTesting"` and `"jest.outputConfig"` settings are not specified. This change should completely eliminate this issue.
 >
 > 
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ This setting can be one of the predefined types or a custom object.
 
 
 <a id="outputconfig-conflict"></a>
-**Handling Conflicts with "TEST RESULTS" panel**
+**Handling Conflicts with "TEST RESULTS" panel setting**
 
 _The Problem_
 
@@ -411,32 +411,18 @@ _Validation and Diagnosis_
 
 The extension features output config diagnosis information in the jest terminal, as well as the built-in conflict detection and quick fixes to assist with the transition.
 
-<a id="outputconfig-issues"></a>
-**Common Issues**
+<a id="default-output-focus"></a>
+**Default Output Focus Behavior by RunMode**
+When none of the output settings (`"testing.openTesting"` and `"jest.outputConfig"`) are present, The default output behavior is determined by [runMode](#runmode):
 
-Upon upgrading to v6.2, some users, frequently with auto run modes (e.g., 'watch', 'on-save'), might experience frequent "TEST RESULTS" panel automatically grabbing focus whenever files are saved or tests are run.
-
-> [!NOTE] 
-> 
-> **update**
-> In version 6.2.3, we've resolved this issue by modifying the default auto-focus behavior so the 'TEST RESULTS' panel will not automatically grab focus in auto-run modes, particularly when `"testing.openTesting"` and `"jest.outputConfig"` settings are not specified. This change should completely eliminate this issue.
->
-> 
-
-<details>
-
-<summary>Previous Workaround</summary>
-
-This is due to the extension generates a default `jest.outputConfig`, if none is existing in your settings, to match the existing `testing.openTesting` setting, which defaults to `"openOnTestStart"`. If this is not your desired output experience, you can easily disable `testing.openTesting` in your settings.json: 
-```json
-"testing.openTesting": "neverOpen"
-```
-Then use the `jest.outputConfig` to find-tune the output experience you prefer.
-
-</details>
+| runMode| auto reveal "TEST RESULTS" | auto reveal "TERMINAL" |
+|:--:|:--:|:--:|
+| "watch" | :heavy_multiplication_x: | :heavy_multiplication_x:|
+| "on-save" | :heavy_multiplication_x: | :heavy_multiplication_x: |
+| "on-demand" | :heavy_check_mark: | :heavy_multiplication_x:|
 
 
-**Examples**
+**Configuration Examples**
 - Choose a passive output experience that is identical to the previous version: no automatic focus switch, no automatic clear.
   ```json
   "testing.openTesting": "neverOpen",
@@ -447,7 +433,7 @@ Then use the `jest.outputConfig` to find-tune the output experience you prefer.
   "testing.openTesting": "neverOpen",
   "jest.outputConfig": "terminal-based"
   ```
-- Choose a test-results-based experience and switch focus to it when test fails.
+- Choose a test-results-based experience and switch focus to it only when test fails.
   ```json
   "testing.openTesting": "neverOpen",
   "jest.outputConfig": {

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ This setting can be one of the predefined types or a custom object.
     4. "none": Do not clear any panel. (default)
     (_**Note**: As of the current version, the testing framework does not support the clearing of the "TEST RESULTS" panel without side effects. The closest available command also clears all test item statuses, which may not be desirable. We are aware of this limitation and will raise the issue with the VS Code team._)
 
+
 <a id="outputconfig-conflict"></a>
 **Handling Conflicts with "TEST RESULTS" panel**
 
@@ -394,7 +395,7 @@ _The Problem_
 
 The behavior of the "TEST RESULTS" panel is influenced by VSCode's native `"testing.openTesting"` setting. This can cause inconsistencies with your `"jest.outputConfig"` settings.
 
-For instance, if you set `"jest.outputConfig": {"revealWithFocus": "none"}` to prevent automatic focus changes, but leave `"testing.openTesting"` at its default value of `"openOnTestStart"`, the "TEST RESULTS" panel will still automatically switch focus whenever tests run.
+For instance, if you set `"jest.outputConfig": {"revealWithFocus": "none"}` to prevent automatic focus changes, but leave `"testing.openTesting"` at its default value of `"openOnTestStart"`, the "TEST RESULTS" panel will still automatically switch focus when the tests are run via UI.
 
 _The Universal Solution_
 
@@ -415,11 +416,25 @@ The extension features output config diagnosis information in the jest terminal,
 
 Upon upgrading to v6.2, some users, frequently with auto run modes (e.g., 'watch', 'on-save'), might experience frequent "TEST RESULTS" panel automatically grabbing focus whenever files are saved or tests are run.
 
+> [!NOTE] 
+> 
+> **update**
+> In version 6.2.3, we've resolved this issue by modifying the default auto-focus behavior so the 'TEST RESULTS' panel will not automatically grab focus in auto-run modes, particularly when `"testing.openTesting"` or `"jest.outputConfig"` settings are not specified. This change should completely eliminate this issue.
+>
+> 
+
+<details>
+
+<summary>Previous Workaround</summary>
+
 This is due to the extension generates a default `jest.outputConfig`, if none is existing in your settings, to match the existing `testing.openTesting` setting, which defaults to `"openOnTestStart"`. If this is not your desired output experience, you can easily disable `testing.openTesting` in your settings.json: 
 ```json
 "testing.openTesting": "neverOpen"
 ```
 Then use the `jest.outputConfig` to find-tune the output experience you prefer.
+
+</details>
+
 
 **Examples**
 - Choose a passive output experience that is identical to the previous version: no automatic focus switch, no automatic clear.
@@ -431,11 +446,6 @@ Then use the `jest.outputConfig` to find-tune the output experience you prefer.
   ```json
   "testing.openTesting": "neverOpen",
   "jest.outputConfig": "terminal-based"
-  ```
-- Choose a test-results-based experience and switch focus to it when test run starts.
-  ```json
-  "testing.openTesting": "neverOpen",
-  "jest.outputConfig": "test-results-based"
   ```
 - Choose a test-results-based experience and switch focus to it when test fails.
   ```json
@@ -457,16 +467,17 @@ Then use the `jest.outputConfig` to find-tune the output experience you prefer.
 > <a id="outputconfig-migration"></a>
 > **Migration Guide**
 >
-> Migrating to the new `"jest.outputConfig"` can require some manual adjustments, especially if you're working in a multi-root workspace. Here are some guidelines to help with the transition:
+> Migrating to the new `"jest.outputConfig"` might require some manual adjustments, especially if you're working in a multi-root workspace. Here are some guidelines to help with the transition:
 > 
 > 1. **Workspace Level vs Workspace-Folder Level**: The new `"jest.outputConfig"` is a workspace-level setting, unlike legacy settings like `"jest.autoClearTerminal"` and `"jest.autoRevealOutput"`, which are workspace-folder level settings.
 > 
 > 2. **Backward Compatibility**: If no `"jest.outputConfig"` is defined in your settings.json, the extension will attempt to generate a backward-compatible outputConfig in memory. This uses the `"testing.openTesting"` setting and any legacy settings (`"jest.autoClearTerminal"`, `"jest.autoRevealOutput"`) you might have. Note that this might only work for single-root workspaces.
 > 
-> 3. **Migration Steps**:
->    - Use the `"Jest: Save Current Output Config"` command from the command palette to update your settings.json.
->    - (optional) Fix warning: The save does not include `"testing.openTesting"`, so you might see the conflict warning message. You can either use the "Quick Fix" action or adjust the `settings.json` manually (see [handling conflict](#outputconfig-conflict)).
->   - Finally, remove any deprecated settings.
+> 3. **Customization Steps**:
+In general it should work out of the box, but if you encounter any issues, here are some steps to help adjusting the output behavior:
+>    - Use the `"Jest: Save Current Output Config"` command from the command palette to update your settings.json. Then adjust it to fit your needs.
+>    - Fix warning if any: The save does not include `"testing.openTesting"`, so you might see the conflict warning message. You can either use the "Quick Fix" action or adjust the `settings.json` manually (see [handling conflict](#outputconfig-conflict)).
+>    - Finally, remove any deprecated settings.
 > 
 > By following these guidelines, you should be able to smoothly transition to using `"jest.outputConfig"`.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.68.1"

--- a/release-notes/release-note-v6.md
+++ b/release-notes/release-note-v6.md
@@ -3,6 +3,7 @@
 Release Notes <!-- omit in toc --> 
 ---
 
+- [v6.2.3](#v623)
 - [v6.2.2](#v622)
   - [CHANGELOG](#changelog)
 - [v6.2.1](#v621)
@@ -35,6 +36,14 @@ Release Notes <!-- omit in toc -->
 
 ---
 
+## v6.2.3
+This release is a patch release with the following changes:
+
+**Enhancement**  
+
+- Improve output-focus default behavior for auto runs (e.g., "watch", "on-save"). This will eliminate the issue that the focus auto switching to "TEST RESULTS" panel whenever files are saved in auto-run modes. Now the default behavior is runMode aware and will not auto switch for auto runs unless specifically configured to do so. See [default output focus behavior](https://github.com/jest-community/vscode-jest#default-output-focus). ([#1128](https://github.com/jest-community/vscode-jest/pull/1128) - @connectdotz)
+- docs: update README to fix jest run mode type. ([#1126](https://github.com/jest-community/vscode-jest/pull/1126) - @kota-kamikawa)
+  
 ## v6.2.2
 This release is a patch release with the following changes:
 

--- a/src/Settings/helper.ts
+++ b/src/Settings/helper.ts
@@ -1,5 +1,10 @@
 import * as vscode from 'vscode';
-import { GetConfigFunction, VirtualFolderSettings, VirtualFolderSettingKey } from './types';
+import {
+  GetConfigFunction,
+  VirtualFolderSettings,
+  VirtualFolderSettingKey,
+  SettingDetail,
+} from './types';
 import { isVirtualWorkspaceFolder } from '../virtual-workspace-folder';
 
 /**
@@ -54,4 +59,24 @@ export const updateSetting = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (vFolder as any)[key] = value;
   await config.update('virtualFolders', virtualFolders);
+};
+
+export const getSettingDetail = <T>(configName: string, section: string): SettingDetail<T> => {
+  // Use the `inspect` method to get detailed information about the setting
+  const config = vscode.workspace.getConfiguration(configName);
+  const value = config.get<T>(section);
+  const settingInspection = config.inspect<T>(section);
+
+  if (settingInspection) {
+    const isExplicitlySet =
+      settingInspection.globalValue !== undefined ||
+      settingInspection.workspaceValue !== undefined ||
+      settingInspection.workspaceFolderValue !== undefined ||
+      settingInspection.globalLanguageValue !== undefined ||
+      settingInspection.workspaceLanguageValue !== undefined ||
+      settingInspection.workspaceFolderLanguageValue !== undefined;
+
+    return { value, isExplicitlySet };
+  }
+  return { value: undefined, isExplicitlySet: false };
 };

--- a/src/Settings/types.ts
+++ b/src/Settings/types.ts
@@ -97,3 +97,9 @@ export interface VirtualFolderSettings extends AllPluginResourceSettings {
 }
 
 export type GetConfigFunction = <T>(key: VirtualFolderSettingKey) => T | undefined;
+
+export interface SettingDetail<T> {
+  value: T | undefined;
+  /** true if the setting is explicitly defined in a settings file, i.e., not from default value */
+  isExplicitlySet: boolean;
+}

--- a/src/extension-manager.ts
+++ b/src/extension-manager.ts
@@ -531,6 +531,7 @@ export class ExtensionManager {
 
 const ReleaseNoteBase = 'https://github.com/jest-community/vscode-jest/blob/master/release-notes';
 const ReleaseNotes: Record<string, string> = {
+  '6.2.3': `${ReleaseNoteBase}/release-note-v6.md#v623`,
   '6.2.2': `${ReleaseNoteBase}/release-note-v6.md#v622`,
   '6.2.0': `${ReleaseNoteBase}/release-note-v6.md#v620`,
   '6.1.0': `${ReleaseNoteBase}/release-note-v6.md#v610-pre-release`,

--- a/tests/Settings/helper.test.ts
+++ b/tests/Settings/helper.test.ts
@@ -139,3 +139,78 @@ describe('updateSetting', () => {
     await expect(updateSetting(v2, key, value)).rejects.toThrow();
   });
 });
+import { getSettingDetail } from '../../src/Settings/helper';
+
+describe('getSettingDetail', () => {
+  it('should return the value and isExplicitlySet true when the setting is explicitly set', () => {
+    const configName = 'testing';
+    const section = 'openTesting';
+    const explicitValue = 'openOnTestFailure';
+    const settingInspection = {
+      globalValue: undefined,
+      workspaceValue: explicitValue,
+      workspaceFolderValue: undefined,
+      globalLanguageValue: undefined,
+      workspaceLanguageValue: undefined,
+      workspaceFolderLanguageValue: undefined,
+    };
+
+    const mockConfig = {
+      get: jest.fn().mockReturnValue(explicitValue),
+      inspect: jest.fn().mockReturnValue(settingInspection),
+    };
+    vscode.workspace.getConfiguration = jest.fn().mockReturnValue(mockConfig);
+
+    const result = getSettingDetail<string>(configName, section);
+
+    expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith(configName);
+    expect(mockConfig.get).toHaveBeenCalledWith(section);
+    expect(mockConfig.inspect).toHaveBeenCalledWith(section);
+    expect(result).toEqual({ value: explicitValue, isExplicitlySet: true });
+  });
+  it('should return the default value and isExplicitlySet false when the setting is not explicitly set', () => {
+    const configName = 'testing';
+    const section = 'openTesting';
+    const defaultValue = 'openOnTestStart';
+    const settingInspection = {
+      globalValue: undefined,
+      workspaceValue: undefined,
+      workspaceFolderValue: undefined,
+      globalLanguageValue: undefined,
+      workspaceLanguageValue: undefined,
+      workspaceFolderLanguageValue: undefined,
+    };
+
+    const mockConfig = {
+      get: jest.fn().mockReturnValue(defaultValue),
+      inspect: jest.fn().mockReturnValue(settingInspection),
+    };
+    vscode.workspace.getConfiguration = jest.fn().mockReturnValue(mockConfig);
+
+    const result = getSettingDetail<string>(configName, section);
+
+    expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith(configName);
+    expect(mockConfig.get).toHaveBeenCalledWith(section);
+    expect(mockConfig.inspect).toHaveBeenCalledWith(section);
+    expect(result).toEqual({ value: defaultValue, isExplicitlySet: false });
+  });
+
+  it('should return undefined value and isExplicitlySet flag as false when inspection failed', () => {
+    const configName = 'jest';
+    const section = 'wrongSetting';
+    const settingInspection = null;
+
+    const mockConfig = {
+      get: jest.fn(),
+      inspect: jest.fn().mockReturnValue(settingInspection),
+    };
+    vscode.workspace.getConfiguration = jest.fn().mockReturnValue(mockConfig);
+
+    const result = getSettingDetail<string>(configName, section);
+
+    expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith(configName);
+    expect(mockConfig.get).toHaveBeenCalledWith(section);
+    expect(mockConfig.inspect).toHaveBeenCalledWith(section);
+    expect(result).toEqual({ value: undefined, isExplicitlySet: false });
+  });
+});


### PR DESCRIPTION
This is to change the default test results panel focusing behavior for auto-run modes (watch, on-save) when no `"testing.openTesting"` and `"jest.outputConfig"` is defined. While there is an easy workaround, it has nevertheless interrupted users' workflow. This fix should eliminate the root cause; thus, no workaround will be needed anymore.

This PR introduce different default behavior by run-mode:
- For watch and on-save, when nothing is defined (the default), test results panel will **not** auto switch focus. 
- For on-demand, when nothing is defined (the default), test results panel will auto switch focus. => same as v6.2.2

Also removed the auto-run mode warning since it is no longer needed.

This is to improve the following issues further:

- #1111
- #1113
- #1117
- #1122
