### PR TITLE
fix "Jest: Run All Test" command blocked by watch mode run

### DIFF
--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -621,7 +621,7 @@ export class JestExt {
     await this.exitDeferMode();
 
     if (!editor) {
-      if (this.processSession.scheduleProcess({ type: 'all-tests' })) {
+      if (this.processSession.scheduleProcess({ type: 'all-tests', nonBlocking: true })) {
         this.dirtyFiles.clear();
         return;
       }

--- a/src/JestExt/process-session.ts
+++ b/src/JestExt/process-session.ts
@@ -33,36 +33,46 @@ const getTransform = (request: JestExtRequestType): JestProcessRequestTransform 
   }
 };
 
-const ProcessScheduleStrategy: Record<JestTestProcessType, ScheduleStrategy> = {
-  // abort if there is already an pending request
-  'all-tests': { queue: 'blocking', dedupe: { filterByStatus: ['pending'] } },
-  'watch-tests': { queue: 'blocking', dedupe: { filterByStatus: ['pending'] } },
-  'watch-all-tests': {
-    queue: 'blocking',
-    dedupe: { filterByStatus: ['pending'] },
-  },
-
-  // abort if there is already identical pending request
-  'by-file': {
-    queue: 'blocking-2',
-    dedupe: { filterByStatus: ['pending'] },
-  },
-  'by-file-test': {
-    queue: 'blocking-2',
-    dedupe: { filterByStatus: ['pending'], filterByContent: true },
-  },
-  'by-file-pattern': {
-    queue: 'blocking-2',
-    dedupe: { filterByStatus: ['pending'] },
-  },
-  'by-file-test-pattern': {
-    queue: 'blocking-2',
-    dedupe: { filterByStatus: ['pending'], filterByContent: true },
-  },
-  'not-test': {
-    queue: 'non-blocking',
-    dedupe: { filterByStatus: ['pending'] },
-  },
+const getScheduleStrategy = (requestType: JestTestProcessType): ScheduleStrategy => {
+  switch (requestType) {
+    // abort if there is already an pending request
+    case 'all-tests':
+      return { queue: 'blocking', dedupe: { filterByStatus: ['pending'] } };
+    case 'watch-tests':
+      return { queue: 'blocking', dedupe: { filterByStatus: ['pending'] } };
+    case 'watch-all-tests':
+      return {
+        queue: 'blocking',
+        dedupe: { filterByStatus: ['pending'] },
+      };
+    case 'by-file':
+      return {
+        queue: 'blocking-2',
+        dedupe: { filterByStatus: ['pending'] },
+      };
+    case 'by-file-test':
+      return {
+        queue: 'blocking-2',
+        dedupe: { filterByStatus: ['pending'], filterByContent: true },
+      };
+    case 'by-file-pattern':
+      return {
+        queue: 'blocking-2',
+        dedupe: { filterByStatus: ['pending'] },
+      };
+    case 'by-file-test-pattern':
+      return {
+        queue: 'blocking-2',
+        dedupe: { filterByStatus: ['pending'], filterByContent: true },
+      };
+    case 'not-test':
+      return {
+        queue: 'non-blocking',
+        dedupe: { filterByStatus: ['pending'] },
+      };
+    default:
+      throw new Error(`Unexpected request type ${requestType}`);
+  }
 };
 
 export interface ProcessSession {
@@ -127,14 +137,24 @@ export const createProcessSession = (context: JestExtProcessContext): ProcessSes
 
     const lSession = listenerSession;
     switch (request.type) {
-      case 'all-tests':
+      case 'all-tests': {
+        const schedule = getScheduleStrategy(request.type);
+        if (request.nonBlocking) {
+          schedule.queue = 'blocking-2';
+        }
+        return transform({
+          ...request,
+          listener: new RunTestListener(lSession),
+          schedule,
+        });
+      }
       case 'watch-all-tests':
       case 'watch-tests':
       case 'by-file':
       case 'by-file-pattern':
       case 'by-file-test':
       case 'by-file-test-pattern': {
-        const schedule = ProcessScheduleStrategy[request.type];
+        const schedule = getScheduleStrategy(request.type);
         return transform({
           ...request,
           listener: new RunTestListener(lSession),
@@ -142,7 +162,7 @@ export const createProcessSession = (context: JestExtProcessContext): ProcessSes
         });
       }
       case 'list-test-files': {
-        const schedule = ProcessScheduleStrategy['not-test'];
+        const schedule = getScheduleStrategy('not-test');
         return transform({
           ...request,
           type: 'not-test',
@@ -165,7 +185,8 @@ export const createProcessSession = (context: JestExtProcessContext): ProcessSes
     }
 
     if (context.settings.runMode.config.runAllTestsOnStartup) {
-      scheduleProcess({ type: 'all-tests' });
+      // on startup, run all tests in blocking mode always
+      scheduleProcess({ type: 'all-tests', nonBlocking: false });
     }
     if (context.settings.runMode.config.type === 'watch') {
       scheduleProcess({ type: 'watch-tests' });

--- a/src/JestExt/process-session.ts
+++ b/src/JestExt/process-session.ts
@@ -70,8 +70,6 @@ const getScheduleStrategy = (requestType: JestTestProcessType): ScheduleStrategy
         queue: 'non-blocking',
         dedupe: { filterByStatus: ['pending'] },
       };
-    default:
-      throw new Error(`Unexpected request type ${requestType}`);
   }
 };
 

--- a/src/JestProcessManagement/types.ts
+++ b/src/JestProcessManagement/types.ts
@@ -62,6 +62,7 @@ export type JestProcessRequestSimple =
   | {
       type: Extract<JestTestProcessType, 'all-tests'>;
       updateSnapshot?: boolean;
+      nonBlocking?: boolean;
     }
   | {
       type: Extract<JestTestProcessType, 'by-file'>;

--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -11,7 +11,7 @@ import { TestSuitChangeEvent } from '../TestResults/test-result-events';
 import { Debuggable, ItemCommand, TestItemData } from './types';
 import { JestTestProviderContext } from './test-provider-context';
 import { JestTestRun } from './jest-test-run';
-import { JestProcessInfo, JestProcessRequest } from '../JestProcessManagement';
+import { JestProcessInfo } from '../JestProcessManagement';
 import { GENERIC_ERROR, LONG_RUNNING_TESTS, getExitErrorDef } from '../errors';
 import { tiContextManager } from './test-item-context-manager';
 import { runModeDescription } from '../JestExt/run-mode';
@@ -153,12 +153,8 @@ export class WorkspaceRoot extends TestItemDataBase {
   }
 
   getJestRunRequest(itemCommand?: ItemCommand): JestExtRequestType {
-    const transform = (request: JestProcessRequest) => {
-      request.schedule.queue = 'blocking-2';
-      return request;
-    };
     const updateSnapshot = itemCommand === ItemCommand.updateSnapshot;
-    return { type: 'all-tests', updateSnapshot, transform };
+    return { type: 'all-tests', nonBlocking: true, updateSnapshot };
   }
   discoverTest(run: JestTestRun): void {
     const testList = this.context.ext.testResultProvider.getTestList();

--- a/tests/JestExt/core.test.ts
+++ b/tests/JestExt/core.test.ts
@@ -875,7 +875,10 @@ describe('JestExt', () => {
         dirtyFiles.clear = jest.fn();
 
         await sut.runAllTests();
-        expect(mockProcessSession.scheduleProcess).toHaveBeenCalledWith({ type: 'all-tests' });
+        expect(mockProcessSession.scheduleProcess).toHaveBeenCalledWith({
+          type: 'all-tests',
+          nonBlocking: true,
+        });
         if (scheduleProcess) {
           expect(dirtyFiles.clear).toHaveBeenCalled();
         } else {

--- a/tests/JestExt/process-session.test.ts
+++ b/tests/JestExt/process-session.test.ts
@@ -50,6 +50,7 @@ describe('ProcessSession', () => {
     it.each`
       type                      | inputProperty                                                | expectedSchedule                                                                           | expectedExtraProperty
       ${'all-tests'}            | ${undefined}                                                 | ${{ queue: 'blocking', dedupe: { filterByStatus: ['pending'] } }}                          | ${undefined}
+      ${'all-tests'}            | ${{ nonBlocking: true }}                                     | ${{ queue: 'blocking-2', dedupe: { filterByStatus: ['pending'] } }}                        | ${undefined}
       ${'all-tests'}            | ${{ transform }}                                             | ${{ queue: 'blocking-2', dedupe: { filterByStatus: ['pending'] } }}                        | ${undefined}
       ${'watch-tests'}          | ${undefined}                                                 | ${{ queue: 'blocking', dedupe: { filterByStatus: ['pending'] } }}                          | ${undefined}
       ${'watch-all-tests'}      | ${undefined}                                                 | ${{ queue: 'blocking', dedupe: { filterByStatus: ['pending'] } }}                          | ${undefined}

--- a/tests/JestExt/process-session.test.ts
+++ b/tests/JestExt/process-session.test.ts
@@ -143,6 +143,22 @@ describe('ProcessSession', () => {
         expect(requestTypes).toEqual(expectedRequests);
       }
     );
+    it('if runAllTestsOnStartup is true, it will run all tests in blocking queue', async () => {
+      expect.hasAssertions();
+      const runMode = new RunMode({ type: 'watch', runAllTestsOnStartup: true });
+      context.settings = { runMode };
+      processManagerMock.numberOfProcesses.mockReturnValue(0);
+      const session = createProcessSession(context);
+      await session.start();
+
+      expect(processManagerMock.scheduleJestProcess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'all-tests',
+          schedule: expect.objectContaining({ queue: 'blocking' }),
+        }),
+        undefined
+      );
+    });
     it('will clear all process before starting new ones', async () => {
       expect.hasAssertions();
       context.settings = { runMode: new RunMode() };

--- a/tests/test-provider/test-item-data.test.ts
+++ b/tests/test-provider/test-item-data.test.ts
@@ -693,14 +693,13 @@ describe('test-item-data', () => {
         process = mockScheduleProcess(context);
       });
       describe('run request', () => {
-        it('WorkspaceRoot runs all tests in the workspace in blocking-2 queue', () => {
+        it('WorkspaceRoot runs all tests in the workspace with non-blocking flag', () => {
           const wsRoot = new WorkspaceRoot(context);
           const jestRun = createTestRun();
           wsRoot.scheduleTest(jestRun);
           const r = context.ext.session.scheduleProcess.mock.calls[0][0];
           expect(r.type).toEqual('all-tests');
-          const transformed = r.transform({ schedule: { queue: 'blocking' } });
-          expect(transformed.schedule.queue).toEqual('blocking-2');
+          expect(r.nonBlocking).toEqual(true);
         });
         it('FolderData runs all tests inside the folder', () => {
           const parent: any = controllerMock.createTestItem('ws-1', 'ws-1', { fsPath: '/ws-1' });


### PR DESCRIPTION
resolves #1131 

The "Jest: Run All Test" command tries to run a blocking jest run that could be blocked by the watch mode runs. This PR made this command run with the same non-blocking queue by other UI-triggered runs.

