### PR TITLE
fixing #1145

### DIFF
--- a/src/test-provider/jest-test-run.ts
+++ b/src/test-provider/jest-test-run.ts
@@ -68,7 +68,13 @@ export class JestTestRun implements JestExtOutput, TestRunProtocol {
     if (!this._run && !this.isCancelled) {
       const runName = `${this.name} (${this.runCount++})`;
 
-      this._run = this.createRun(this.request, runName);
+      // vscode seems to identify run by the request instance, so we need to create a new request for each run
+      const request = new vscode.TestRunRequest(
+        this.request.include,
+        this.request.exclude,
+        this.request.profile
+      );
+      this._run = this.createRun(request, runName);
       this._run.appendOutput(`\r\nTestRun "${runName}" started\r\n`);
 
       // ignore skipped tests if there are more than one test to run

--- a/tests/test-provider/jest-test-runt.test.ts
+++ b/tests/test-provider/jest-test-runt.test.ts
@@ -44,6 +44,8 @@ describe('JestTestRun', () => {
       }));
 
     mockRequest = {};
+    (vscode.TestRunRequest as jest.Mocked<any>).mockClear();
+    (vscode.TestRunRequest as jest.Mocked<any>).mockImplementation(() => mockRequest);
     jestRun = new JestTestRun('test', mockContext, mockRequest, mockCreateTestRun);
   });
 
@@ -365,10 +367,36 @@ describe('JestTestRun', () => {
       expect(run1.end).toHaveBeenCalled();
 
       const newRequest: any = { include: ['test1'] };
+      (vscode.TestRunRequest as jest.Mocked<any>).mockImplementation(() => newRequest);
       jestRun.updateRequest(newRequest);
       jestRun.started({} as any);
       expect(mockCreateTestRun).toHaveBeenCalledTimes(2);
-      expect(mockCreateTestRun.mock.calls[1][0]).toBe(newRequest);
+      expect(mockCreateTestRun.mock.calls[1][0]).toEqual(newRequest);
+      expect(vscode.TestRunRequest).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('supports continuous test run', () => {
+    it('by start/stop underlying TestRun per continuous run session', () => {
+      jestRun = new JestTestRun('test', mockContext, mockRequest, mockCreateTestRun);
+
+      // first run
+      jestRun.started({} as any);
+      expect(mockCreateTestRun).toHaveBeenCalledTimes(1);
+      const run1 = mockCreateTestRun.mock.results[0].value;
+      expect(run1.started).toHaveBeenCalled();
+      jestRun.end();
+      expect(run1.end).toHaveBeenCalled();
+      expect(vscode.TestRunRequest).toHaveBeenCalledTimes(1);
+
+      // 2nd run
+      jestRun.started({} as any);
+      expect(mockCreateTestRun).toHaveBeenCalledTimes(2);
+      const run2 = mockCreateTestRun.mock.results[1].value;
+      expect(run2.started).toHaveBeenCalled();
+      jestRun.end();
+      expect(run2.end).toHaveBeenCalled();
+      expect(vscode.TestRunRequest).toHaveBeenCalledTimes(2);
     });
   });
   describe('cancel', () => {


### PR DESCRIPTION
It seems vscode might have changed how it handles run identity in recent releases. When we passed the same request upon creating a new TestRun, it was ignored. This PR is to make sure we recreate the request for the new run so it can be handled properly.

Resolve #1145 