### PR TITLE
Support Jest v30

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,6 +366,12 @@
               "markdownDescription": "A detailed runMode configuration. See details in [runMode](https://github.com/jest-community/vscode-jest#runmode)"
             }
           ]
+        },
+        "jest.useJest30": {
+          "description": "Use Jest 30+ features",
+          "type": "boolean",
+          "default": null,
+          "scope": "resource"
         }
       }
     },

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -107,6 +107,7 @@ export const getExtensionResourceSettings = (
     parserPluginOptions: getSetting<JESParserPluginOptions>('parserPluginOptions'),
     enable: getSetting<boolean>('enable'),
     useDashedArgs: getSetting<boolean>('useDashedArgs') ?? false,
+    useJest30: getSetting<boolean>('useJest30'),
   };
 };
 

--- a/src/JestProcessManagement/JestProcess.ts
+++ b/src/JestProcessManagement/JestProcess.ts
@@ -122,6 +122,11 @@ export class JestProcess implements JestProcessInfo {
     return `"${removeSurroundingQuote(aString)}"`;
   }
 
+  private getTestPathPattern(pattern: string): string[] {
+    return this.extContext.settings.useJest30
+      ? ['--testPathPatterns', pattern]
+      : ['--testPathPattern', pattern];
+  }
   public start(): Promise<void> {
     if (this.status === ProcessStatus.Cancelled) {
       this.logging('warn', `the runner task has been cancelled!`);
@@ -166,7 +171,7 @@ export class JestProcess implements JestProcessInfo {
       }
       case 'by-file-pattern': {
         const regex = this.quoteFilePattern(escapeRegExp(this.request.testFileNamePattern));
-        args.push('--watchAll=false', '--testPathPattern', regex);
+        args.push('--watchAll=false', ...this.getTestPathPattern(regex));
         if (this.request.updateSnapshot) {
           args.push('--updateSnapshot');
         }
@@ -191,7 +196,7 @@ export class JestProcess implements JestProcessInfo {
           escapeRegExp(this.request.testNamePattern),
           this.extContext.settings.shell.toSetting()
         );
-        args.push('--watchAll=false', '--testPathPattern', regex);
+        args.push('--watchAll=false', ...this.getTestPathPattern(regex));
         if (this.request.updateSnapshot) {
           args.push('--updateSnapshot');
         }

--- a/src/Settings/types.ts
+++ b/src/Settings/types.ts
@@ -77,6 +77,7 @@ export interface PluginResourceSettings {
   enable?: boolean;
   parserPluginOptions?: JESParserPluginOptions;
   useDashedArgs?: boolean;
+  useJest30?: boolean;
 }
 
 export interface DeprecatedPluginResourceSettings {

--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -370,6 +370,9 @@ export class WorkspaceRoot extends TestItemDataBase {
         fileName = process.request.testFileNamePattern;
         break;
       default:
+        // the current flow would not reach here, but for future proofing
+        // and avoiding failed silently, we will keep the code around but disable coverage reporting
+        /* istanbul ignore next */
         throw new Error(`unsupported external process type ${process.request.type}`);
     }
 
@@ -405,8 +408,9 @@ export class WorkspaceRoot extends TestItemDataBase {
       return;
     }
 
+    let run;
     try {
-      const run = this.getJestRun(event, true);
+      run = this.getJestRun(event, true);
       switch (event.type) {
         case 'scheduled': {
           this.deepItemState(event.process.userData?.testItem, run.enqueued);
@@ -461,7 +465,8 @@ export class WorkspaceRoot extends TestItemDataBase {
       }
     } catch (err) {
       this.log('error', `<onRunEvent> ${event.type} failed:`, err);
-      this.context.output.write(`<onRunEvent> ${event.type} failed: ${err}`, 'error');
+      run?.write(`<onRunEvent> ${event.type} failed: ${err}`, 'error');
+      run?.end({ reason: 'Internal error onRunEvent' });
     }
   };
 

--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -355,7 +355,6 @@ export class WorkspaceRoot extends TestItemDataBase {
       return process.userData.testItem;
     }
 
-    // should only come here for autoRun processes
     let fileName;
     switch (process.request.type) {
       case 'watch-tests':
@@ -366,6 +365,7 @@ export class WorkspaceRoot extends TestItemDataBase {
         fileName = process.request.testFileName;
         break;
       case 'by-file-pattern':
+      case 'by-file-test-pattern':
         fileName = process.request.testFileNamePattern;
         break;
       default:

--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -362,6 +362,7 @@ export class WorkspaceRoot extends TestItemDataBase {
       case 'all-tests':
         return this.item;
       case 'by-file':
+      case 'by-file-test':
         fileName = process.request.testFileName;
         break;
       case 'by-file-pattern':

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -177,6 +177,7 @@ describe('getExtensionResourceSettings()', () => {
       enable: true,
       nodeEnv: undefined,
       useDashedArgs: false,
+      useJest30: null,
     });
     expect(createJestSettingGetter).toHaveBeenCalledWith(folder);
   });

--- a/tests/JestProcessManagement/JestProcess.test.ts
+++ b/tests/JestProcessManagement/JestProcess.test.ts
@@ -186,6 +186,28 @@ describe('JestProcess', () => {
         }
       );
     });
+    describe('supports jest v30 options', () => {
+      it.each`
+        case | type                      | extraProperty                                             | useJest30 | expectedOption
+        ${1} | ${'by-file-pattern'}      | ${{ testFileNamePattern: 'abc' }}                         | ${null}   | ${'--testPathPattern'}
+        ${2} | ${'by-file-pattern'}      | ${{ testFileNamePattern: 'abc' }}                         | ${true}   | ${'--testPathPatterns'}
+        ${3} | ${'by-file-pattern'}      | ${{ testFileNamePattern: 'abc' }}                         | ${false}  | ${'--testPathPattern'}
+        ${4} | ${'by-file-test-pattern'} | ${{ testFileNamePattern: 'abc', testNamePattern: 'abc' }} | ${null}   | ${'--testPathPattern'}
+        ${5} | ${'by-file-test-pattern'} | ${{ testFileNamePattern: 'abc', testNamePattern: 'abc' }} | ${true}   | ${'--testPathPatterns'}
+        ${6} | ${'by-file-test-pattern'} | ${{ testFileNamePattern: 'abc', testNamePattern: 'abc' }} | ${false}  | ${'--testPathPattern'}
+      `(
+        'case $case: generate the correct TestPathPattern(s) option',
+        ({ type, extraProperty, useJest30, expectedOption }) => {
+          expect.hasAssertions();
+          extContext.settings.useJest30 = useJest30;
+          const request = mockRequest(type, extraProperty);
+          const jp = new JestProcess(extContext, request);
+          jp.start();
+          const [, options] = RunnerClassMock.mock.calls[0];
+          expect(options.args.args).toContain(expectedOption);
+        }
+      );
+    });
     describe('common flags', () => {
       it.each`
         type                      | extraProperty                                                    | excludeWatch | withColors

--- a/tests/test-provider/test-item-data.test.ts
+++ b/tests/test-provider/test-item-data.test.ts
@@ -1404,13 +1404,15 @@ describe('test-item-data', () => {
             mockedJestTestRun.mockClear();
           });
           describe.each`
-            request                                                              | withFile
-            ${{ type: 'watch-tests' }}                                           | ${false}
-            ${{ type: 'watch-all-tests' }}                                       | ${false}
-            ${{ type: 'all-tests' }}                                             | ${false}
-            ${{ type: 'by-file', testFileName: file }}                           | ${true}
-            ${{ type: 'by-file', testFileName: 'source.ts', notTestFile: true }} | ${false}
-            ${{ type: 'by-file-pattern', testFileNamePattern: file }}            | ${true}
+            request                                                                                     | withFile
+            ${{ type: 'watch-tests' }}                                                                  | ${false}
+            ${{ type: 'watch-all-tests' }}                                                              | ${false}
+            ${{ type: 'all-tests' }}                                                                    | ${false}
+            ${{ type: 'by-file', testFileName: file }}                                                  | ${true}
+            ${{ type: 'by-file', testFileName: 'source.ts', notTestFile: true }}                        | ${false}
+            ${{ type: 'by-file-test', testFileName: file, testNamePattern: 'whatever' }}                | ${true}
+            ${{ type: 'by-file-pattern', testFileNamePattern: file }}                                   | ${true}
+            ${{ type: 'by-file-test-pattern', testFileNamePattern: file, testNamePattern: 'whatever' }} | ${true}
           `('will create a new run and use it throughout: $request', ({ request, withFile }) => {
             it('if only reports assertion-update, everything should still work', () => {
               const process: any = { id: 'whatever', request };
@@ -1515,8 +1517,6 @@ describe('test-item-data', () => {
             it.each`
               request
               ${{ type: 'not-test' }}
-              ${{ type: 'by-file-test', testFileName: file, testNamePattern: 'whatever' }}
-              ${{ type: 'by-file-test-pattern', testFileNamePattern: file, testNamePattern: 'whatever' }}
             `('$request', ({ request }) => {
               const process = { id: 'whatever', request };
 


### PR DESCRIPTION
This PR mainly added the ability to auto-switch the command-line option `--TestPathPattern` to `--TestPathPatterns` when Jest 30 is detected.

We detect Jest 30 by looking for the error string pattern during the Jest run. Once detected, the `jest.useJest30` option is set accordingly and the process will be re-run with the correct options. 

Users can also set this option themselves just like any jest customization. 

---
Resolve #1109