### PR TITLE
Make all test items debuggable

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -19,6 +19,7 @@ export const DEBUG_CONFIG_PLATFORMS = ['windows', 'linux', 'osx'];
 const testNamePatternRegex = /\$\{jest.testNamePattern\}/g;
 const testFileRegex = /\$\{jest.testFile\}/g;
 const testFilePatternRegex = /\$\{jest.testFilePattern\}/g;
+const replaceTestPathPatternRegex = /--(testPathPattern(s?)|runTestsByPath)/g;
 
 export type DebugConfigOptions = Partial<
   Pick<PluginResourceSettings, 'jestCommandLine' | 'rootPath' | 'nodeEnv'>
@@ -130,8 +131,8 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       if (debugInfo.useTestPathPattern) {
         // if the debugInfo indicated this is a testPathPattern (such as running all tests within a folder)
         // , we need to replace the --runTestsByPath argument with the correct --testPathPattern(s) argument
-        if (arg.includes('--runTestsByPath')) {
-          return arg.replace('--runTestsByPath', this.getTestPathPatternOption());
+        if (replaceTestPathPatternRegex.test(arg)) {
+          return arg.replace(replaceTestPathPatternRegex, this.getTestPathPatternOption());
         }
         if (testFileRegex.test(arg)) {
           return arg.replace(testFileRegex, escapeRegExp(debugInfo.testPath));

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -12,6 +12,7 @@ import {
 } from './helpers';
 import { platform } from 'os';
 import { PluginResourceSettings } from './Settings';
+import { DebugInfo } from './types';
 
 export const DEBUG_CONFIG_PLATFORMS = ['windows', 'linux', 'osx'];
 const testNamePatternRegex = /\$\{jest.testNamePattern\}/g;
@@ -23,22 +24,22 @@ export type DebugConfigOptions = Partial<
 >;
 type PartialDebugConfig = Partial<vscode.DebugConfiguration>;
 export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-  private fileNameToRun = '';
-  private testToRun = '';
+  private debugInfo: DebugInfo | undefined;
   private fromWorkspaceFolder: vscode.WorkspaceFolder | undefined;
+  private useJest30: boolean | undefined;
 
   /**
    * Prepares injecting the name of the test, which has to be debugged, into the `DebugConfiguration`,
    * This function has to be called before `vscode.debug.startDebugging`.
    */
   public prepareTestRun(
-    fileNameToRun: string,
-    testToRun: string,
-    workspaceFolder: vscode.WorkspaceFolder
+    debugInfo: DebugInfo,
+    workspaceFolder: vscode.WorkspaceFolder,
+    useJest30?: boolean
   ): void {
-    this.fileNameToRun = fileNameToRun;
-    this.testToRun = testToRun;
+    this.debugInfo = { ...debugInfo };
     this.fromWorkspaceFolder = workspaceFolder;
+    this.useJest30 = useJest30;
   }
 
   getDebugConfigNames(workspaceFolder?: vscode.WorkspaceFolder): {
@@ -82,22 +83,29 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
     const args = debugConfiguration.args || [];
 
-    if (this.fileNameToRun) {
-      if (this.testToRun) {
+    if (this.debugInfo) {
+      if (this.debugInfo.testName) {
         args.push('--testNamePattern');
-        args.push(this.testToRun);
+        args.push(escapeRegExp(this.debugInfo.testName));
       }
-      args.push('--runTestsByPath');
-      args.push(toFilePath(this.fileNameToRun));
+      if (this.debugInfo.useTestPathPattern) {
+        args.push(this.getTestPathPatternOption());
+        args.push(escapeRegExp(this.debugInfo.testPath));
+      } else {
+        args.push('--runTestsByPath');
+        args.push(toFilePath(this.debugInfo.testPath));
+      }
 
-      this.fileNameToRun = '';
-      this.testToRun = '';
+      this.debugInfo = undefined;
     }
 
     debugConfiguration.args = args;
     return debugConfiguration;
   }
 
+  private getTestPathPatternOption(): string {
+    return this.useJest30 ? '--testPathPatterns' : '--testPathPattern';
+  }
   /**
    * resolve v2 debug config
    * @param debugConfiguration v2 debug config
@@ -105,22 +113,39 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
    */
   resolveDebugConfig2(debugConfiguration: vscode.DebugConfiguration): vscode.DebugConfiguration {
     if (
+      !this.debugInfo ||
       !debugConfiguration.args ||
       !Array.isArray(debugConfiguration.args) ||
       debugConfiguration.args.length <= 0
     ) {
       return debugConfiguration;
     }
+
+    const debugInfo = this.debugInfo;
     const args = debugConfiguration.args.map((arg) => {
       if (typeof arg !== 'string') {
         return arg;
       }
+      if (debugInfo.useTestPathPattern) {
+        // if the debugInfo indicated this is a testPathPattern (such as running all tests within a folder)
+        // , we need to replace the --runTestsByPath argument with the correct --testPathPattern(s) argument
+        if (arg.includes('--runTestsByPath')) {
+          return arg.replace('--runTestsByPath', this.getTestPathPatternOption());
+        }
+        if (testFileRegex.test(arg)) {
+          return arg.replace(testFileRegex, escapeRegExp(debugInfo.testPath));
+        }
+      }
       return arg
-        .replace(testFileRegex, toFilePath(this.fileNameToRun))
-        .replace(testFilePatternRegex, escapeRegExp(this.fileNameToRun))
-        .replace(testNamePatternRegex, this.testToRun);
+        .replace(testFileRegex, toFilePath(debugInfo.testPath))
+        .replace(testFilePatternRegex, escapeRegExp(debugInfo.testPath))
+        .replace(
+          testNamePatternRegex,
+          debugInfo.testName ? escapeRegExp(debugInfo.testName) : '.*'
+        );
     });
     debugConfiguration.args = args;
+    this.debugInfo = undefined;
 
     return debugConfiguration;
   }

--- a/src/JestExt/core.ts
+++ b/src/JestExt/core.ts
@@ -8,11 +8,11 @@ import {
   SortedTestResults,
   TestResultProviderOptions,
 } from '../TestResults';
-import { escapeRegExp, emptyTestStats, getValidJestCommand } from '../helpers';
+import { emptyTestStats, getValidJestCommand } from '../helpers';
 import { CoverageMapProvider, CoverageCodeLensProvider } from '../Coverage';
 import { updateDiagnostics, updateCurrentDiagnostics, resetDiagnostics } from '../diagnostics';
 import { DebugConfigurationProvider } from '../DebugConfigurationProvider';
-import { TestExplorerRunRequest, TestNamePattern, TestStats } from '../types';
+import { TestExplorerRunRequest, TestStats } from '../types';
 import { CoverageOverlay } from '../Coverage/CoverageOverlay';
 import { resultsWithoutAnsiEscapeSequence } from '../TestResults/TestResult';
 import { CoverageMapData } from 'istanbul-lib-coverage';
@@ -25,6 +25,7 @@ import {
   JestRunEvent,
   JestTestDataAvailableEvent,
 } from './types';
+import { DebugInfo } from '../types';
 import { extensionName, SupportedLanguageIds } from '../appGlobals';
 import { createJestExtContext, getExtensionResourceSettings, prefixWorkspace } from './helper';
 import { PluginResourceSettings } from '../Settings';
@@ -566,10 +567,7 @@ export class JestExt {
   }
 
   //**  commands */
-  public debugTests = async (
-    document: vscode.TextDocument | string,
-    testNamePattern?: TestNamePattern
-  ): Promise<void> => {
+  public debugTests = async (debugInfo: DebugInfo): Promise<void> => {
     const getDebugConfig = (
       folder?: vscode.WorkspaceFolder
     ): vscode.DebugConfiguration | undefined => {
@@ -592,9 +590,9 @@ export class JestExt {
     };
 
     this.debugConfigurationProvider.prepareTestRun(
-      typeof document === 'string' ? document : document.fileName,
-      testNamePattern ? escapeRegExp(testNamePattern) : '.*',
-      this.extContext.workspace
+      debugInfo,
+      this.extContext.workspace,
+      this.extContext.settings.useJest30
     );
 
     let debugConfig =

--- a/src/JestExt/types.ts
+++ b/src/JestExt/types.ts
@@ -7,7 +7,7 @@ import { ProcessSession } from './process-session';
 import { JestProcessInfo } from '../JestProcessManagement';
 import { JestOutputTerminal } from './output-terminal';
 import { TestIdentifier } from '../TestResults';
-import { TestNamePattern } from '../types';
+import { DebugInfo } from '../types';
 
 export enum WatchMode {
   None = 'none',
@@ -61,7 +61,5 @@ export interface JestExtProcessContextRaw extends JestExtContext {
 export type JestExtProcessContext = Readonly<JestExtProcessContextRaw>;
 
 export type DebugTestIdentifier = string | TestIdentifier;
-export type DebugFunction = (
-  document: vscode.TextDocument | string,
-  testNamePattern?: TestNamePattern
-) => Promise<void>;
+
+export type DebugFunction = (debugInfo: DebugInfo) => Promise<void>;

--- a/src/extension-manager.ts
+++ b/src/extension-manager.ts
@@ -392,13 +392,6 @@ export class ExtensionManager {
         callback: (extension, editor) => extension.runAllTests(editor),
       }),
       this.registerCommand({
-        type: 'active-text-editor',
-        name: 'debug-tests',
-        callback: (extension, editor, ...identifiers) => {
-          extension.debugTests(editor.document, ...identifiers);
-        },
-      }),
-      this.registerCommand({
         type: 'select-workspace',
         name: 'save-run-mode',
         callback: (extension) => extension.saveRunMode(),

--- a/src/test-provider/test-item-data.ts
+++ b/src/test-provider/test-item-data.ts
@@ -8,7 +8,7 @@ import { ItBlock, TestAssertionStatus } from 'jest-editor-support';
 import { ContainerNode, DataNode, NodeType, ROOT_NODE_NAME } from '../TestResults/match-node';
 import { Logging } from '../logging';
 import { TestSuitChangeEvent } from '../TestResults/test-result-events';
-import { Debuggable, ItemCommand, ScheduleTestOptions, TestItemData } from './types';
+import { ItemCommand, ScheduleTestOptions, TestItemData } from './types';
 import { JestTestProviderContext } from './test-provider-context';
 import { JestTestRun } from './jest-test-run';
 import { JestProcessInfo, ProcessStatus } from '../JestProcessManagement';
@@ -17,7 +17,7 @@ import { tiContextManager } from './test-item-context-manager';
 import { runModeDescription } from '../JestExt/run-mode';
 import { isVirtualWorkspaceFolder } from '../virtual-workspace-folder';
 import { outputManager } from '../output-manager';
-import { TestNamePattern } from '../types';
+import { DebugInfo, TestNamePattern } from '../types';
 
 interface JestRunnable {
   getJestRunRequest: (options?: ScheduleTestOptions) => JestExtRequestType;
@@ -109,6 +109,10 @@ abstract class TestItemDataBase implements TestItemData, JestRunnable, WithUri {
   viewSnapshot(): Promise<void> {
     return Promise.reject(`viewSnapshot is not supported for ${this.item.id}`);
   }
+
+  getDebugInfo(): DebugInfo {
+    return { testPath: this.uri.fsPath, useTestPathPattern: true };
+  }
   abstract getJestRunRequest(options?: ScheduleTestOptions): JestExtRequestType;
 }
 
@@ -141,9 +145,7 @@ export class WorkspaceRoot extends TestItemDataBase {
       isVirtualWorkspaceFolder(workspaceFolder)
         ? workspaceFolder.effectiveUri
         : workspaceFolder.uri,
-      this,
-      undefined,
-      ['run']
+      this
     );
     const desc = runModeDescription(this.context.ext.settings.runMode.config);
     item.description = `(${desc.deferred?.label ?? desc.type.label})`;
@@ -496,7 +498,7 @@ export class FolderData extends TestItemDataBase {
   }
   private createTestItem(name: string, parent: vscode.TestItem) {
     const uri = FolderData.makeUri(parent, name);
-    const item = this.context.createTestItem(uri.fsPath, name, uri, this, parent, ['run']);
+    const item = this.context.createTestItem(uri.fsPath, name, uri, this, parent);
 
     item.canResolveChildren = false;
     return item;
@@ -724,18 +726,17 @@ export class TestDocumentRoot extends TestResultData {
     };
   }
 
-  getDebugInfo(): ReturnType<Debuggable['getDebugInfo']> {
-    return { fileName: this.uri.fsPath };
-  }
-
   public onTestMatched(): void {
     this.forEachChild((child) => child.onTestMatched());
   }
   public gatherSnapshotItems(snapshotItems: SnapshotItemCollection): void {
     this.forEachChild((child) => child.gatherSnapshotItems(snapshotItems));
   }
+  getDebugInfo(): DebugInfo {
+    return { testPath: this.uri.fsPath };
+  }
 }
-export class TestData extends TestResultData implements Debuggable {
+export class TestData extends TestResultData {
   constructor(
     readonly context: JestTestProviderContext,
     fileUri: vscode.Uri,
@@ -778,8 +779,8 @@ export class TestData extends TestResultData implements Debuggable {
     };
   }
 
-  getDebugInfo(): ReturnType<Debuggable['getDebugInfo']> {
-    return { fileName: this.uri.fsPath, testNamePattern: this.getTestNamePattern() };
+  getDebugInfo(): DebugInfo {
+    return { testPath: this.uri.fsPath, testName: this.getTestNamePattern() };
   }
   private updateItemRange(): void {
     if (this.node.attrs.range) {

--- a/src/test-provider/test-provider.ts
+++ b/src/test-provider/test-provider.ts
@@ -1,16 +1,13 @@
 import * as vscode from 'vscode';
 import { JestTestProviderContext } from './test-provider-context';
 import { WorkspaceRoot } from './test-item-data';
-import { Debuggable, ItemCommand, JestExtExplorerContext, TestItemData, TestTagId } from './types';
+import { ItemCommand, JestExtExplorerContext, TestItemData, TestTagId } from './types';
 import { extensionId, extensionName } from '../appGlobals';
 import { Logging } from '../logging';
 import { toErrorString } from '../helpers';
 import { tiContextManager } from './test-item-context-manager';
 import { JestTestRun } from './jest-test-run';
 import { JestTestCoverageProvider } from './test-coverage';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isDebuggable = (arg: any): arg is Debuggable => arg && typeof arg.getDebugInfo === 'function';
 
 export class JestTestProvider {
   private readonly controller: vscode.TestController;
@@ -132,20 +129,13 @@ export class JestTestProvider {
    */
   debugTest = async (tData: TestItemData, run: JestTestRun): Promise<void> => {
     let error;
-    if (isDebuggable(tData)) {
-      try {
-        const debugInfo = tData.getDebugInfo();
-        if (debugInfo.testNamePattern) {
-          await this.context.ext.debugTests(debugInfo.fileName, debugInfo.testNamePattern);
-        } else {
-          await this.context.ext.debugTests(debugInfo.fileName);
-        }
-        return;
-      } catch (e) {
-        error = `item ${tData.item.id} failed to debug: ${JSON.stringify(e)}`;
-      }
+    try {
+      const debugInfo = tData.getDebugInfo();
+      await this.context.ext.debugTests(debugInfo);
+      return;
+    } catch (e) {
+      error = `item ${tData.item.id} failed to debug: ${JSON.stringify(e)}`;
     }
-    error = error ?? `item ${tData.item.id} is not debuggable`;
     run.errored(tData.item, new vscode.TestMessage(error));
     run.write(error, 'error');
     return Promise.resolve();

--- a/src/test-provider/types.ts
+++ b/src/test-provider/types.ts
@@ -4,7 +4,7 @@ import { TestResultProvider } from '../TestResults';
 import { WorkspaceRoot, FolderData, TestData, TestDocumentRoot } from './test-item-data';
 import { JestTestProviderContext } from './test-provider-context';
 import { JestTestRun } from './jest-test-run';
-import { TestNamePattern } from '../types';
+import { DebugInfo } from '../types';
 
 export type TestItemDataType = WorkspaceRoot | FolderData | TestDocumentRoot | TestData;
 
@@ -19,6 +19,7 @@ export interface ScheduleTestOptions {
   itemCommand?: ItemCommand;
   profile?: vscode.TestRunProfile;
 }
+
 export interface TestItemData {
   readonly item: vscode.TestItem;
   readonly uri: vscode.Uri;
@@ -26,10 +27,7 @@ export interface TestItemData {
   discoverTest?: (run: JestTestRun) => void;
   scheduleTest: (run: JestTestRun, options?: ScheduleTestOptions) => void;
   runItemCommand: (command: ItemCommand) => void;
-}
-
-export interface Debuggable {
-  getDebugInfo: () => { fileName: string; testNamePattern?: TestNamePattern };
+  getDebugInfo: () => DebugInfo;
 }
 
 export enum TestTagId {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,8 @@ export interface StringPattern {
 }
 
 export type TestNamePattern = StringPattern | string;
+export interface DebugInfo {
+  testPath: string;
+  useTestPathPattern?: boolean;
+  testName?: TestNamePattern;
+}

--- a/tests/extension-manager.test.ts
+++ b/tests/extension-manager.test.ts
@@ -1147,7 +1147,6 @@ describe('ExtensionManager', () => {
         ${'editor.workspace.toggle-coverage'} | ${'toggleCoverage'}
         ${'editor.workspace.run-all-tests'}   | ${'runAllTests'}
         ${'editor.run-all-tests'}             | ${'runAllTests'}
-        ${'editor.debug-tests'}               | ${'debugTests'}
       `('editor-based commands "$name"', async ({ name, extFunc }) => {
         extensionManager.register();
         const expectedName = `${extensionName}.${name}`;

--- a/tests/test-provider/test-item-data.test.ts
+++ b/tests/test-provider/test-item-data.test.ts
@@ -1264,33 +1264,46 @@ describe('test-item-data', () => {
         expect(itemData.item.tags.find((t) => t.id === 'run')).toBeTruthy();
       });
     });
-    it('only TestData and TestDocument supports debug tags', () => {
-      [doc, testItem].forEach((itemData) =>
+    it('all test items support debug tags', () => {
+      [wsRoot, folder, doc, testItem].forEach((itemData) =>
         expect(itemData.item.tags.find((t) => t.id === 'debug')).toBeTruthy()
-      );
-      [wsRoot, folder].forEach((itemData) =>
-        expect(itemData.item.tags.find((t) => t.id === 'debug')).toBeUndefined()
       );
     });
   });
   describe('getDebugInfo', () => {
-    let doc, test;
+    let doc, test, parentItem;
     beforeEach(() => {
       const uri: any = { fsPath: 'whatever' };
-      const parentItem: any = controllerMock.createTestItem('ws-1', 'ws-1', uri);
+      parentItem = controllerMock.createTestItem('ws-1', 'ws-1', uri);
       doc = new TestDocumentRoot(context, uri, parentItem);
       const node: any = { fullName: 'a test', attrs: {}, data: {} };
       test = new TestData(context, uri, node, doc.item);
     });
     it('TestData returns file and test info', () => {
       const debugInfo = test.getDebugInfo();
-      expect(debugInfo.fileName).toEqual(test.item.uri.fsPath);
-      expect(debugInfo.testNamePattern).toEqual({ value: 'a test', exactMatch: true });
+      expect(debugInfo.testPath).toEqual(test.item.uri.fsPath);
+      expect(debugInfo.testName).toEqual({ value: 'a test', exactMatch: true });
+      expect(debugInfo.useTestPathPattern).toBeFalsy();
     });
     it('TestDocumentRoot returns only file info', () => {
       const debugInfo = doc.getDebugInfo();
-      expect(debugInfo.fileName).toEqual(doc.item.uri.fsPath);
+      expect(debugInfo.testPath).toEqual(doc.item.uri.fsPath);
       expect(debugInfo.testNamePattern).toBeUndefined();
+      expect(debugInfo.useTestPathPattern).toBeFalsy();
+    });
+    it('FolderData returns folder path info', () => {
+      const folder = new FolderData(context, 'folder', parentItem);
+      const debugInfo = folder.getDebugInfo();
+      expect(debugInfo.testPath).toEqual(folder.item.uri.fsPath);
+      expect(debugInfo.testName).toBeUndefined();
+      expect(debugInfo.useTestPathPattern).toBeTruthy();
+    });
+    it('workspaceRoot returns workspace path info', () => {
+      const root = new WorkspaceRoot(context);
+      const debugInfo = root.getDebugInfo();
+      expect(debugInfo.testPath).toEqual(root.item.uri.fsPath);
+      expect(debugInfo.testName).toBeUndefined();
+      expect(debugInfo.useTestPathPattern).toBeTruthy();
     });
   });
   describe('WorkspaceRoot', () => {

--- a/tests/test-provider/test-provider.test.ts
+++ b/tests/test-provider/test-provider.test.ts
@@ -286,15 +286,15 @@ describe('JestTestProvider', () => {
           debugDone = () => resolve();
         });
       it.each`
-        case | debugInfo               | testNamePattern | debugTests                       | hasError
-        ${1} | ${undefined}            | ${undefined}    | ${() => Promise.resolve()}       | ${true}
-        ${2} | ${{ fileName: 'file' }} | ${'a test'}     | ${() => Promise.resolve()}       | ${false}
-        ${3} | ${{ fileName: 'file' }} | ${'a test'}     | ${() => Promise.reject('error')} | ${true}
-        ${4} | ${{ fileName: 'file' }} | ${'a test'}     | ${throwError}                    | ${true}
-        ${5} | ${{ fileName: 'file' }} | ${undefined}    | ${() => Promise.resolve()}       | ${false}
+        case | debugInfo               | testName     | debugTests                       | hasError
+        ${1} | ${undefined}            | ${undefined} | ${() => Promise.resolve()}       | ${true}
+        ${2} | ${{ testPath: 'file' }} | ${'a test'}  | ${() => Promise.resolve()}       | ${false}
+        ${3} | ${{ testPath: 'file' }} | ${'a test'}  | ${() => Promise.reject('error')} | ${true}
+        ${4} | ${{ testPath: 'file' }} | ${'a test'}  | ${throwError}                    | ${true}
+        ${5} | ${{ testPath: 'file' }} | ${undefined} | ${() => Promise.resolve()}       | ${false}
       `(
         'invoke debug test async case $case => error? $hasError',
-        async ({ debugInfo, testNamePattern, debugTests, hasError }) => {
+        async ({ debugInfo, testName, debugTests, hasError }) => {
           expect.hasAssertions();
           extExplorerContextMock.debugTests = jest.fn().mockImplementation(() => {
             if (debugTests) {
@@ -308,9 +308,7 @@ describe('JestTestProvider', () => {
             if (debugInfo) {
               d.getDebugInfo = jest
                 .fn()
-                .mockImplementation(() =>
-                  testNamePattern ? { ...debugInfo, testNamePattern } : debugInfo
-                );
+                .mockImplementation(() => (testName ? { ...debugInfo, testName } : debugInfo));
             } else {
               d.getDebugInfo = undefined;
             }
@@ -330,13 +328,12 @@ describe('JestTestProvider', () => {
             expect(jestRun.errored).toHaveBeenCalledWith(itemDataList[0].item, expect.anything());
             expect(vscode.TestMessage).toHaveBeenCalledTimes(1);
           } else {
-            if (testNamePattern) {
+            if (testName) {
               expect(extExplorerContextMock.debugTests).toHaveBeenCalledWith(
-                'file',
-                testNamePattern
+                expect.objectContaining({ testPath: 'file', testName })
               );
             } else {
-              expect(extExplorerContextMock.debugTests).toHaveBeenCalledWith('file');
+              expect(extExplorerContextMock.debugTests).toHaveBeenCalledWith({ testPath: 'file' });
             }
           }
         }


### PR DESCRIPTION
Make all test items (folders, project root, in addition to test files and test blocks) debuggable. 

This means the DebugConfigProvider has to support both explicit test path as well as partial test path matches, i.e. support and dynamically switch `--runTestsByPath` and `--testPathPattern(s)`.

Refactored to consolidate the logic into the DebugConfigProvider when possible.

resolve #1056