### PR TITLE
fixed command line parsing crashed debugger session

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -314,7 +314,7 @@ export const parseCmdLine = (cmdLine: string): string[] => {
   const parts = cmdLine.match(cmdSplitRegex) || [];
   // clean up command
   if (parts.length > 0 && parts[0]) {
-    parts[0] = removeSurroundingQuote(normalize(parts[0]));
+    parts[0] = normalize(removeSurroundingQuote(parts[0]));
   }
   return parts;
 };

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -390,6 +390,8 @@ describe('platform-specific tests', () => {
       ${true}  | ${'\\absolute\\jest --runInBand'}                             | ${{ cmd: '\\absolute\\jest', args: ['--runInBand'], program: '\\absolute\\jest' }}
       ${true}  | ${'"\\dir with space\\jest" --arg1=1 --arg2 2 "some string"'} | ${{ cmd: '\\dir with space\\jest', args: ['--arg1=1', '--arg2', '2', '"some string"'], program: '\\dir with space\\jest' }}
       ${true}  | ${'c:\\jest --arg1 "escaped \\"this\\" string" --arg2 2'}     | ${{ cmd: 'c:\\jest', args: ['--arg1', '"escaped \\"this\\" string"', '--arg2', '2'], program: 'c:\\jest' }}
+      ${true}  | ${'"c:\\jest" --arg1 "escaped \\"this\\" string" --arg2 2'}   | ${{ cmd: 'c:\\jest', args: ['--arg1', '"escaped \\"this\\" string"', '--arg2', '2'], program: 'c:\\jest' }}
+      ${true}  | ${`'c:\\jest' --arg1 "escaped \\"this\\" string" --arg2 2`}   | ${{ cmd: 'c:\\jest', args: ['--arg1', '"escaped \\"this\\" string"', '--arg2', '2'], program: 'c:\\jest' }}
     `('$cmdLine', ({ cmdLine, expected, isWin32 }) => {
       if (!canRunTest(isWin32)) {
         return;


### PR DESCRIPTION
resolve #1221

On Windows, when an absolute path command is enclosed in quotes and passed to `parseCmdLine()` in `helpers.ts`, the `path.normalize()` function misinterprets it as a relative path, appending an incorrect relative prefix. This bug surfaces during the generation of the default debug configuration, ultimately causing a crash in the vscode debug session.

It seems that previous versions of VS Code might have handled such quoted paths differently, though the precise behavior remains unclear. The fix is straightforward: strip any extraneous quotes from the command line argument before calling `path.normalize()`, rather than afterwards.
