### PR TITLE
Fix relative uplevels of Symlinked Workspace (Issue #798)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Content
       - [coverageColors](#coveragecolors)
       - [outputConfig](#outputconfig)
       - [runMode](#runmode)
+      - [trimSymlinks](#trimSymlinks)
       - [autoRun](#autorun)
       - [testExplorer](#testexplorer)
       - [shell](#shell)
@@ -288,6 +289,7 @@ useDashedArgs| Determine if to use dashed arguments for jest processes |undefine
 |**UX**|
 |[outputConfig](#outputconfig) 💼|Controls test output experience across the whole workspace.|undefined|`"jest.outputConfig": "neutral"` or `"jest.outputConfig": {"revealOn": "run", "revealWithFocus": "terminal", "clearOnRun": 'terminal"`| >= v6.1.0
 |[runMode](#runmode)|Controls most test UX, including when tests should be run, output management, etc|undefined|`"jest.runMode": "watch"` or `"jest.runMode": "on-demand"` or `"jest.runMode": {"type": "on-demand", "deferred": true}`| >= v6.1.0
+|[trimSymlinks](#trimSymlinks)|Trims relative path walking-up a symbolic link in Test Explorer.|`false`|`"jest.trimSymlinks": true`| `T.B.D` - Fill near release
 |:x: autoClearTerminal|Clear the terminal output at the start of any new test run.|false|`"jest.autoClearTerminal": true`| v6.0.0 (replaced by outputConfig)
 |:x: [testExplorer](#testexplorer) |Configure jest test explorer|null|`{"showInlineError": "true"}`| < 6.1.0 (replaced by runMode)
 |:x: [autoRun](#autorun)|Controls when and what tests should be run|undefined|`"jest.autoRun": "off"` or `"jest.autoRun": "watch"` or `"jest.autoRun": {"watch": false, "onSave":"test-only"}`| < v6.1.0 (replaced by runMode)
@@ -584,6 +586,16 @@ While the concepts of performance and automation are generally clear, "completen
 > **Migration Guide**
 > 
 > Starting from v6.1.0, if no runMode is defined in settings.json, the extension will automatically generate one using legacy settings (`autoRun`, `showCoverageOnLoad`). To migrate, simply use the `"Jest: Save Current RunMode"` command from the command palette to update the setting, then remove the deprecated settings.
+
+---
+
+#### trimSymlinks
+When enabled, this setting resolves symbolic links in the workspace path to avoid showing unnecessary parent folders in the Test Explorer.<br>
+Useful if your workspace or any of its ancestor directories is a symlink—without it, test files may appear under awkward relative paths (e.g. starting with ../) 
+due to symlink resolution behavior.
+
+Default: `false`
+
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -372,6 +372,12 @@
           "type": "boolean",
           "default": null,
           "scope": "resource"
+        },
+        "jest.trimSymlinks": {
+          "markdownDescription": "Enable to show test relative to workspace in case of symlinked workspace (or any directory above it). Use if your tests look like in [this image](https://private-user-images.githubusercontent.com/84509513/438940965-b7532345-0332-4265-a108-cac1703de39f.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDU5NTQ4MzcsIm5iZiI6MTc0NTk1NDUzNywicGF0aCI6Ii84NDUwOTUxMy80Mzg5NDA5NjUtYjc1MzIzNDUtMDMzMi00MjY1LWExMDgtY2FjMTcwM2RlMzlmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MjklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDI5VDE5MjIxN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTcwZjEzMWIzZmFkOTBiODllMTU3NjYzMzBhOWIwMGI3MWMwMjI4YzBiYjhlZTA2NzYzOTM4N2NmNGMzMDkxNjUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.bWHlErbUnTuXEP2_LPGUbJu509UdNl22Ee73q2f1FXU)",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
         }
       }
     },

--- a/src/JestExt/helper.ts
+++ b/src/JestExt/helper.ts
@@ -111,6 +111,7 @@ export const getExtensionResourceSettings = (
     enable: getSetting<boolean>('enable'),
     useDashedArgs: getSetting<boolean>('useDashedArgs') ?? false,
     useJest30: getSetting<boolean>('useJest30'),
+    trimSymlinks: getSetting<boolean>('trimSymlinks'),
   };
 };
 

--- a/src/Settings/types.ts
+++ b/src/Settings/types.ts
@@ -78,6 +78,7 @@ export interface PluginResourceSettings {
   parserPluginOptions?: JESParserPluginOptions;
   useDashedArgs?: boolean;
   useJest30?: boolean;
+  trimSymlinks?: boolean;
 }
 
 export interface DeprecatedPluginResourceSettings {

--- a/tests/JestExt/helper.test.ts
+++ b/tests/JestExt/helper.test.ts
@@ -179,6 +179,7 @@ describe('getExtensionResourceSettings()', () => {
       nodeEnv: undefined,
       useDashedArgs: false,
       useJest30: null,
+      trimSymlinks: false,
     });
     expect(createJestSettingGetter).toHaveBeenCalledWith(folder);
   });

--- a/tests/test-provider/test-helper.ts
+++ b/tests/test-provider/test-helper.ts
@@ -106,3 +106,19 @@ export const mockJestProcess = (id: string, extra?: any): any => {
     ...(extra ?? {}),
   };
 };
+
+export interface SymlinkMock {
+  pushSymlink: (config: SymlinkConfig) => void;
+  delink: (src: string) => void;
+}
+
+export type SymlinkConfig = {
+  src: string;
+  dst: string;
+  link: string;
+};
+
+export type MockedPath = typeof import('path') & SymlinkMock & {
+  setSep: (sep: string) => void;
+  sep: string;
+};


### PR DESCRIPTION
## TL;DR
Solves the issue reported in #798 
Examples of the fix can be found in [my comment](https://github.com/jest-community/vscode-jest/issues/798#issuecomment-2839986007)

## Some explanation
While the issue might initially seem rooted in Jest—which reports test results based on the tests’ real paths—it actually makes sense from Jest’s own perspective. Therefore, I implemented the logic in this extension to handle cases where a workspace (or one of its parent directories) is linked, and to hide such links from the Tests Explorer view.


## Tests made:
- Feature-flag disabled - show current behavior remains
- Feature-flag enabled - show the changes take effect